### PR TITLE
fix(release-utils-internal): use generic package info

### DIFF
--- a/packages/tools/release-utils-internal/bin/rui-changelog-helper.ts
+++ b/packages/tools/release-utils-internal/bin/rui-changelog-helper.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node-script
 
 import { prompt } from "enquirer";
-import { getModuleInfo, PackageListing, selectPackage } from "../src";
+import { getPackageInfo, PackageListing, selectPackage } from "../src";
 import { getNextVersion, writeVersion } from "../src/bump-version";
 import {
     getModuleChangelog,
@@ -75,7 +75,7 @@ async function writeChanges(pkg: PackageListing, sections: LogSection[], nextVer
     try {
         changelog = await getWidgetChangelog(pkg.path);
     } catch {
-        const module = await getModuleInfo(pkg.path);
+        const module = await getPackageInfo(pkg.path);
         changelog = await getModuleChangelog(pkg.path, module.mxpackage.name);
     }
 


### PR DESCRIPTION
### Description

If you run `pnpm run changelog` and choose `charts-web` this command will fail. Right now we have two changelog formats: `widget` and `module`. Widget format is simple and don't require extra effort to handle and maintain. Module format is bit complex and actually it's better to call this format as "composed changelog" as it tries to get all records from it's children (eg. in data-widgets and charts-web). So, `pnpm run changelog` tries to parse changelog with `widget` format, if it fails, then it tries to parse changelog with `module` format. The problem is that `charts-web`, is a widget, which uses `module` format for changelogs... yeah, I know. So, to not make things even more complex we now use generic function to parse package metadata, so we don't care what format is used for package.

### Pull request checklist

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [x] PR title properly formatted `[XX-000]: description`
-   [ ] Added record to packages' CHANGELOG.md
-   [ ] Bumped package version in `package.json` and `package.xml`
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

-   [x] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

- `pnpm run changelog` command for `charts-web` pacakge
