### PR TITLE
Invalidate ci cache if release tools changed

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,10 +2,10 @@
     "$schema": "https://turborepo.org/schema.json",
     "pipeline": {
         "update-changelog": {
-            "outputs": []
+            "cache": false
         },
         "verify": {
-            "cache": false
+            "inputs": ["package.json", "**/package.xml"]
         },
         "build": {
             "dependsOn": ["^build"],
@@ -37,5 +37,6 @@
         "publish-marketplace": {
             "cache": false
         }
-    }
+    },
+    "globalDependencies": ["packages/tools/release-utils-internal/**"]
 }


### PR DESCRIPTION
TLDR, This changes will make sure that our CI cache is invalidated whenever we update `release-utils-internal`.

If you wan't to know more, [hashing](https://turbo.build/repo/docs/core-concepts/caching#hashing) and [globalDependencies](https://turbo.build/repo/docs/reference/configuration#globalDependencies-1) docs are good place to start learning how turbo works;