### PR TITLE
[WC-1325] Fix changelog format (web-actions)

### DIFF
--- a/packages/modules/web-actions/CHANGELOG.md
+++ b/packages/modules/web-actions/CHANGELOG.md
@@ -12,13 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We fixed errors in SetFavicon action.
 
-## [2.5.0] WebActions - 2022-08-31
+## [2.5.0] - 2022-08-31
 
 ### Added
 
 -   We added new actions: SetCookie, ReadCookie, SetFavicon.
 
-## [2.4.0] WebActions - 2022-01-25
+## [2.4.0] - 2022-01-25
 
 ### Added
 
@@ -32,13 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We changed the javascript actions to be exclusive for Web platform.
 
-## [2.3.0] WebActions - 2021-09-28
+## [2.3.0] - 2021-09-28
 
 ### Added
 
 -   Added tile images for all the actions.
 
-## [2.2.0] WebActions - 2021-08-11
+## [2.2.0] - 2021-08-11
 
 ### Added
 
@@ -50,25 +50,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   Changed the "Take a picture" action to hide the action buttons after taking a picture while waiting for the picture to be processed.
 
-## [2.1.1] WebActions - 2021-07-01
+## [2.1.1] - 2021-07-01
 
 ### Changed
 
 -   We changed the category of 'Take picture' action to 'Web camera'
 
-## [2.1.0] WebActions - 2021-05-28
+## [2.1.0] - 2021-05-28
 
 ### Added
 
 -   We've added a JavaScript action to allow take picture in PWA and web apps
 
-## [2.0.0] WebActions - 2021-04-20
+## [2.0.0] - 2021-04-20
 
 ### Added
 
 -   Adding compatibility with Studio Pro 9
 
-## [1.0.0] WebActions - 2020-05-22
+## [1.0.0] - 2020-05-22
 
 ### Added
 


### PR DESCRIPTION
### Description

Current changelog use "module" format, but we switched to "widget" format, so changelog should be formatted accordingly 

### Pull request checklist

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [x] PR title properly formatted `[XX-000]: description`
-   [ ] Added record to packages' CHANGELOG.md
-   [ ] Bumped package version in `package.json` and `package.xml`
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

-   [x] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)
