### PR TITLE
[WC-1626] RichText listen to widget fix

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
@@ -1,80 +1,8 @@
-import { ReactNode, createElement, useCallback } from "react";
-import { RichTextEditor as RichTextComponent } from "./components/RichText";
+import { createElement } from "react";
 import { RichTextContainerProps } from "../typings/RichTextProps";
-import { GroupType, createCustomToolbar, ToolbarItems } from "./utils/ckeditorPresets";
-import { debounce, executeAction } from "@mendix/pluggable-widgets-commons";
-import { getPreset, defineAdvancedGroups } from "./utils/ckeditorConfigs";
-import { CKEditorConfig } from "ckeditor4-react";
-import loadingCircleSvg from "./ui/loading-circle.svg";
 import "./ui/RichText.scss";
+import { RichText as Component } from "./components/RichText";
 
-export default function RichText(props: RichTextContainerProps): ReactNode {
-    const onKeyChange = useCallback(() => executeAction(props.onChange), [props.onChange]);
-    const onKeyPress = useCallback(() => executeAction(props.onKeyPress), [props.onKeyPress]);
-    const onChangeFn = useCallback(
-        debounce((value: string) => props.stringAttribute.setValue(value), 500),
-        [props.stringAttribute]
-    );
-
-    if (props.stringAttribute.status !== "available") {
-        return <img src={loadingCircleSvg} className="widget-rich-text-loading-spinner" alt="" aria-hidden />;
-    }
-
-    const defineToolbar = (): CKEditorConfig => {
-        const { advancedConfig, toolbarConfig, preset } = props;
-        if (preset !== "custom") {
-            return getPreset(preset);
-        } else {
-            const groupKeys = Object.keys(props).filter((key: string) => (key.includes("Group") ? key : null));
-            let groupItems: ToolbarItems[] | string[];
-            if (toolbarConfig === "basic") {
-                groupItems = groupKeys
-                    .filter((groupName: GroupType) => props[groupName])
-                    .map((groupName: GroupType) =>
-                        groupName.includes("separator") ? "/" : groupName.replace("Group", "").toLowerCase()
-                    );
-            } else {
-                groupItems = defineAdvancedGroups(advancedConfig);
-            }
-
-            return createCustomToolbar(groupItems, toolbarConfig === "basic");
-        }
-    };
-    const plugins = ["openlink", "indent", "indentlist"];
-    if (props.codeHighlight) {
-        plugins.push("codesnippet");
-    }
-    return (
-        <RichTextComponent
-            advancedContentFilter={
-                props.advancedContentFilter === "custom"
-                    ? {
-                          allowedContent: props.allowedContent,
-                          disallowedContent: props.disallowedContent
-                      }
-                    : null
-            }
-            sanitizeContent={props.sanitizeContent}
-            name={props.name}
-            editorType={props.editorType}
-            readOnlyStyle={props.readOnlyStyle}
-            readOnly={props.stringAttribute.readOnly}
-            enterMode={props.enterMode}
-            shiftEnterMode={props.shiftEnterMode}
-            spellChecker={props.spellChecker}
-            toolbar={defineToolbar()}
-            plugins={plugins}
-            value={props.stringAttribute.value}
-            onValueChange={onChangeFn}
-            onKeyPress={onKeyPress}
-            onKeyChange={onKeyChange}
-            dimensions={{
-                width: props.width,
-                widthUnit: props.widthUnit,
-                height: props.height,
-                heightUnit: props.heightUnit
-            }}
-            tabIndex={props.tabIndex}
-        />
-    );
+export default function RichText(props: RichTextContainerProps): JSX.Element {
+    return createElement(Component, props);
 }

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<widget id="com.mendix.widget.custom.richtext.RichText" needsEntityContext="true" pluginWidget="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
+<widget id="com.mendix.widget.custom.richtext.RichText" needsEntityContext="true" pluginWidget="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name>Rich Text</name>
     <description>Rich inline or toolbar text editing</description>
     <studioProCategory>Input elements</studioProCategory>

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -1,0 +1,211 @@
+import { debounce } from "@mendix/pluggable-widgets-commons";
+import { CKEditorEventPayload, CKEditorHookProps, CKEditorInstance } from "ckeditor4-react";
+import { Component, createElement } from "react";
+import sanitizeHtml from "sanitize-html";
+import { RichTextContainerProps } from "../../typings/RichTextProps";
+import { getCKEditorConfig } from "../utils/ckeditorConfigs";
+import { MainEditor } from "./MainEditor";
+
+interface EditorProps {
+    element: HTMLElement;
+    widgetProps: RichTextContainerProps;
+}
+
+type EditorHookProps = CKEditorHookProps<never>;
+
+export class Editor extends Component<EditorProps> {
+    widgetProps: RichTextContainerProps;
+    editor: CKEditorInstance | null;
+    editorHookProps: EditorHookProps;
+    editorKey: number;
+    editorScript = "widgets/ckeditor/ckeditor.js";
+    element: HTMLElement;
+    lastSentValue: string | undefined;
+
+    constructor(props: EditorProps) {
+        super(props);
+        // Props are read only, so, make a copy;
+        this.widgetProps = { ...this.props.widgetProps };
+        this.element = this.props.element;
+        this.editorKey = this.getNewKey();
+        this.editorHookProps = this.getNewEditorHookProps();
+        this.onChange = debounce(this.onChange.bind(this), 500);
+        this.onKeyPress = this.onKeyPress.bind(this);
+    }
+
+    setNewRenderProps(): void {
+        this.widgetProps = { ...this.props.widgetProps };
+        this.element = this.props.element;
+        this.editorKey = this.getNewKey();
+        this.editorHookProps = this.getNewEditorHookProps();
+    }
+
+    getRenderProps(): [number, EditorHookProps] {
+        if (this.shouldRebuildEditor()) {
+            this.setNewRenderProps();
+        }
+
+        return [this.editorKey, this.editorHookProps];
+    }
+
+    shouldRebuildEditor(): boolean {
+        const keys = Object.keys(this.widgetProps) as Array<keyof RichTextContainerProps>;
+
+        const prevProps = this.widgetProps;
+        const nextProps = this.props.widgetProps;
+
+        if (this.element !== this.props.element) {
+            return true;
+        }
+
+        return keys.some(key => {
+            // We skip stringAttribute as it always changes. And we
+            // handle updates in componentDidUpdate method.
+            if (key === "stringAttribute") {
+                return false;
+            }
+
+            return prevProps[key] !== nextProps[key];
+        });
+    }
+
+    getNewKey(): number {
+        return Date.now();
+    }
+
+    getEditorUrl(): string {
+        return new URL(this.editorScript, window.mx.remoteUrl).toString();
+    }
+
+    getNewEditorHookProps(): EditorHookProps {
+        const onInstanceReady = this.onInstanceReady.bind(this);
+        const onDestroy = this.onDestroy.bind(this);
+        const config = getCKEditorConfig(this.widgetProps);
+
+        return {
+            element: this.element,
+            editorUrl: this.getEditorUrl(),
+            type: this.widgetProps.editorType,
+            // Here we ignore hook API and instead use
+            // editor instance to subscribe to events.
+            subscribeTo: [],
+            config: Object.assign(config, {
+                on: {
+                    instanceReady(this: CKEditorInstance) {
+                        onInstanceReady(this);
+                    },
+                    destroy: onDestroy
+                }
+            })
+        };
+    }
+
+    onInstanceReady(editor: CKEditorInstance): void {
+        this.editor = editor;
+        this.updateEditorState({
+            data: this.widgetProps.stringAttribute.value
+        });
+    }
+
+    onDestroy(): void {
+        this.editor = null;
+    }
+
+    onKeyPress(): void {
+        this.widgetProps.onKeyPress?.execute();
+    }
+
+    // onChange is wrapped in debounce, so, we always need to check
+    // weather we sill have editor.
+    onChange(_event: CKEditorEventPayload<"change">): void {
+        if (this.editor) {
+            const editorData = this.editor.getData();
+            const content = this.widgetProps.sanitizeContent ? sanitizeHtml(editorData) : editorData;
+            this.lastSentValue = content;
+            this.widgetProps.stringAttribute.setValue(content);
+        }
+
+        this.widgetProps.onChange?.execute();
+    }
+
+    addListeners(): void {
+        if (this.editor && !this.editor.readOnly) {
+            this.editor.on("change", this.onChange);
+            this.editor.on("key", this.onKeyPress);
+        }
+    }
+
+    removeListeners(): void {
+        this.editor?.removeListener("change", this.onChange);
+        this.editor?.removeListener("key", this.onKeyPress);
+    }
+
+    updateEditorState(
+        args: { data: string | undefined; readOnly: boolean } | { data: string | undefined } | { readOnly: boolean }
+    ): void {
+        this.removeListeners();
+
+        if ("readOnly" in args) {
+            this.editor.setReadOnly(args.readOnly);
+        }
+
+        // The trick is that when setting new data,
+        // we need to await till data become "ready" and
+        // only then attach listeners. Otherwise onChange will
+        // be called whenever we call setData, which is not what we want.
+        // So, to solve this, we pass callback, which is called
+        // when data is "read".
+        // If we just update readOnly state, then we can
+        // call addListeners immediately.
+        // https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-setData
+        if ("data" in args) {
+            this.editor?.setData(args.data, () => this.addListeners());
+        } else {
+            this.addListeners();
+        }
+    }
+
+    updateEditor(
+        prevAttr: RichTextContainerProps["stringAttribute"],
+        nextAttr: RichTextContainerProps["stringAttribute"]
+    ): void {
+        if (this.editor) {
+            const shouldUpdateData = nextAttr.value !== prevAttr.value && nextAttr.value !== this.lastSentValue;
+
+            const shouldUpdateReadOnly = this.editor.readOnly !== nextAttr.readOnly;
+
+            if (shouldUpdateData && shouldUpdateReadOnly) {
+                this.updateEditorState({
+                    data: nextAttr.value,
+                    readOnly: nextAttr.readOnly
+                });
+            } else if (shouldUpdateData) {
+                this.updateEditorState({
+                    data: nextAttr.value
+                });
+            } else if (shouldUpdateReadOnly) {
+                this.updateEditorState({
+                    readOnly: nextAttr.readOnly
+                });
+            }
+        }
+
+        this.lastSentValue = undefined;
+    }
+
+    componentDidUpdate(): void {
+        const prevAttr = this.widgetProps.stringAttribute;
+        const nextAttr = this.props.widgetProps.stringAttribute;
+
+        if (prevAttr !== nextAttr) {
+            this.widgetProps.stringAttribute = nextAttr;
+            this.updateEditor(prevAttr, nextAttr);
+        }
+    }
+
+    render(): JSX.Element | null {
+        const [key, config] = this.getRenderProps();
+
+        return <MainEditor key={key} config={config} />;
+    }
+}

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -1,10 +1,10 @@
 import { debounce } from "@mendix/pluggable-widgets-commons";
 import { CKEditorEventPayload, CKEditorHookProps, CKEditorInstance } from "ckeditor4-react";
 import { Component, createElement } from "react";
-import sanitizeHtml from "sanitize-html";
 import { RichTextContainerProps } from "../../typings/RichTextProps";
 import { getCKEditorConfig } from "../utils/ckeditorConfigs";
 import { MainEditor } from "./MainEditor";
+import DOMPurify from "dompurify";
 
 interface EditorProps {
     element: HTMLElement;
@@ -120,7 +120,7 @@ export class Editor extends Component<EditorProps> {
     onChange(_event: CKEditorEventPayload<"change">): void {
         if (this.editor) {
             const editorData = this.editor.getData();
-            const content = this.widgetProps.sanitizeContent ? sanitizeHtml(editorData) : editorData;
+            const content = this.widgetProps.sanitizeContent ? DOMPurify.sanitize(editorData) : editorData;
             this.lastSentValue = content;
             this.widgetProps.stringAttribute.setValue(content);
         }

--- a/packages/pluggableWidgets/rich-text-web/src/components/MainEditor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/MainEditor.tsx
@@ -1,24 +1,17 @@
-import { useCKEditor, CKEditorHookProps, CKEditorInstance } from "ckeditor4-react";
+import { memo } from "react";
+import { useCKEditor, CKEditorHookProps } from "ckeditor4-react";
 
-export interface MainEditoProps {
-    config: CKEditorHookProps<string>;
-    editorRef?: (editor: CKEditorInstance | null) => void;
+export interface MainEditorProps {
+    config: CKEditorHookProps<never>;
 }
-export const MainEditor = ({ config, editorRef }: MainEditoProps): null => {
-    Object.assign(config.config, {
-        on: {
-            instanceReady() {
-                if (editorRef) {
-                    editorRef(this);
-                }
-            },
-            destroy() {
-                if (editorRef) {
-                    editorRef(null);
-                }
-            }
-        }
-    });
-    useCKEditor(config);
-    return null;
-};
+
+// Main idea of this component is to make sure it's never rerenders.
+// This is why we pass function that always returns true.
+export const MainEditor = memo(
+    // eslint-disable-next-line prefer-arrow-callback
+    function MainEditor({ config }: MainEditorProps): null {
+        useCKEditor(config);
+        return null;
+    },
+    () => true
+);

--- a/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
@@ -1,153 +1,35 @@
-import { createElement, ReactElement, useState, useEffect, useMemo, useRef, useCallback } from "react";
-import {
-    CKEditorHookProps,
-    CKEditorType,
-    CKEditorConfig,
-    CKEditorEventAction,
-    CKEditorInstance
-} from "ckeditor4-react";
-import { getDimensions, Dimensions } from "@mendix/pluggable-widgets-commons";
-import { defineEnterMode, addPlugin, PluginName } from "../utils/ckeditorConfigs";
-import DOMPurify from "dompurify";
+import { createElement, useState } from "react";
+import { getDimensions } from "@mendix/pluggable-widgets-commons";
+import { RichTextContainerProps } from "../../typings/RichTextProps";
+import loadingCircleSvg from "../ui/loading-circle.svg";
 import classNames from "classnames";
-import { ReadOnlyStyleEnum, EnterModeEnum, ShiftEnterModeEnum } from "../../typings/RichTextProps";
-import { MainEditor } from "./MainEditor";
+import { Editor } from "./Editor";
 
-export interface RichTextProps {
-    name: string;
-    readOnly: boolean;
-    spellChecker: boolean;
-    sanitizeContent?: boolean;
-    value: string | undefined;
-    plugins?: string[];
-    readOnlyStyle: ReadOnlyStyleEnum;
-    toolbar: CKEditorConfig;
-    enterMode?: EnterModeEnum;
-    shiftEnterMode?: ShiftEnterModeEnum;
-    editorType: CKEditorType;
-    dimensions?: Dimensions;
-    advancedContentFilter?: { allowedContent: string; disallowedContent: string } | null;
-    onValueChange?: (value: string) => void;
-    onKeyChange?: () => void;
-    onKeyPress?: () => void;
-    tabIndex: number | undefined;
-}
-
-export const RichTextEditor = ({
-    name,
-    readOnly,
-    spellChecker,
-    sanitizeContent,
-    value,
-    plugins,
-    readOnlyStyle,
-    toolbar,
-    enterMode,
-    shiftEnterMode,
-    editorType,
-    dimensions,
-    advancedContentFilter,
-    onValueChange,
-    onKeyChange,
-    onKeyPress,
-    tabIndex
-}: RichTextProps): ReactElement => {
+export function RichText(props: RichTextContainerProps): JSX.Element | null {
+    const { width: w, height: h, widthUnit, heightUnit, readOnlyStyle, name, id } = props;
     const [element, setElement] = useState<HTMLElement | null>(null);
-    const localEditorValueRef = useRef("");
-    const editorInstanceRef = useRef<null | CKEditorInstance>(null);
-    const editorRefCallback = useCallback(
-        (editor: null | CKEditorInstance) => (editorInstanceRef.current = editor),
-        []
-    );
-    const { width, height } = dimensions
-        ? getDimensions({ ...dimensions })
-        : {
-              width: "100%",
-              height: "100%"
-          };
 
-    const dispatchEvent = ({ type, payload }: { type: string; payload: any }): void => {
-        if (type === CKEditorEventAction.key) {
-            if (onKeyPress) {
-                onKeyPress();
-            }
-        }
-        if (type === CKEditorEventAction.change) {
-            const value = payload.editor.getData();
-            if (onKeyChange) {
-                onKeyChange();
-            }
-            if (onValueChange) {
-                const content = sanitizeContent ? DOMPurify.sanitize(value) : value;
-                localEditorValueRef.current = content;
-                onValueChange(content);
-            }
-        }
-    };
+    if (props.stringAttribute.status !== "available") {
+        return <img src={loadingCircleSvg} className="widget-rich-text-loading-spinner" alt="" aria-hidden />;
+    }
 
-    const [ckeditorConfig, setCkeditorConfig] = useState<CKEditorHookProps<"change" | "key">>({
-        element,
-        editorUrl: `${window.mx.remoteUrl}widgets/ckeditor/ckeditor.js`,
-        type: editorType,
-        config: {
-            autoGrow_minHeight: 300,
-            toolbarCanCollapse: true,
-            autoGrow_onStartup: true,
-            width,
-            height,
-            tabIndex,
-            enterMode: defineEnterMode(enterMode || ""),
-            shiftEnterMode: defineEnterMode(shiftEnterMode || ""),
-            disableNativeSpellChecker: !spellChecker,
-            readOnly,
-            removeButtons: ""
-        },
-        initContent: value,
-        dispatchEvent,
-        subscribeTo: ["change", "key"]
+    const { width, height } = getDimensions({
+        width: w,
+        widthUnit,
+        height: h,
+        heightUnit
     });
 
-    const key = useMemo(() => Date.now(), [ckeditorConfig]);
-    useEffect(() => {
-        const config = { ...toolbar };
-        if (plugins?.length) {
-            plugins.forEach((plugin: PluginName) => addPlugin(plugin, config));
-        }
-        if (advancedContentFilter) {
-            config.extraAllowedContent = advancedContentFilter.allowedContent;
-            config.disallowedContent = advancedContentFilter.disallowedContent;
-        }
-
-        setCkeditorConfig({
-            ...ckeditorConfig,
-            initContent: value,
-            element,
-            dispatchEvent,
-            config: {
-                ...ckeditorConfig.config,
-                ...config,
-                readOnly
-            }
-        });
-    }, [element, readOnly]);
-
-    useEffect(() => {
-        const editor = editorInstanceRef.current;
-        if (editor) {
-            if (localEditorValueRef.current !== value) {
-                editor.setData(value);
-                localEditorValueRef.current = value ?? "";
-            }
-        }
-    }, [value]);
+    const readOnly = props.stringAttribute.readOnly;
 
     return (
         <div
+            id={id}
             className={classNames("widget-rich-text", `${readOnly ? `editor-${readOnlyStyle}` : ""}`)}
             style={{ width, height }}
         >
             <div ref={setElement} id={name} />
-            <MainEditor key={key} config={ckeditorConfig} editorRef={editorRefCallback} />
+            {element ? <Editor element={element} widgetProps={props} /> : null}
         </div>
     );
-};
+}

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/__snapshots__/RichText.spec.tsx.snap
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/__snapshots__/RichText.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`RichText render DOM structure 1`] = `
 <div
   className="widget-rich-text"
+  id="1.Dev.Test_ListenTo.richText1_x_1"
   style={
     Object {
       "height": "auto",

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
@@ -175,13 +175,8 @@ export function getCKEditorConfig(widgetProps: RichTextContainerProps): CKEditor
     }
 
     if (advancedContentFilter === "custom") {
-        if (allowedContent) {
-            config.allowedContent = allowedContent;
-        }
-
-        if (disallowedContent) {
-            config.disallowedContent = disallowedContent;
-        }
+        config.extraAllowedContent = allowedContent;
+        config.disallowedContent = disallowedContent;
     }
 
     return config;


### PR DESCRIPTION
### Description

This is rewrite of `RichText.tsx`. I decided to switch to `React.Component` because it better suites prop update strategy in this case (only stringAttribute). Using `componentDidUpdate` in combination with event listeners management I was able to achieve good result. Now we can sync state with attribute, focus stays same and we don't override new passed attributes.

### Pull request checklist

-   [x] All new and existing tests passed
-   [x] I run `lint` command locally and it doesn’t give errors
-   [x] PR title properly formatted `[XX-000]: description`
-   [ ] Added record to packages' CHANGELOG.md (TODO)
-   [ ] Bumped package version in `package.json` and `package.xml` (TODO)
-   [ ] Added a link to related project PRs (atlas, pluggable-widgets-tools, testProject, etc.) (optional)
-   [ ] Created docs PR to [mendix/docs](https://github.com/mendix/docs.git) and added a link (optional)

### Pull request type

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

- Rich text widget. It's default behavior and in combination with ListView.
