### PR TITLE
[WC-1301]: update structure preview for data grid 2

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   We improved structure preview of the widget in Studio Pro 9.20 and above.
+
 ## [2.4.2] - 2022-09-01
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -1,7 +1,7 @@
 import {
     container,
     dropzone,
-    RowLayoutProps,
+    rowLayout,
     selectable,
     StructurePreviewProps,
     text
@@ -133,6 +133,8 @@ export function getProperties(
 }
 
 export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): StructurePreviewProps => {
+    const modeColor = (colorDark: string, colorLight: string) => (isDarkMode ? colorDark : colorLight);
+
     const hasColumns = values.columns && values.columns.length > 0;
     const columnProps: ColumnsPreviewType[] = hasColumns
         ? values.columns
@@ -156,19 +158,15 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                   wrapText: false
               }
           ];
-    const columns: RowLayoutProps = {
-        type: "RowLayout",
-        columnSize: "fixed",
-        children: columnProps.map(column =>
+    const columns = rowLayout({
+        columnSize: "fixed"
+    })(
+        ...columnProps.map(column =>
             container({
                 borders: true,
                 grow: column.width === "manual" && column.size ? column.size : 1,
                 backgroundColor:
-                    values.columnsHidable && column.hidable === "hidden"
-                        ? isDarkMode
-                            ? "#3E3E3E"
-                            : "#F5F5F5"
-                        : undefined
+                    values.columnsHidable && column.hidable === "hidden" ? modeColor("#3E3E3E", "#F5F5F5") : undefined
             })(
                 column.showContentAs === "customContent"
                     ? dropzone()(column.content)
@@ -183,29 +181,26 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                       )
             )
         )
-    };
-    const titleHeader: RowLayoutProps = {
-        type: "RowLayout",
+    );
+    const titleHeader = rowLayout({
         columnSize: "fixed",
-        backgroundColor: isDarkMode ? "#3B5C8F" : "#DAEFFB",
+        backgroundColor: modeColor("#3B5C8F", "#DAEFFB"),
         borders: true,
-        borderWidth: 1,
-        children: [
-            container({
-                padding: 4
-            })(text({ fontColor: isDarkMode ? "#6DB1FE" : "#2074C8" })("Data grid 2"))
-        ]
-    };
-    const headerFilters = {
-        type: "RowLayout",
+        borderWidth: 1
+    })(
+        container({
+            padding: 4
+        })(text({ fontColor: modeColor("#6DB1FE", "#2074C8") })("Data grid 2"))
+    );
+    const headerFilters = rowLayout({
         columnSize: "fixed",
-        borders: true,
-        children: [dropzone(dropzone.placeholder("Place filter widget(s) here"))(values.filtersPlaceholder)]
-    } as RowLayoutProps;
-    const headers: RowLayoutProps = {
-        type: "RowLayout",
-        columnSize: "fixed",
-        children: columnProps.map(column => {
+        borders: true
+    })(dropzone(dropzone.placeholder("Place filter widget(s) here"))(values.filtersPlaceholder));
+
+    const headers = rowLayout({
+        columnSize: "fixed"
+    })(
+        ...columnProps.map(column => {
             const isColumnHidden = values.columnsHidable && column.hidable === "hidden";
             const content = container({
                 borders: true,
@@ -215,13 +210,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                             ? column.size
                             : 1
                         : undefined,
-                backgroundColor: isColumnHidden
-                    ? isDarkMode
-                        ? "#4F4F4F"
-                        : "#DCDCDC"
-                    : isDarkMode
-                    ? "#3E3E3E"
-                    : "#F5F5F5"
+                backgroundColor: isColumnHidden ? modeColor("#4F4F4F", "#DCDCDC") : modeColor("#3E3E3E", "#F5F5F5")
             })(
                 container({
                     padding: 8
@@ -232,12 +221,8 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                         fontColor: column.header
                             ? undefined
                             : isColumnHidden
-                            ? isDarkMode
-                                ? "#4F4F4F"
-                                : "#DCDCDC"
-                            : isDarkMode
-                            ? "#3E3E3E"
-                            : "#F5F5F5"
+                            ? modeColor("#4F4F4F", "#DCDCDC")
+                            : modeColor("#3E3E3E", "#F5F5F5")
                     })(column.header ? column.header : "Header")
                 ),
                 ...(hasColumns && values.columnsFilterable
@@ -250,22 +235,17 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                   )
                 : content;
         })
-    };
+    );
     const footer =
         values.showEmptyPlaceholder === "custom"
             ? [
-                  {
-                      type: "RowLayout",
+                  rowLayout({
                       columnSize: "fixed",
-                      borders: true,
-                      children: [
-                          dropzone(dropzone.placeholder("Empty list message: Place widgets here"))(
-                              values.emptyPlaceholder
-                          )
-                      ]
-                  } as RowLayoutProps
+                      borders: true
+                  })(dropzone(dropzone.placeholder("Empty list message: Place widgets here"))(values.emptyPlaceholder))
               ]
             : [];
+
     return container()(
         titleHeader,
         ...(values.showHeaderFilters && values.filterList.length > 0 ? [headerFilters] : []),

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -2,6 +2,7 @@ import {
     container,
     DropZoneProps,
     RowLayoutProps,
+    selectable,
     StructurePreviewProps,
     text
 } from "@mendix/pluggable-widgets-commons";
@@ -259,12 +260,9 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                     : [])
             );
             return values.columns.length > 0
-                ? {
-                      type: "Selectable",
-                      object: column,
-                      grow: column.width === "manual" && column.size ? column.size : 1,
-                      child: container()(content)
-                  }
+                ? selectable(column, { grow: column.width === "manual" && column.size ? column.size : 1 })(
+                      container()(content)
+                  )
                 : content;
         })
     };

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -1,5 +1,6 @@
 import {
     container,
+    datasource,
     dropzone,
     rowLayout,
     selectable,
@@ -132,7 +133,14 @@ export function getProperties(
     return defaultProperties;
 }
 
-export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): StructurePreviewProps => {
+export const getPreview = (
+    values: DatagridPreviewProps,
+    isDarkMode: boolean,
+    spVersion: number[] = [0, 0, 0]
+): StructurePreviewProps => {
+    const [x, y] = spVersion;
+    const canHideDataSourceHeader = x >= 9 && y >= 20;
+
     const modeColor = (colorDark: string, colorLight: string) => (isDarkMode ? colorDark : colorLight);
 
     const hasColumns = values.columns && values.columns.length > 0;
@@ -169,7 +177,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                     values.columnsHidable && column.hidable === "hidden" ? modeColor("#3E3E3E", "#F5F5F5") : undefined
             })(
                 column.showContentAs === "customContent"
-                    ? dropzone()(column.content)
+                    ? dropzone(dropzone.hideDataSourceHeaderIf(canHideDataSourceHeader))(column.content)
                     : container({
                           padding: 8
                       })(
@@ -195,7 +203,12 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
     const headerFilters = rowLayout({
         columnSize: "fixed",
         borders: true
-    })(dropzone(dropzone.placeholder("Place filter widget(s) here"))(values.filtersPlaceholder));
+    })(
+        dropzone(
+            dropzone.placeholder("Place filter widget(s) here"),
+            dropzone.hideDataSourceHeaderIf(canHideDataSourceHeader)
+        )(values.filtersPlaceholder)
+    );
 
     const headers = rowLayout({
         columnSize: "fixed"
@@ -226,7 +239,12 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                     })(column.header ? column.header : "Header")
                 ),
                 ...(hasColumns && values.columnsFilterable
-                    ? [dropzone(dropzone.placeholder("Place filter widget here"))(column.filter)]
+                    ? [
+                          dropzone(
+                              dropzone.placeholder("Place filter widget here"),
+                              dropzone.hideDataSourceHeaderIf(canHideDataSourceHeader)
+                          )(column.filter)
+                      ]
                     : [])
             );
             return values.columns.length > 0
@@ -242,12 +260,18 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                   rowLayout({
                       columnSize: "fixed",
                       borders: true
-                  })(dropzone(dropzone.placeholder("Empty list message: Place widgets here"))(values.emptyPlaceholder))
+                  })(
+                      dropzone(
+                          dropzone.placeholder("Empty list message: Place widgets here"),
+                          dropzone.hideDataSourceHeaderIf(canHideDataSourceHeader)
+                      )(values.emptyPlaceholder)
+                  )
               ]
             : [];
 
     return container()(
         titleHeader,
+        datasource(values.datasource)(),
         ...(values.showHeaderFilters && values.filterList.length > 0 ? [headerFilters] : []),
         headers,
         ...Array.from({ length: 5 }).map(() => columns),

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -2,7 +2,8 @@ import {
     ContainerProps,
     DropZoneProps,
     RowLayoutProps,
-    StructurePreviewProps
+    StructurePreviewProps,
+    text
 } from "@mendix/pluggable-widgets-commons";
 import {
     changePropertyIn,
@@ -179,16 +180,11 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                                   type: "Container",
                                   padding: 8,
                                   children: [
-                                      {
-                                          type: "Text",
-                                          content:
-                                              column.showContentAs === "dynamicText"
-                                                  ? column.dynamicText ?? "Dynamic text"
-                                                  : `[${
-                                                        column.attribute ? column.attribute : "No attribute selected"
-                                                    }]`,
-                                          fontSize: 10
-                                      }
+                                      text({ fontSize: 10 })(
+                                          column.showContentAs === "dynamicText"
+                                              ? column.dynamicText ?? "Dynamic text"
+                                              : `[${column.attribute ? column.attribute : "No attribute selected"}]`
+                                      )
                                   ]
                               }
                     ]
@@ -205,13 +201,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
             {
                 type: "Container",
                 padding: 4,
-                children: [
-                    {
-                        type: "Text",
-                        content: "Data grid 2",
-                        fontColor: isDarkMode ? "#6DB1FE" : "#2074C8"
-                    }
-                ]
+                children: [text({ fontColor: isDarkMode ? "#6DB1FE" : "#2074C8" })("Data grid 2")]
             }
         ]
     };
@@ -253,11 +243,9 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                         type: "Container",
                         padding: 8,
                         children: [
-                            {
-                                type: "Text",
+                            text({
                                 bold: true,
                                 fontSize: 10,
-                                content: column.header ? column.header : "Header",
                                 fontColor: column.header
                                     ? undefined
                                     : isColumnHidden
@@ -267,7 +255,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                                     : isDarkMode
                                     ? "#3E3E3E"
                                     : "#F5F5F5"
-                            }
+                            })(column.header ? column.header : "Header")
                         ]
                     },
                     ...(hasColumns && values.columnsFilterable

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -271,7 +271,7 @@ export const getPreview = (
 
     return container()(
         titleHeader,
-        datasource(values.datasource)(),
+        ...(canHideDataSourceHeader ? [datasource(values.datasource)()] : []),
         ...(values.showHeaderFilters && values.filterList.length > 0 ? [headerFilters] : []),
         headers,
         ...Array.from({ length: 5 }).map(() => columns),

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -1,5 +1,5 @@
 import {
-    ContainerProps,
+    container,
     DropZoneProps,
     RowLayoutProps,
     StructurePreviewProps,
@@ -158,37 +158,32 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
     const columns: RowLayoutProps = {
         type: "RowLayout",
         columnSize: "fixed",
-        children: columnProps.map(
-            column =>
-                ({
-                    type: "Container",
-                    borders: true,
-                    grow: column.width === "manual" && column.size ? column.size : 1,
-                    backgroundColor:
-                        values.columnsHidable && column.hidable === "hidden"
-                            ? isDarkMode
-                                ? "#3E3E3E"
-                                : "#F5F5F5"
-                            : undefined,
-                    children: [
-                        column.showContentAs === "customContent"
-                            ? {
-                                  type: "DropZone",
-                                  property: column.content
-                              }
-                            : {
-                                  type: "Container",
-                                  padding: 8,
-                                  children: [
-                                      text({ fontSize: 10 })(
-                                          column.showContentAs === "dynamicText"
-                                              ? column.dynamicText ?? "Dynamic text"
-                                              : `[${column.attribute ? column.attribute : "No attribute selected"}]`
-                                      )
-                                  ]
-                              }
-                    ]
-                } as ContainerProps)
+        children: columnProps.map(column =>
+            container({
+                borders: true,
+                grow: column.width === "manual" && column.size ? column.size : 1,
+                backgroundColor:
+                    values.columnsHidable && column.hidable === "hidden"
+                        ? isDarkMode
+                            ? "#3E3E3E"
+                            : "#F5F5F5"
+                        : undefined
+            })(
+                column.showContentAs === "customContent"
+                    ? {
+                          type: "DropZone",
+                          property: column.content
+                      }
+                    : container({
+                          padding: 8
+                      })(
+                          text({ fontSize: 10 })(
+                              column.showContentAs === "dynamicText"
+                                  ? column.dynamicText ?? "Dynamic text"
+                                  : `[${column.attribute ? column.attribute : "No attribute selected"}]`
+                          )
+                      )
+            )
         )
     };
     const titleHeader: RowLayoutProps = {
@@ -198,11 +193,9 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
         borders: true,
         borderWidth: 1,
         children: [
-            {
-                type: "Container",
-                padding: 4,
-                children: [text({ fontColor: isDarkMode ? "#6DB1FE" : "#2074C8" })("Data grid 2")]
-            }
+            container({
+                padding: 4
+            })(text({ fontColor: isDarkMode ? "#6DB1FE" : "#2074C8" })("Data grid 2"))
         ]
     };
     const headerFilters = {
@@ -222,8 +215,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
         columnSize: "fixed",
         children: columnProps.map(column => {
             const isColumnHidden = values.columnsHidable && column.hidable === "hidden";
-            const content: ContainerProps = {
-                type: "Container",
+            const content = container({
                 borders: true,
                 grow:
                     values.columns.length > 0
@@ -237,47 +229,41 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                         : "#DCDCDC"
                     : isDarkMode
                     ? "#3E3E3E"
-                    : "#F5F5F5",
-                children: [
-                    {
-                        type: "Container",
-                        padding: 8,
-                        children: [
-                            text({
-                                bold: true,
-                                fontSize: 10,
-                                fontColor: column.header
-                                    ? undefined
-                                    : isColumnHidden
-                                    ? isDarkMode
-                                        ? "#4F4F4F"
-                                        : "#DCDCDC"
-                                    : isDarkMode
-                                    ? "#3E3E3E"
-                                    : "#F5F5F5"
-                            })(column.header ? column.header : "Header")
-                        ]
-                    },
-                    ...(hasColumns && values.columnsFilterable
-                        ? [
-                              {
-                                  type: "DropZone",
-                                  property: column.filter,
-                                  placeholder: "Place filter widget here"
-                              } as DropZoneProps
-                          ]
-                        : [])
-                ]
-            };
+                    : "#F5F5F5"
+            })(
+                container({
+                    padding: 8
+                })(
+                    text({
+                        bold: true,
+                        fontSize: 10,
+                        fontColor: column.header
+                            ? undefined
+                            : isColumnHidden
+                            ? isDarkMode
+                                ? "#4F4F4F"
+                                : "#DCDCDC"
+                            : isDarkMode
+                            ? "#3E3E3E"
+                            : "#F5F5F5"
+                    })(column.header ? column.header : "Header")
+                ),
+                ...(hasColumns && values.columnsFilterable
+                    ? [
+                          {
+                              type: "DropZone",
+                              property: column.filter,
+                              placeholder: "Place filter widget here"
+                          } as DropZoneProps
+                      ]
+                    : [])
+            );
             return values.columns.length > 0
                 ? {
                       type: "Selectable",
                       object: column,
                       grow: column.width === "manual" && column.size ? column.size : 1,
-                      child: {
-                          type: "Container",
-                          children: [content]
-                      }
+                      child: container()(content)
                   }
                 : content;
         })
@@ -299,16 +285,13 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                   } as RowLayoutProps
               ]
             : [];
-    return {
-        type: "Container",
-        children: [
-            titleHeader,
-            ...(values.showHeaderFilters && values.filterList.length > 0 ? [headerFilters] : []),
-            headers,
-            ...Array.from({ length: 5 }).map(() => columns),
-            ...footer
-        ]
-    };
+    return container()(
+        titleHeader,
+        ...(values.showHeaderFilters && values.filterList.length > 0 ? [headerFilters] : []),
+        headers,
+        ...Array.from({ length: 5 }).map(() => columns),
+        ...footer
+    );
 };
 
 export function check(values: DatagridPreviewProps): Problem[] {

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -1,6 +1,6 @@
 import {
     container,
-    DropZoneProps,
+    dropzone,
     RowLayoutProps,
     selectable,
     StructurePreviewProps,
@@ -171,10 +171,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                         : undefined
             })(
                 column.showContentAs === "customContent"
-                    ? {
-                          type: "DropZone",
-                          property: column.content
-                      }
+                    ? dropzone()(column.content)
                     : container({
                           padding: 8
                       })(
@@ -203,13 +200,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
         type: "RowLayout",
         columnSize: "fixed",
         borders: true,
-        children: [
-            {
-                type: "DropZone",
-                property: values.filtersPlaceholder,
-                placeholder: "Place filter widget(s) here"
-            } as DropZoneProps
-        ]
+        children: [dropzone(dropzone.placeholder("Place filter widget(s) here"))(values.filtersPlaceholder)]
     } as RowLayoutProps;
     const headers: RowLayoutProps = {
         type: "RowLayout",
@@ -250,13 +241,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                     })(column.header ? column.header : "Header")
                 ),
                 ...(hasColumns && values.columnsFilterable
-                    ? [
-                          {
-                              type: "DropZone",
-                              property: column.filter,
-                              placeholder: "Place filter widget here"
-                          } as DropZoneProps
-                      ]
+                    ? [dropzone(dropzone.placeholder("Place filter widget here"))(column.filter)]
                     : [])
             );
             return values.columns.length > 0
@@ -274,11 +259,9 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
                       columnSize: "fixed",
                       borders: true,
                       children: [
-                          {
-                              type: "DropZone",
-                              property: values.emptyPlaceholder,
-                              placeholder: "Empty list message: Place widgets here"
-                          } as DropZoneProps
+                          dropzone(dropzone.placeholder("Empty list message: Place widgets here"))(
+                              values.emptyPlaceholder
+                          )
                       ]
                   } as RowLayoutProps
               ]

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.4.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.4.3" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/html-element-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/html-element-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with HTML Element widget producing errors in Studio Pro versions below 9.18.
+
 ## [1.0.0] - 2022-11-24
 
 ### Added

--- a/packages/pluggableWidgets/html-element-web/package.json
+++ b/packages/pluggableWidgets/html-element-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "html-element-web",
   "widgetName": "HTMLElement",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Displays custom HTML",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/html-element-web/src/HTMLElement.editorConfig.ts
+++ b/packages/pluggableWidgets/html-element-web/src/HTMLElement.editorConfig.ts
@@ -196,7 +196,9 @@ export function getPreview(
               );
 
     return container({ grow: 1, borders: true, borderWidth: 1 })(
-        values.tagContentRepeatDataSource ? datasource(values.tagContentRepeatDataSource)() : container()(),
+        values.tagContentRepeatDataSource && canHideDataSourceHeader
+            ? datasource(values.tagContentRepeatDataSource)()
+            : container()(),
         isVoidElement(tagName) ? voidElementPreview(tagName) : flowElementPreview()
     );
 }

--- a/packages/pluggableWidgets/html-element-web/src/HTMLElement.editorConfig.ts
+++ b/packages/pluggableWidgets/html-element-web/src/HTMLElement.editorConfig.ts
@@ -189,13 +189,9 @@ export function getPreview(
               )
             : container({ padding: 0 })(
                   text()(`<${tagName}>`),
-                  dropzone(
-                      canHideDataSourceHeader
-                          ? {
-                                showDataSourceHeader: false
-                            }
-                          : {}
-                  )(values.tagUseRepeat ? values.tagContentRepeatContainer : values.tagContentContainer),
+                  dropzone(dropzone.hideDataSourceHeaderIf(canHideDataSourceHeader))(
+                      values.tagUseRepeat ? values.tagContentRepeatContainer : values.tagContentContainer
+                  ),
                   text()(`</${tagName}>`)
               );
 

--- a/packages/pluggableWidgets/html-element-web/src/package.xml
+++ b/packages/pluggableWidgets/html-element-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="HTMLElement" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="HTMLElement" version="1.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="HTMLElement.xml" />
         </widgetFiles>

--- a/packages/shared/pluggable-widgets-commons/src/structure-preview-api/index.ts
+++ b/packages/shared/pluggable-widgets-commons/src/structure-preview-api/index.ts
@@ -101,13 +101,24 @@ export interface DropZoneProps extends DropZoneStylingProps {
     property: object;
 }
 
-export function dropzone(style: DropZoneStylingProps): (prop: object) => DropZoneProps {
+export function dropzone(...options: Array<Partial<DropZoneStylingProps>>): (prop: object) => DropZoneProps {
+    const params = Object.assign({}, ...options) as Partial<DropZoneStylingProps>;
+
     return (property: object) => ({
         type: "DropZone",
         property,
-        ...style
+        ...params
     });
 }
+
+dropzone.placeholder = (placeholder: string) => {
+    return {
+        placeholder
+    };
+};
+dropzone.hideDataSourceHeaderIf = (hideCondition: boolean) => {
+    return hideCondition ? { showDataSourceHeader: false } : {};
+};
 
 export interface SelectableProps extends BaseStylingProps {
     type: "Selectable";

--- a/packages/shared/pluggable-widgets-commons/src/structure-preview-api/index.ts
+++ b/packages/shared/pluggable-widgets-commons/src/structure-preview-api/index.ts
@@ -126,12 +126,16 @@ export interface SelectableProps extends BaseStylingProps {
     child: StructurePreviewProps;
 }
 
-export function selectable(object: object): (child: StructurePreviewProps) => SelectableProps {
+export function selectable(
+    object: object,
+    style?: BaseStylingProps
+): (child: StructurePreviewProps) => SelectableProps {
     return (child: StructurePreviewProps) => {
         return {
             type: "Selectable",
             object,
-            child
+            child,
+            ...style
         };
     };
 }


### PR DESCRIPTION
### Description

<!--- Describe your changes in detail -->

### Pull request checklist

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [x] PR title properly formatted `[XX-000]: description`
-   [X] Added record to packages' CHANGELOG.md
-   [x] Bumped package version in `package.json` and `package.xml`
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

<!--- Describe what part of pacakge need to be tested and more important - how -->
This also includes a small fix for WC-1562 for HTML Element. Make sure structure preview for **DataGrid 2** and **HTML Element** works in:
 - Below 9.18 (old structure preview)
 - At 9.18 (old structure preview)
 - At 9.19 (old structure preview)
 - At 9.20+ (new structure preview with one global datasource header)

This is needed because of API transitions in 9.18 - 9.20, so we want to cover all cases.