### PR TITLE
[WC-1550]: Handle pnpm install failure in dependabot PRs

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -63,6 +63,27 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+      # This step is meant to update pnpm-lock.yaml file on Dependabot
+      # pull requests. Right now dependabot not work fine with monorepos
+      # so we have to do extra work to automatically update lock file.
+      # This step is part of "check" job, but could be part of any other job.
+      # We put it here just because previous `Install dependencies` step is just
+      # first "install" in this workflow.
+      # The idea of this step - if install fails, try to fix lock file, commit and
+      # push changes.
+      # NOTE: we use magic string ([dependabot skip]) to allow branch rebase,
+      # read more at link below
+      # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#allowing-dependabot-to-rebase-and-force-push-over-extra-commits
+      - name: Update pnpm-lock.yaml on Dependabot pull request
+        if: ${{ failure() && github.actor == 'dependabot[bot]' }}
+        # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
+        run: |
+          pnpm install --no-frozen-lockfile
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add pnpm-lock.yaml
+          git commit -m "build: update pnpm-lock.yaml [dependabot skip]"
+          git push
       - name: Lint code
         run: pnpm run lint ${{ needs.setup-options.outputs.since-flag }}
       - name: Run unit tests


### PR DESCRIPTION
### Description

This PR introduces new build step, to handle `pnpm install` step failure on dependabot PRs
This step is meant to update pnpm-lock.yaml file on Dependabot
pull requests. Right now dependabot not work fine with monorepos
so we have to do extra work to automatically update lock file.
This step is part of "check" job, but could be part of any other job.
We put it here just because previous `Install dependencies` step is just
first "install" in this workflow.
The idea of this step - if install fails, try to fix lock file, commit and
push changes.
NOTE: we use magic string ([dependabot skip]) to allow branch rebase, read more at link below.
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#allowing-dependabot-to-rebase-and-force-push-over-extra-commits

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

- After merging this PR we need to instruct dependabot to rebase one or two PRs and see if failure handling executes correctly.
