### PR TITLE
ci: stop triggering Renovate action when pr is labeled

### DIFF
--- a/.github/workflows/Renovate.yml
+++ b/.github/workflows/Renovate.yml
@@ -3,11 +3,6 @@ name: Renovate
 on:
   workflow_dispatch:
 
-  # run workflow when PR labeled
-  # renovate will rebase PR when "renovate-rebase" label is added
-  pull_request:
-    types: [labeled]
-
   schedule:
     # At minute 0 past hour 8, 14, and 20 on every day-of-week from Monday through Friday.
     - cron: '0 8,14,20 * * 1-5'


### PR DESCRIPTION
### Description

Stop triggering renovate workflow when PR is labeled. It worked few times, but now it doesn't work, so it's better to disable it. We still can trigger workflow manually if we need to rebase some branches.

### Pull request type

-   [x] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)
