### PR TITLE
Rich text widget- Change openlink key modifier to 0

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
@@ -10,7 +10,8 @@ const PLUGIN_CONFIGS = {
         name: "OpenLink",
         config: {
             openlink_enableReadOnly: true,
-            openlink_target: "_blank"
+            openlink_target: "_blank",
+            openlink_modifier: 0
         }
     },
     codesnippet: {


### PR DESCRIPTION
### Description

Change openlink key modifier to 0, instead of CTRL + click to open a link in the CKeditor. That will keep the open link action consistent with the old widget version.

https://github.com/mlewand/ckeditor-plugin-openlink#configopenlink_modifier

### Pull request checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [ ] PR title properly formatted `[XX-000]: description`
-   [ ] Added record to packages' CHANGELOG.md
-   [ ] Bumped package version in `package.json` and `package.xml`
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

Any link in the CKEditor should open a new tab after you click on it. 
