### PR TITLE
ci(build): save turbo cache only for master

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -24,11 +24,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       since-flag: ${{ steps.set-since-flag.outputs.SINCE_FLAG }}
+      main_sha: ${{ steps.main_sha.outputs.MAIN_SHA }}
 
     steps:
       - if: github.event_name == 'pull_request'
         id: set-since-flag
         run: echo "SINCE_FLAG=--filter '...[origin/${{ github.base_ref }}]'" >> $GITHUB_OUTPUT
+      - name: Get sha of main
+        id: main_sha
+        run: echo "MAIN_SHA=`git rev-parse origin/main`" >> $GITHUB_OUTPUT
 
   check:
     name: Code quality check
@@ -55,7 +59,7 @@ jobs:
           path: node_modules/.cache/turbo
           # NOTE: We create new cache record for every new github.sha 
           # but fallback to latest entry 
-          key: turbo-cache-${{ runner.os }}-lint-test-${{ github.sha }}
+          key: turbo-cache-${{ runner.os }}-lint-test-${{ needs.setup-options.outputs.main_sha }}
           restore-keys: |
             turbo-cache-${{ runner.os }}-lint-test
 
@@ -98,7 +102,7 @@ jobs:
           # this is why we include matrix.target param in key
           # NOTE: We create new cache record for every new github.sha 
           # but fallback to latest entry 
-          key: turbo-cache-${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
+          key: turbo-cache-${{ runner.os }}-${{ matrix.target }}-${{ needs.setup-options.outputs.main_sha }}
           restore-keys: |
             turbo-cache-${{ runner.os }}-${{ matrix.target }}
       - if: runner.os == 'Windows'

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -24,15 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       since-flag: ${{ steps.set-since-flag.outputs.SINCE_FLAG }}
-      main_sha: ${{ steps.main_sha.outputs.MAIN_SHA }}
 
     steps:
       - if: github.event_name == 'pull_request'
         id: set-since-flag
         run: echo "SINCE_FLAG=--filter '...[origin/${{ github.base_ref }}]'" >> $GITHUB_OUTPUT
-      - name: Get sha of main
-        id: main_sha
-        run: echo "MAIN_SHA=`git rev-parse origin/main`" >> $GITHUB_OUTPUT
 
   check:
     name: Code quality check
@@ -53,13 +49,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
+      - name: Get sha of main
+        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ env.GITHUB_OUTPUT }}
       - name: Restore Turbo Cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           path: node_modules/.cache/turbo
           # NOTE: We create new cache record for every new github.sha 
           # but fallback to latest entry 
-          key: turbo-cache-${{ runner.os }}-lint-test-${{ needs.setup-options.outputs.main_sha }}
+          key: turbo-cache-${{ runner.os }}-lint-test-${{ env.main_sha }}
           restore-keys: |
             turbo-cache-${{ runner.os }}-lint-test
 
@@ -94,6 +92,8 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
+      - name: Get sha of main
+        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ env.GITHUB_OUTPUT }}
       - name: Restore Turbo Cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
@@ -102,7 +102,7 @@ jobs:
           # this is why we include matrix.target param in key
           # NOTE: We create new cache record for every new github.sha 
           # but fallback to latest entry 
-          key: turbo-cache-${{ runner.os }}-${{ matrix.target }}-${{ needs.setup-options.outputs.main_sha }}
+          key: turbo-cache-${{ runner.os }}-${{ matrix.target }}-${{ env.main_sha }}
           restore-keys: |
             turbo-cache-${{ runner.os }}-${{ matrix.target }}
       - if: runner.os == 'Windows'

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -50,7 +50,7 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Get sha of main
-        run: echo "main_sha=$(git rev-parse origin/main)" >> $GITHUB_OUTPUT
+        run: echo "main_sha=$(git rev-parse origin/main)" >> $GITHUB_ENV
       - name: Restore Turbo Cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
@@ -93,7 +93,7 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Get sha of main
-        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ runner.os == 'Windows' && '$GITHUB_OUTPUT' || '$env:GITHUB_OUTPUT' }}
+        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ runner.os == 'Windows' && '$GITHUB_ENV' || '$env:GITHUB_ENV' }}
       - name: Restore Turbo Cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -50,7 +50,7 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Get sha of main
-        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ env.GITHUB_OUTPUT }}
+        run: echo "main_sha=$(git rev-parse origin/main)" >> $GITHUB_OUTPUT
       - name: Restore Turbo Cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
@@ -93,7 +93,7 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Get sha of main
-        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ env.GITHUB_OUTPUT }}
+        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ runner.os == 'Windows' && '$GITHUB_OUTPUT' || '$env:GITHUB_OUTPUT' }}
       - name: Restore Turbo Cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:


### PR DESCRIPTION
### Description

This PR change how we store trubo cache on GH. Now cache should be saved only on master and updated when master SHA changes. That means we not storing cache for pull request branches anymore.

### Pull request type

-   [x] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)
