### PR TITLE
Update to cypress 12

### DIFF
--- a/automation/run-e2e/cypress.config.cjs
+++ b/automation/run-e2e/cypress.config.cjs
@@ -18,6 +18,7 @@ module.exports = defineConfig({
         videoUploadOnPasses: false,
         viewportHeight: 1080,
         viewportWidth: 1280,
+        testIsolation: false,
         chromeWebSecurity: false,
         specPattern: "cypress/integration/**/*.js",
         supportFile: "cypress/support/e2e.js"

--- a/automation/run-e2e/lib/ci.mjs
+++ b/automation/run-e2e/lib/ci.mjs
@@ -9,11 +9,7 @@ import { createDeploymentBundle, prepareImage, startCypress, startRuntime } from
 import { setupTestProject } from "./setup-test-project.mjs";
 import { updateWidget } from "./utils.mjs";
 
-const MX_VERSION_MAP_URL =
-    // Remove after merge
-    "https://raw.githubusercontent.com/mendix/widgets-resources/master/configs/e2e/mendix-versions.json";
-// Uncomment after merge
-// "https://raw.githubusercontent.com/mendix/web-widgets/main/automation/run-e2e/mendix-versions.json";
+const MX_VERSION_MAP_URL = "https://raw.githubusercontent.com/mendix/web-widgets/main/automation/run-e2e/mendix-versions.json";
 
 const { ls, cat } = sh;
 

--- a/automation/run-e2e/lib/docker-utils.mjs
+++ b/automation/run-e2e/lib/docker-utils.mjs
@@ -158,12 +158,12 @@ export function startCypress(ip, freePort) {
         // container name
         `--name cypress`,
         // image to run, the entrypoint set to `cypress run` by default
-        `cypress/included:10.11.0`,
+        `cypress/included:12.1.0`,
         // cypress options
         `--browser ${browserCypress} ${headedMode}`.trim(),
         `--e2e`,
         `--config-file cypress.config.cjs`,
-        `--config baseUrl=http://${ip}:${freePort},video=true,videoUploadOnPasses=false,viewportWidth=1280,viewportHeight=1080,chromeWebSecurity=false`
+        `--config baseUrl=http://${ip}:${freePort},video=true,videoUploadOnPasses=false,viewportWidth=1280,viewportHeight=1080,testIsolation=false,chromeWebSecurity=false`
     ];
     const command = [`docker run`, ...args].join(" ");
 

--- a/automation/run-e2e/package.json
+++ b/automation/run-e2e/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "ansi-colors": "^4.1.3",
     "cross-zip": "^4.0.0",
-    "cypress": "^10.11.0",
+    "cypress": "^12.1.0",
     "cypress-image-diff-js": "^1.22.0",
-    "cypress-terminal-report": "^4.1.2",
+    "cypress-terminal-report": "^5.0.0",
     "enquirer": "^2.3.6",
     "eslint": "^7.20.0",
     "eslint-plugin-cypress": "^2.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,9 @@ importers:
     specifiers:
       ansi-colors: ^4.1.3
       cross-zip: ^4.0.0
-      cypress: ^10.11.0
+      cypress: ^12.1.0
       cypress-image-diff-js: ^1.22.0
-      cypress-terminal-report: ^4.1.2
+      cypress-terminal-report: ^5.0.0
       enquirer: ^2.3.6
       eslint: ^7.20.0
       eslint-plugin-cypress: ^2.12.1
@@ -93,9 +93,9 @@ importers:
     dependencies:
       ansi-colors: 4.1.3
       cross-zip: 4.0.0
-      cypress: 10.11.0
-      cypress-image-diff-js: 1.22.0_cypress@10.11.0
-      cypress-terminal-report: 4.1.2_cypress@10.11.0
+      cypress: 12.1.0
+      cypress-image-diff-js: 1.22.0_cypress@12.1.0
+      cypress-terminal-report: 5.0.0_cypress@12.1.0
       enquirer: 2.3.6
       eslint: 7.32.0
       eslint-plugin-cypress: 2.12.1_eslint@7.32.0
@@ -7918,7 +7918,7 @@ packages:
     resolution: {integrity: sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==}
     dev: true
 
-  /cypress-image-diff-js/1.22.0_cypress@10.11.0:
+  /cypress-image-diff-js/1.22.0_cypress@12.1.0:
     resolution: {integrity: sha512-ugCXZF6mVcp+TQQBrb2xARgFsnS5Mt3MCVpAr/fiF/GG7usuuiJWbHqQ+98H0kIoPIvFJzC5Nzf6VZ1+zycHLw==}
     hasBin: true
     peerDependencies:
@@ -7927,7 +7927,7 @@ packages:
       '@babel/runtime': 7.19.4
       arg: 4.1.3
       colors: 1.4.0
-      cypress: 10.11.0
+      cypress: 12.1.0
       cypress-recurse: 1.24.0
       fs-extra: 9.1.0
       handlebars: 4.7.7
@@ -7941,21 +7941,21 @@ packages:
       humanize-duration: 3.27.3
     dev: false
 
-  /cypress-terminal-report/4.1.2_cypress@10.11.0:
-    resolution: {integrity: sha512-UyCR7AJXMJYt87JXBAxdZxWC+FXG1S7+ePVACcumUQZq5lH490pXPPg47KY/7J6yyFatT6da+Mb1/J6E7K8sLg==}
+  /cypress-terminal-report/5.0.0_cypress@12.1.0:
+    resolution: {integrity: sha512-X5JVRB2fs/KbZJU19qLjzcLidA2TO4g5dm4ya4XDXLoGvtEDI9XWSX+E8CFC25wzbvczIboWGBxLKSsDRZrTBw==}
     peerDependencies:
       cypress: '>=4.10.0'
     dependencies:
       chalk: 4.1.2
-      cypress: 10.11.0
+      cypress: 12.1.0
       fs-extra: 10.1.0
       semver: 7.3.8
       tv4: 1.3.0
     dev: false
 
-  /cypress/10.11.0:
-    resolution: {integrity: sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==}
-    engines: {node: '>=12.0.0'}
+  /cypress/12.1.0:
+    resolution: {integrity: sha512-7fz8N84uhN1+ePNDsfQvoWEl4P3/VGKKmAg+bJQFY4onhA37Ys+6oBkGbNdwGeC7n2QqibNVPhk8x3YuQLwzfw==}
+    engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
     hasBin: true
     requiresBuild: true
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -51,5 +51,5 @@
             "outputs": []
         }
     },
-    "globalDependencies": ["packages/tools/release-utils-internal/**"]
+    "globalDependencies": ["automation/**"]
 }


### PR DESCRIPTION
### Description

The main goal here is to update Cypress to version 12. Important note, since version 12 Cypress is enabling by default the testIsolation, that means all the tests are running in a clean state, in our case that affects our tests since we depend on some page content, to revert that I have disabled this testIsolation, so now it's behaving like before. 
We need to do a new analysis to see if we can follow this recommendation(https://docs.cypress.io/guides/references/migration-guide#Test-Isolation). I also uncommented one part of the code to get the correct Mendix version.

EXTRA: fix e2e hitting the turbo cache incorrectly.

### Pull request checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [ ] PR title properly formatted `[XX-000]: description`
-   [ ] Added record to packages' CHANGELOG.md
-   [ ] Bumped package version in `package.json` and `package.xml`
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [x] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

Automation should execute and pass.
