### PR TITLE
[WC-1614]: Re-enable firefox e2e

### DIFF
--- a/.github/workflows/RunE2EFirefox.yml
+++ b/.github/workflows/RunE2EFirefox.yml
@@ -1,0 +1,83 @@
+name: Run E2E test on Firefox
+# This workflow is used to test our widgets against the Firefox browser weekly.
+
+on:
+  schedule:
+    # At 03:00 on Tuesday.
+    - cron: "0 03 * * 2"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  since_flag: ${{ github.event_name == 'pull_request' && format('--filter "...[origin/{0}]"', github.base_ref) || '' }}
+
+jobs:
+  e2e:
+    name: Run automated end-to-end tests on Firefox
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: read
+      contents: read
+
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      fail-fast: false
+      matrix:
+        # run 3 copies of the current job in parallel
+        index: [0, 1, 2]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          fetch-depth: 0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # v2.2.4
+        with:
+          version: ^7.13.4
+      - name: Setup node
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Get sha of main
+        run: echo "main_sha=$(git rev-parse origin/main)" >> ${{ runner.os == 'Windows' && '$env:GITHUB_ENV' || '$GITHUB_ENV' }}
+      - name: Restore Turbo Cache
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+        with:
+          path: node_modules/.cache/turbo
+          key: turbo-cache-${{ runner.os }}-e2e-chunk-${{ matrix.index }}-${{ env.main_sha }}
+          restore-keys: |
+            turbo-cache-${{ runner.os }}-e2e-chunk-${{ matrix.index }}
+      - name: Install dependencies
+        run: pnpm install
+      - name: "Executing E2E tests"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BROWSER_CYPRESS: firefox
+        run: >-
+          node 
+          ./automation/run-e2e/bin/run-e2e-in-chunks.mjs
+          --chunks 3
+          --index ${{ matrix.index }}
+          --event-name ${{ github.event_name }}
+      - name: "Fixing files permissions"
+        if: failure()
+        run: |
+          sudo find ${{ github.workspace }}/packages/* -type d -exec chmod 755 {} \;
+          sudo find ${{ github.workspace }}/packages/* -type f -exec chmod 644 {} \;
+      - name: "Archive test screenshot diff results"
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        if: failure()
+        with:
+          name: test-screenshot-results
+          path: |
+            ${{ github.workspace }}/packages/**/tests/e2e/screenshot-results/diff/**/*.png
+            ${{ github.workspace }}/packages/**/tests/e2e/screenshot-results/TESTFAIL_*.png
+            ${{ github.workspace }}/packages/**/cypress-visual-screenshots/diff/*.png
+            ${{ github.workspace }}/packages/**/cypress-visual-screenshots/comparison/*.png
+            ${{ github.workspace }}/packages/**/cypress/videos/*.mp4
+          if-no-files-found: error

--- a/automation/run-e2e/lib/setup-test-project.mjs
+++ b/automation/run-e2e/lib/setup-test-project.mjs
@@ -21,7 +21,8 @@ export async function setupTestProject() {
     sh.config.silent = false;
 
     if (testsFiles.length !== 0) {
-        throw new Error("tests dir is not empty");
+        console.log("Test project directory already exists, cleaning up...");
+        rm("-rf", "tests");
     }
 
     const archivePath = await downloadTestProject(


### PR DESCRIPTION
### Description

Re-enable Firefox e2e workflow for this repository.

Extra: Added removal of the testProject directory when it's not empty.

### Pull request checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [x] PR title properly formatted `[XX-000]: description`
-   [ ] Added record to packages' CHANGELOG.md
-   [ ] Bumped package version in `package.json` and `package.xml`
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?
Automation should pass.
