### PR TITLE
ci(build): keep turbo cache only on main

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -49,13 +49,15 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
+      - name: Get sha of main
+        run: echo "main_sha=$(git rev-parse origin/main)" >> $GITHUB_ENV
       - name: Restore Turbo Cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           path: node_modules/.cache/turbo
           # NOTE: We create new cache record for every new github.sha 
           # but fallback to latest entry 
-          key: turbo-cache-${{ runner.os }}-lint-test-${{ github.sha }}
+          key: turbo-cache-${{ runner.os }}-lint-test-${{ env.main_sha }}
           restore-keys: |
             turbo-cache-${{ runner.os }}-lint-test
 
@@ -90,6 +92,8 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
+      - name: Get sha of main
+        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ runner.os == 'Windows' && '$env:GITHUB_ENV' || '$GITHUB_ENV' }}
       - name: Restore Turbo Cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
@@ -98,7 +102,7 @@ jobs:
           # this is why we include matrix.target param in key
           # NOTE: We create new cache record for every new github.sha 
           # but fallback to latest entry 
-          key: turbo-cache-${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
+          key: turbo-cache-${{ runner.os }}-${{ matrix.target }}-${{ env.main_sha }}
           restore-keys: |
             turbo-cache-${{ runner.os }}-${{ matrix.target }}
       - if: runner.os == 'Windows'


### PR DESCRIPTION
### Description

This PR change how we store trubo cache on GH. Now cache should be saved only on `main` and updated when `main` SHA changes. That means we not storing cache for pull request branches anymore.

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

