### PR TITLE
DB-1953 remove null check, because null values are a feature in plotly

### DIFF
--- a/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
+++ b/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
@@ -209,12 +209,12 @@ function extractDataPoints(
         if (!x.value) {
             xData.push(null);
         } else {
-            xData.push(x.value instanceof Big ? Number(x.value.toString()) : x.value);
+            xData.push(x.value instanceof Big ? x.value.toNumber() : x.value);
         }
         if (!y.value) {
             yData.push(null);
         } else {
-            yData.push(y.value instanceof Big ? Number(y.value.toString()) : y.value);
+            yData.push(y.value instanceof Big ? y.value.toNumber() : y.value);
         }
 
         const tooltipHoverTextSource =

--- a/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
+++ b/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
@@ -7,8 +7,8 @@ import { executeAction } from "@mendix/pluggable-widgets-commons";
 import { MendixChartDataProps } from "../components/Chart";
 
 type PlotChartDataPoints = {
-    x: Array<Datum>;
-    y: Array<Datum>;
+    x: Datum[];
+    y: Datum[];
     hovertext: string[] | undefined;
     hoverinfo: PlotData["hoverinfo"];
     // We want this optional.

--- a/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
+++ b/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
@@ -7,8 +7,8 @@ import { executeAction } from "@mendix/pluggable-widgets-commons";
 import { MendixChartDataProps } from "../components/Chart";
 
 type PlotChartDataPoints = {
-    x: Array<NonNullable<Datum>>;
-    y: Array<NonNullable<Datum>>;
+    x: Array<Datum>;
+    y: Array<Datum>;
     hovertext: string[] | undefined;
     hoverinfo: PlotData["hoverinfo"];
     // We want this optional.
@@ -237,11 +237,14 @@ export function getPlotChartDataTransforms(
     return [
         {
             type: "aggregate",
-            groups: dataPoints.x.map(dataPoint =>
-                typeof dataPoint === "string" || typeof dataPoint === "number"
+            groups: dataPoints.x.map(dataPoint => {
+                if (!dataPoint) {
+                    return "";
+                }
+                return typeof dataPoint === "string" || typeof dataPoint === "number"
                     ? dataPoint.toLocaleString()
-                    : dataPoint.toLocaleDateString()
-            ),
+                    : dataPoint.toLocaleDateString();
+            }),
             aggregations: [
                 {
                     target: "y",

--- a/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
+++ b/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
@@ -206,10 +206,6 @@ function extractDataPoints(
         const x = xValue.get(item);
         const y = yValue.get(item);
 
-        if (!x.value || !y.value) {
-            return null;
-        }
-
         xData.push(x.value instanceof Big ? Number(x.value.toString()) : x.value);
         yData.push(y.value instanceof Big ? Number(y.value.toString()) : y.value);
 

--- a/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
+++ b/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
@@ -206,8 +206,16 @@ function extractDataPoints(
         const x = xValue.get(item);
         const y = yValue.get(item);
 
-        xData.push(x.value instanceof Big ? Number(x.value.toString()) : x.value);
-        yData.push(y.value instanceof Big ? Number(y.value.toString()) : y.value);
+        if (!x.value) {
+            xData.push(null);
+        } else {
+            xData.push(x.value instanceof Big ? Number(x.value.toString()) : x.value);
+        }
+        if (!y.value) {
+            yData.push(null);
+        } else {
+            yData.push(y.value instanceof Big ? Number(y.value.toString()) : y.value);
+        }
 
         const tooltipHoverTextSource =
             series.dataSet === "dynamic" ? series.dynamicTooltipHoverText : series.staticTooltipHoverText;


### PR DESCRIPTION
## This PR contains

-   [x] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?
Plotly allows for `null` in your data and will by default fill up gaps. It also has the option to set `connectgaps` to false so you can have a line with gaps in between.  https://plotly.com/javascript/line-charts/#connect-gaps-between-data

The code that this pull request removes prevents `null` ending up in your data set, even though plotly can handle this. Right now if you would have an empty value in your dataset the chart would not render. 

By removing this code, the chart will still render when you have an empty value in your data, by default it will connect the gaps and you will have to option to turn this off.
