### PR TITLE
ci: fix git issues on lock file update

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -78,6 +78,7 @@ jobs:
         if: ${{ failure() && github.actor == 'dependabot[bot]' }}
         # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
         run: |
+          git checkout -t origin/${{ github.ref_name }}
           pnpm install --no-frozen-lockfile
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
### Description

Small fix to resolve issue with branch in GH workflow:
```
> validate-staged-widget-versions
> node scripts/validation/validate-versions-staged-files.js

[detached HEAD 447659c7] build: update pnpm-lock.yaml [dependabot skip]
 1 file changed, 4 insertions(+), 4 deletions(-)
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>

```

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)
