### PR TITLE
Fix incorrect assertion in color picker Firefox e2e

### DIFF
--- a/packages/pluggableWidgets/color-picker-web/cypress/integration/ColorPicker.spec.js
+++ b/packages/pluggableWidgets/color-picker-web/cypress/integration/ColorPicker.spec.js
@@ -40,7 +40,7 @@ describe("color-picker-web", () => {
             cy.get(".mx-name-colorPicker3 .widget-color-picker-inner").should(
                 "have.css",
                 "background",
-                "rgb(76, 175, 80) none repeat scroll 0% 0%"
+                "rgb(76, 175, 80)"
             );
         });
         it("input box", () => {


### PR DESCRIPTION
### Description

Fix incorrect assertion in color picker Firefox e2e.

### Pull request checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [ ] PR title properly formatted `[XX-000]: description`
-   [ ] Added record to packages' CHANGELOG.md
-   [ ] Bumped package version in `package.json` and `package.xml`
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

Automation should pass.
