### PR TITLE
[WC-1550]: Add workflow to update lock file

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -63,28 +63,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-      # This step is meant to update pnpm-lock.yaml file on Dependabot
-      # pull requests. Right now dependabot not work fine with monorepos
-      # so we have to do extra work to automatically update lock file.
-      # This step is part of "check" job, but could be part of any other job.
-      # We put it here just because previous `Install dependencies` step is just
-      # first "install" in this workflow.
-      # The idea of this step - if install fails, try to fix lock file, commit and
-      # push changes.
-      # NOTE: we use magic string ([dependabot skip]) to allow branch rebase,
-      # read more at link below
-      # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#allowing-dependabot-to-rebase-and-force-push-over-extra-commits
-      - name: Update pnpm-lock.yaml on Dependabot pull request
-        if: ${{ failure() && github.actor == 'dependabot[bot]' }}
-        # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
-        run: |
-          git checkout -t origin/${{ github.head_ref }}
-          pnpm install --no-frozen-lockfile
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add pnpm-lock.yaml
-          git commit -m "build: update pnpm-lock.yaml [dependabot skip]"
-          git push
       - name: Lint code
         run: pnpm run lint ${{ needs.setup-options.outputs.since-flag }}
       - name: Run unit tests

--- a/.github/workflows/UpdateLockFile.yml
+++ b/.github/workflows/UpdateLockFile.yml
@@ -1,0 +1,53 @@
+name: Update lock file
+# The goal of this workflow is to update pnpm-lock.yaml file on Dependabot pull requests.
+# Right now dependabot not work fine with monorepos
+# so we have to do extra work to automatically update lock file.
+# NOTE: we use magic string ([dependabot skip]) to allow branch rebase,
+# read more at link below
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#allowing-dependabot-to-rebase-and-force-push-over-extra-commits
+
+on:
+  pull_request:
+    branches:
+      - "dependabot/**"
+
+permissions:
+  pull-requests: write
+  actions: read
+  checks: read
+  contents: read
+  deployments: read
+  id-token: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+jobs:
+  update-lock-file:
+    name: Update lockfile, commit and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@af2eb3226618e2494e3d9084f515ad6dcf16e229 # v2.0.1
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # v2.2.4
+      - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+        with:
+          node-version-file: ".nvmrc"
+      - name: Fix lockfile and push to branch created by dependabot
+        # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
+        run: |
+          git checkout -t origin/${{ github.head_ref }}
+          pnpm install --lockfile-only
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add pnpm-lock.yaml
+          git commit -m "build: update pnpm-lock.yaml [dependabot skip]"
+          git push
+      
+
+


### PR DESCRIPTION
### Description

This time we split lock file update into separate workflow. It seems that we need to grand `pull-request` write permissions. So, to not make `Build` workflow too heavy, and not break permissions, I decided to split this into separate workflow, that will be triggered only for dependabot PRs.

### Pull request type

-   [x] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

<!--- Describe what part of pacakge need to be tested and more important - how -->
