### PR TITLE
RichTextEditor fix conditianl editability and minor cleanup

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Using editable settings, when switch from readonly state to editable then it is possible to change the text
+
 ## [2.1.0] - 2022-11-22
 
 ### Security

--- a/packages/pluggableWidgets/rich-text-web/package.json
+++ b/packages/pluggableWidgets/rich-text-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rich-text-web",
   "widgetName": "RichText",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Rich inline or toolbar text editing",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
@@ -46,7 +46,6 @@ export default function RichText(props: RichTextContainerProps): ReactNode {
     }
     return (
         <RichTextComponent
-            advancedConfig={props.advancedConfig}
             advancedContentFilter={
                 props.advancedContentFilter === "custom"
                     ? {

--- a/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
@@ -10,7 +10,7 @@ import { getDimensions, Dimensions } from "@mendix/pluggable-widgets-commons";
 import { defineEnterMode, addPlugin, PluginName } from "../utils/ckeditorConfigs";
 import sanitizeHtml from "sanitize-html";
 import classNames from "classnames";
-import { ReadOnlyStyleEnum, EnterModeEnum, ShiftEnterModeEnum, AdvancedConfigType } from "../../typings/RichTextProps";
+import { ReadOnlyStyleEnum, EnterModeEnum, ShiftEnterModeEnum } from "../../typings/RichTextProps";
 import { MainEditor } from "./MainEditor";
 
 export interface RichTextProps {
@@ -19,7 +19,6 @@ export interface RichTextProps {
     spellChecker: boolean;
     sanitizeContent?: boolean;
     value: string | undefined;
-    advancedConfig: AdvancedConfigType[] | null;
     plugins?: string[];
     readOnlyStyle: ReadOnlyStyleEnum;
     toolbar: CKEditorConfig;

--- a/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
@@ -34,9 +34,25 @@ export interface RichTextProps {
     tabIndex: number | undefined;
 }
 
-export const RichTextEditor = (props: RichTextProps): ReactElement => {
-    const { editorType, plugins, enterMode, shiftEnterMode, value, readOnly, readOnlyStyle, advancedContentFilter } =
-        props;
+export const RichTextEditor = ({
+    name,
+    readOnly,
+    spellChecker,
+    sanitizeContent,
+    value,
+    plugins,
+    readOnlyStyle,
+    toolbar,
+    enterMode,
+    shiftEnterMode,
+    editorType,
+    dimensions,
+    advancedContentFilter,
+    onValueChange,
+    onKeyChange,
+    onKeyPress,
+    tabIndex
+}: RichTextProps): ReactElement => {
     const [element, setElement] = useState<HTMLElement | null>(null);
     const localEditorValueRef = useRef("");
     const editorInstanceRef = useRef<null | CKEditorInstance>(null);
@@ -44,8 +60,8 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
         (editor: null | CKEditorInstance) => (editorInstanceRef.current = editor),
         []
     );
-    const { width, height } = props.dimensions
-        ? getDimensions({ ...props.dimensions })
+    const { width, height } = dimensions
+        ? getDimensions({ ...dimensions })
         : {
               width: "100%",
               height: "100%"
@@ -53,19 +69,19 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
 
     const dispatchEvent = ({ type, payload }: { type: string; payload: any }): void => {
         if (type === CKEditorEventAction.key) {
-            if (props.onKeyPress) {
-                props.onKeyPress();
+            if (onKeyPress) {
+                onKeyPress();
             }
         }
         if (type === CKEditorEventAction.change) {
             const value = payload.editor.getData();
-            if (props.onKeyChange) {
-                props.onKeyChange();
+            if (onKeyChange) {
+                onKeyChange();
             }
-            if (props?.onValueChange) {
-                const content = props.sanitizeContent ? sanitizeHtml(value) : value;
+            if (onValueChange) {
+                const content = sanitizeContent ? sanitizeHtml(value) : value;
                 localEditorValueRef.current = content;
-                props?.onValueChange(content);
+                onValueChange(content);
             }
         }
     };
@@ -80,11 +96,11 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
             autoGrow_onStartup: true,
             width,
             height,
-            tabIndex: props.tabIndex,
+            tabIndex,
             enterMode: defineEnterMode(enterMode || ""),
             shiftEnterMode: defineEnterMode(shiftEnterMode || ""),
-            disableNativeSpellChecker: !props.spellChecker,
-            readOnly: props.readOnly
+            disableNativeSpellChecker: !spellChecker,
+            readOnly
         },
         initContent: value,
         dispatchEvent,
@@ -93,7 +109,7 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
 
     const key = useMemo(() => Date.now(), [ckeditorConfig]);
     useEffect(() => {
-        const config = { ...props.toolbar };
+        const config = { ...toolbar };
         if (plugins?.length) {
             plugins.forEach((plugin: PluginName) => addPlugin(plugin, config));
         }
@@ -130,7 +146,7 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
             className={classNames("widget-rich-text", `${readOnly ? `editor-${readOnlyStyle}` : ""}`)}
             style={{ width, height }}
         >
-            <div ref={setElement} id={props.name} />
+            <div ref={setElement} id={name} />
             <MainEditor key={key} config={ckeditorConfig} editorRef={editorRefCallback} />
         </div>
     );

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
@@ -14,7 +14,6 @@ describe("RichText", () => {
         remoteUrl: ""
     };
     const defaultRichTextProps: RichTextProps = {
-        advancedConfig: null,
         dimensions: {
             width: 100,
             height: 100,

--- a/packages/pluggableWidgets/rich-text-web/src/package.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="RichText" version="2.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="RichText" version="2.1.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="RichText.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
+++ b/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
@@ -1,7 +1,7 @@
 /**
  * This file was generated from RichText.xml
  * WARNING: All changes made to this file will be overwritten
- * @author Mendix UI Content Team
+ * @author Mendix Widgets Framework Team
  */
 import { ActionValue, EditableValue } from "mendix";
 


### PR DESCRIPTION
### Description

In the current version, there is a bug that when using conditional editability in widget settings and rendering the widget in read-only mode then it's not possible to switch to edit mode and the setValue will be failed.

This PR is to fix this issue.

### Pull request checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [ ] PR title properly formatted `[XX-000]: description`
-   [x] Added record to packages' CHANGELOG.md
-   [x] Bumped package version in `package.json` and `package.xml`
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

<!--- Describe what part of pacakge need to be tested and more important - how -->
