### PR TITLE
[WC-1621]: Rich Text image upload performance drop

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Added 1MB file size limit for pasted and dropped images.
+
 ## [2.1.2] - 2023-01-25
 
 ### Fixed

--- a/packages/pluggableWidgets/rich-text-web/package.json
+++ b/packages/pluggableWidgets/rich-text-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rich-text-web",
   "widgetName": "RichText",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Rich inline or toolbar text editing",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -6,6 +6,8 @@ import { getCKEditorConfig } from "../utils/ckeditorConfigs";
 import { MainEditor } from "./MainEditor";
 import DOMPurify from "dompurify";
 
+const FILE_SIZE_LIMIT = 1000000;
+
 interface EditorProps {
     element: HTMLElement;
     widgetProps: RichTextContainerProps;
@@ -131,9 +133,7 @@ export class Editor extends Component<EditorProps> {
     onPasteContent(event: CKEditorEvent): void {
         if (event.data.dataTransfer.isFileTransfer()) {
             for (let i = 0; i < event.data.dataTransfer.getFilesCount(); i++) {
-                console.log("paste", event.data.dataTransfer.getFile(i));
-
-                if (event.data.dataTransfer.getFile(i).size > 1000000) {
+                if (event.data.dataTransfer.getFile(i).size > FILE_SIZE_LIMIT) {
                     this.editor.showNotification(
                         `The image ${
                             event.data.dataTransfer.getFile(i).name
@@ -149,8 +149,7 @@ export class Editor extends Component<EditorProps> {
     onDropContent(event: CKEditorEvent): void {
         if (event.data.dataTransfer.isFileTransfer()) {
             for (let i = 0; i < event.data.dataTransfer.getFilesCount(); i++) {
-                console.log("drop", event.data.dataTransfer.getFile(i));
-                if (event.data.dataTransfer.getFile(i).size > 1000000) {
+                if (event.data.dataTransfer.getFile(i).size > FILE_SIZE_LIMIT) {
                     this.editor.showNotification(
                         `The image ${
                             event.data.dataTransfer.getFile(i).name
@@ -189,6 +188,8 @@ export class Editor extends Component<EditorProps> {
     removeListeners(): void {
         this.editor?.removeListener("change", this.onChange);
         this.editor?.removeListener("key", this.onKeyPress);
+        this.editor?.removeListener("paste", this.onPasteContent);
+        this.editor?.removeListener("drop", this.onDropContent);
     }
 
     updateEditorState(

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -6,7 +6,7 @@ import { getCKEditorConfig } from "../utils/ckeditorConfigs";
 import { MainEditor } from "./MainEditor";
 import DOMPurify from "dompurify";
 
-const FILE_SIZE_LIMIT = 1000000;
+const FILE_SIZE_LIMIT = 1048576; // Binary bytes for 1MB
 
 interface EditorProps {
     element: HTMLElement;

--- a/packages/pluggableWidgets/rich-text-web/src/package.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="RichText" version="2.1.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="RichText" version="2.1.3" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="RichText.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Description
Added a file size limit for pasting or dropping images, user is warned with a notification if the selected image(s) is exceeding the limit.

<!--- Describe your changes in detail -->

### Pull request checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] All new and existing tests passed
-   [X] I run `lint` command locally and it doesn’t give errors
-   [X] PR title properly formatted `[XX-000]: description`
-   [X] Added record to packages' CHANGELOG.md
-   [X] Bumped package version in `package.json` and `package.xml`

### Pull request type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] No code changes (changes to documentation, CI, metadata, etc)
-   [ ] Dependency changes (any modification to dependencies in `package.json`)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Test related change (New E2E test, test automation, etc.)

### What should be covered while testing?

<!--- Describe what part of pacakge need to be tested and more important - how -->
Try pasting and dropping images in the editor in different file sizes, also can be tested with text and other pasteable/droppable items since they also go through same events (we have an image-or-not control there, but still).