### PR TITLE
feat(run-e2e): add e2e update project hook

### DIFF
--- a/automation/run-e2e/lib/config.mjs
+++ b/automation/run-e2e/lib/config.mjs
@@ -1,0 +1,18 @@
+export const testsDir = "tests";
+export const testProjectDir = "tests/testProject";
+export const postUnzipProjectDirGlob = "tests/testProjects-*";
+export const mprFileGlob = "tests/testProject/*.mpr";
+export const nameForDownloadedArchive = "testProject.zip";
+export const nameForDownloadedStarterApp = "StarterAppRelease.zip";
+export const starterAppLatestReleaseUrl = "https://api.github.com/repos/mendix/StarterApp_Blank/releases/latest";
+export const mxVersionMapUrl =
+    "https://raw.githubusercontent.com/mendix/web-widgets/main/automation/run-e2e/mendix-versions.json";
+export const tmpDirPrefix = "run_e2e_files_";
+export const atlasDirsToRemove = [
+    "tests/testProject/theme",
+    "tests/testProject/themesource/atlas_ui_resources",
+    "tests/testProject/themesource/atlas_core",
+    "tests/testProject/themesource/atlas_nativemobile_content",
+    "tests/testProject/themesource/atlas_web_content",
+    "tests/testProject/themesource/datawidgets"
+];

--- a/automation/run-e2e/lib/dev.mjs
+++ b/automation/run-e2e/lib/dev.mjs
@@ -5,7 +5,9 @@ import parseArgs from "yargs-parser";
 import c from "ansi-colors";
 import enquirer from "enquirer";
 import { setupTestProject } from "./setup-test-project.mjs";
-import { await200, updateWidget } from "./utils.mjs";
+import { updateTestProject } from "./update-test-project.mjs";
+import { await200 } from "./utils.mjs";
+import * as config from "./config.mjs";
 
 export async function dev() {
     console.log(c.cyan("Run e2e tests in development environment"));
@@ -34,13 +36,13 @@ export async function dev() {
     if (options.withPreps) {
         // Download test project from github
         await setupTestProject();
-        // Run release script and copy widget to testProject
-        await updateWidget();
+        // Run update project hook
+        await updateTestProject();
 
         console.log(
             c.yellow(
                 [
-                    "Please open and run tests/testProject/<name>.mpr in Studio Pro.",
+                    `Please open and run ${config.mprFileGlob} in Studio Pro.`,
                     "If project contains errors, then you have to resolve them manually.",
                     "Once project is running, press Enter to continue."
                 ].join("\n")

--- a/automation/run-e2e/lib/setup-test-project.mjs
+++ b/automation/run-e2e/lib/setup-test-project.mjs
@@ -1,28 +1,23 @@
 #!/usr/bin/env node
-import { tmpdir } from "node:os";
 import { createWriteStream } from "node:fs";
-import { mkdtemp } from "node:fs/promises";
-import { pipeline } from "node:stream";
-import { promisify } from "node:util";
 import { join } from "node:path";
 import sh from "shelljs";
 import crossZip from "cross-zip";
-import { packageMeta, fetchGithubRestAPI, fetchWithReport } from "./utils.mjs";
+import { packageMeta, fetchWithReport, usetmp, streamPipe } from "./utils.mjs";
+import * as config from "./config.mjs";
 
-const { cp, ls, mkdir, rm, mv } = sh;
-const streamPipe = promisify(pipeline);
-const usetmp = async () => mkdtemp(join(tmpdir(), "run_e2e_files_"));
+const { ls, mkdir, rm, mv } = sh;
 
 export async function setupTestProject() {
     console.log("Copying test project from GitHub repository");
 
     sh.config.silent = true;
-    const testsFiles = ls("tests");
+    const testsFiles = ls(config.testsDir);
     sh.config.silent = false;
 
     if (testsFiles.length !== 0) {
         console.log("Test project directory already exists, cleaning up...");
-        rm("-rf", "tests");
+        rm("-rf", config.testsDir);
     }
 
     const archivePath = await downloadTestProject(
@@ -31,25 +26,23 @@ export async function setupTestProject() {
     );
 
     try {
-        mkdir("-p", "tests");
-        crossZip.unzipSync(archivePath, "tests");
-        mv("tests/testProjects-*", "tests/testProject");
+        mkdir("-p", config.testsDir);
+        crossZip.unzipSync(archivePath, config.testsDir);
+        mv(config.postUnzipProjectDirGlob, config.testProjectDir);
         rm("-f", archivePath);
 
-        if (ls(`tests/testProject/*.mpr`).length === 0) {
+        if (ls(config.mprFileGlob).length === 0) {
             throw new Error('Invalid test project retrieved from GitHub: "mpr" file is missing.');
         }
-
-        await updateAtlas();
     } catch (e) {
         console.error(e);
-        throw new Error("Failed to unzip the test project into tests/testProject");
+        throw new Error(`Failed to unzip the test project into ${config.testProjectDir}`);
     }
 }
 
 async function downloadTestProject(repository, branch) {
     const tmp = await usetmp();
-    const downloadedArchivePath = join(tmp, `testProject.zip`);
+    const downloadedArchivePath = join(tmp, config.nameForDownloadedArchive);
 
     if (!repository.includes("github.com")) {
         throw new Error("githubUrl is not a valid github repository!");
@@ -66,41 +59,5 @@ async function downloadTestProject(repository, branch) {
     } catch (e) {
         rm("-f", downloadedArchivePath);
         throw new Error("Cannot find test project in GitHub repository. Try again later.");
-    }
-}
-
-async function updateAtlas() {
-    console.log("Copying Atlas files from latest StarterApp");
-    rm(
-        "-rf",
-        "tests/testProject/theme",
-        "tests/testProject/themesource/atlas_ui_resources",
-        "tests/testProject/themesource/atlas_core",
-        "tests/testProject/themesource/atlas_nativemobile_content",
-        "tests/testProject/themesource/atlas_web_content",
-        "tests/testProject/themesource/datawidgets"
-    );
-
-    const releasesResponse = await fetchGithubRestAPI(
-        "https://api.github.com/repos/mendix/StarterApp_Blank/releases/latest"
-    );
-    if (releasesResponse.ok) {
-        const release = await releasesResponse.json();
-        const [{ browser_download_url }] = release.assets;
-        const downloadedPath = join(await usetmp(), `StarterAppRelease.zip`);
-        const outPath = await usetmp();
-        try {
-            await streamPipe((await fetchWithReport(browser_download_url)).body, createWriteStream(downloadedPath));
-            crossZip.unzipSync(downloadedPath, outPath);
-            cp("-r", join(outPath, "theme"), "tests/testProject");
-            cp("-r", join(outPath, "themesource"), "tests/testProject");
-        } catch (e) {
-            throw new Error("Unable to download StarterApp mpk");
-        } finally {
-            rm("-f", downloadedPath);
-            rm("-rf", outPath);
-        }
-    } else {
-        throw new Error("Can't fetch latest StarterApp release");
     }
 }

--- a/automation/run-e2e/lib/update-test-project.mjs
+++ b/automation/run-e2e/lib/update-test-project.mjs
@@ -1,0 +1,87 @@
+import crossZip from "cross-zip";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import { join, resolve } from "node:path";
+import sh from "shelljs";
+import * as config from "./config.mjs";
+import { fetchGithubRestAPI, fetchWithReport, packageMeta, streamPipe, usetmp } from "./utils.mjs";
+
+const { cp, rm, mkdir } = sh;
+
+async function updateAtlas() {
+    console.log("Copying Atlas files from latest StarterApp");
+
+    rm("-rf", config.atlasDirsToRemove);
+
+    const releasesResponse = await fetchGithubRestAPI(config.starterAppLatestReleaseUrl);
+
+    if (releasesResponse.ok) {
+        const release = await releasesResponse.json();
+        const [{ browser_download_url }] = release.assets;
+        const downloadedPath = join(await usetmp(), config.nameForDownloadedStarterApp);
+        const outPath = await usetmp();
+        try {
+            await streamPipe((await fetchWithReport(browser_download_url)).body, createWriteStream(downloadedPath));
+            crossZip.unzipSync(downloadedPath, outPath);
+            cp("-r", join(outPath, "theme"), config.testProjectDir);
+            cp("-r", join(outPath, "themesource"), config.testProjectDir);
+        } catch (e) {
+            throw new Error("Unable to download StarterApp mpk");
+        } finally {
+            rm("-f", downloadedPath);
+            rm("-rf", outPath);
+        }
+    } else {
+        throw new Error("Can't fetch latest StarterApp release");
+    }
+}
+
+async function runReleaseScript() {
+    const { name: packageName, version } = packageMeta;
+    assert.ok(typeof packageName === "string", "missing package.name");
+
+    // Please keep in mind that order of args matters.
+    // Our goal is to run `turbo run --filter <widget>`
+    // as then we can make sure that widget build with dependencies.
+    // But both, pnpm and turbo have `--filter` flag (which may be confusing).
+    // To pass flags to turbo, we pass --filter AFTER command (`release` in our case).
+    // Check https://pnpm.io/cli/run#options for more details.
+    const command = "pnpm";
+    // prettier-ignore
+    const args = [
+        "run",
+        "--workspace-root",
+        "release",
+        `--filter ${packageName}`
+    ];
+
+    spawnSync(command, args, { stdio: "inherit", shell: true });
+
+    console.log("Copying widget mpk.");
+    const mpkPath = `dist/${version}/*.mpk`;
+    const outDir = join(config.testProjectDir, "widgets");
+    mkdir("-p", outDir);
+    cp("-f", mpkPath, outDir);
+}
+
+async function runUpdateProjectScript() {
+    const command = "pnpm";
+    const args = ["run", "e2e-update-project"];
+
+    spawnSync(command, args, { stdio: "inherit", shell: true });
+}
+
+export async function updateTestProject() {
+    console.log("Updating test project files (widgets, themesource, atlas, etc.)");
+
+    await updateAtlas();
+
+    process.env.MX_PROJECT_PATH = resolve(process.cwd(), config.testProjectDir);
+
+    if (packageMeta.scripts["e2e-update-project"]) {
+        await runUpdateProjectScript();
+    } else {
+        await runReleaseScript();
+    }
+}


### PR DESCRIPTION
### Description

Right now, when running e2e tests we downloading test project and then running `release` and then we copying mpk to downloaded test project. This case don't work with `data-widgets` as widgets may depend on changes that were made in datagrid itself. Also, there are might be changes related to styles. So, to bypass this limitation I added new option - `e2e-update-project` hook (script). Now, e2e will check presence of this hook (script) in `package.json` and will execute this hook (script) if hook is present.   

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

<!--- Describe what part of pacakge need to be tested and more important - how -->
