### PR TITLE
feat(rich-text-web): make content templates for RichText widget (CKEditor 4) customizable

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [2.2.0] - 2023-02-27
+
+### Added
+
+-   Enabled customization of CKEditor 4 content template plugin.
+
 ## [2.1.3] - 2023-01-31
 
 ### Fixed

--- a/packages/pluggableWidgets/rich-text-web/package.json
+++ b/packages/pluggableWidgets/rich-text-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rich-text-web",
   "widgetName": "RichText",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Rich inline or toolbar text editing",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
@@ -38,11 +38,39 @@ export function getProperties(
     if (values.preset !== "custom") {
         hidePropertiesIn(defaultProperties, values, toolbarGroups.concat(["toolbarConfig", "advancedConfig"]));
     }
+    if (values.preset === "basic" || values.preset === "standard") {
+        hidePropertiesIn(defaultProperties, values, [
+            "templates",
+            "templateDatasource",
+            "templateTitleAttribute",
+            "templateImageAttribute",
+            "templateDescriptionAttribute",
+            "templateHtmlAttribute"
+        ]);
+    }
     if (values.toolbarConfig === "basic") {
-        hidePropertiesIn(defaultProperties, values, ["advancedConfig"]);
+        hidePropertiesIn(defaultProperties, values, [
+            "advancedConfig",
+            "templates",
+            "templateDatasource",
+            "templateTitleAttribute",
+            "templateImageAttribute",
+            "templateDescriptionAttribute",
+            "templateHtmlAttribute"
+        ]);
     }
     if (values.toolbarConfig === "advanced") {
         hidePropertiesIn(defaultProperties, values, toolbarGroups);
+        if (values.advancedConfig.filter(e => e.ctItemType === "Templates").length < 1) {
+            hidePropertiesIn(defaultProperties, values, [
+                "templates",
+                "templateDatasource",
+                "templateTitleAttribute",
+                "templateImageAttribute",
+                "templateDescriptionAttribute",
+                "templateHtmlAttribute"
+            ]);
+        }
     }
     if (values.advancedContentFilter === "auto") {
         hidePropertiesIn(defaultProperties, values, ["allowedContent", "disallowedContent"]);

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.xml
@@ -251,28 +251,28 @@
             </property>
             <property key="templateTitleAttribute" type="attribute" required="true" dataSource="templateDatasource">
                 <caption>Title attribute</caption>
-                <description>The title of the current content template.</description>
+                <description>The name of the title attribute of the current content template.</description>
                 <attributeTypes>
                     <attributeType name="String" />
                 </attributeTypes>
             </property>
             <property key="templateImageAttribute" type="attribute" required="true" dataSource="templateDatasource">
                 <caption>Image attribute</caption>
-                <description>The image of the current content template.</description>
+                <description>The name of the image attribute of the current content template. The datasource must deliver the attribute value in the form {module_name}${image_collection}${image_name}.{image_format}.</description>
                 <attributeTypes>
                     <attributeType name="String" />
                 </attributeTypes>
             </property>
             <property key="templateDescriptionAttribute" type="attribute" required="true" dataSource="templateDatasource">
                 <caption>Description attribute</caption>
-                <description>The description of the current content template.</description>
+                <description>The name of the description attribute of the current content template.</description>
                 <attributeTypes>
                     <attributeType name="String" />
                 </attributeTypes>
             </property>
             <property key="templateHtmlAttribute" type="attribute" required="true" dataSource="templateDatasource">
                 <caption>HTML attribute</caption>
-                <description>The HTML of the current content template.</description>
+                <description>The name of the HTML attribute of the current content template.</description>
                 <attributeTypes>
                     <attributeType name="String" />
                 </attributeTypes>

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.xml
@@ -240,6 +240,44 @@
                 </property>
             </propertyGroup>
         </propertyGroup>
+        <propertyGroup caption="Content templates">
+            <property key="templates" type="string" defaultValue="default">
+                <caption>Template name</caption>
+                <description>Name of the template to be used. Default is 'default'.</description>
+            </property>
+            <property key="templateDatasource" type="datasource" isList="true">
+                <caption>Template source</caption>
+                <description>The datasource providing a list of actual content templates for the rich text editor.</description>
+            </property>
+            <property key="templateTitleAttribute" type="attribute" required="true" dataSource="templateDatasource">
+                <caption>Title attribute</caption>
+                <description>The title of the current content template.</description>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+            </property>
+            <property key="templateImageAttribute" type="attribute" required="true" dataSource="templateDatasource">
+                <caption>Image attribute</caption>
+                <description>The image of the current content template.</description>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+            </property>
+            <property key="templateDescriptionAttribute" type="attribute" required="true" dataSource="templateDatasource">
+                <caption>Description attribute</caption>
+                <description>The description of the current content template.</description>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+            </property>
+            <property key="templateHtmlAttribute" type="attribute" required="true" dataSource="templateDatasource">
+                <caption>HTML attribute</caption>
+                <description>The HTML of the current content template.</description>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+            </property>
+        </propertyGroup>
         <propertyGroup caption="Events">
             <propertyGroup caption="Events">
                 <property key="onKeyPress" type="action">

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -194,7 +194,7 @@ export class Editor extends Component<EditorProps> {
             }
             var CKEDITOR: CKEditorNamespace = this.namespace;
             CKEDITOR.addTemplates(this.widgetProps.templates, {
-                imagesPath: CKEDITOR.getUrl(CKEDITOR.plugins.getPath("templates") + "templates/images/"),
+                imagesPath: window.location.origin + "/img/",
                 templates: contentTemplates
             });
             console.info("Templates added for editor " + this.widgetProps.name);

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -34,12 +34,12 @@ interface CKEditorEvent {
 }
 
 class ContentTemplate {
-    title: String;
-    image: String;
-    description: String;
-    html: String;
+    title: string;
+    image: string;
+    description: string;
+    html: string;
 
-    constructor(title: String, image: String, description: String, html: String) {
+    constructor(title: string, image: string, description: string, html: string) {
         this.title = title;
         this.image = image;
         this.description = description;
@@ -167,7 +167,7 @@ export class Editor extends Component<EditorProps> {
             const contentTemplates: ContentTemplate[] = [];
             const mxObjects = datasource.items;
             if (mxObjects) {
-                mxObjects.map(mxObject => {
+                mxObjects.forEach(mxObject => {
                     const contentTemplate: ContentTemplate = new ContentTemplate(
                         this.widgetProps.templateTitleAttribute.get(mxObject).value || "<title>",
                         this.widgetProps.templateImageAttribute.get(mxObject).value || "<description>",
@@ -177,7 +177,7 @@ export class Editor extends Component<EditorProps> {
                     contentTemplates.push(contentTemplate);
                 });
             }
-            var CKEDITOR: CKEditorNamespace = this.namespace;
+            const CKEDITOR: CKEditorNamespace = this.namespace;
             CKEDITOR.addTemplates(this.widgetProps.templates, {
                 imagesPath: window.location.origin + "/img/",
                 templates: contentTemplates

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -61,7 +61,6 @@ export class Editor extends Component<EditorProps> {
         super(props);
 
         // Props are read only, so, make a copy;
-        console.info("Constructing new editor");
         this.widgetProps = { ...this.props.widgetProps };
         this.element = this.props.element;
         this.editorKey = this.getNewKey();
@@ -70,11 +69,9 @@ export class Editor extends Component<EditorProps> {
         this.onKeyPress = this.onKeyPress.bind(this);
         this.onPasteContent = this.onPasteContent.bind(this);
         this.onDropContent = this.onDropContent.bind(this);
-        console.info("New editor constructed");
     }
 
     setNewRenderProps(updatePlugins: boolean): void {
-        console.info("Setting new render props");
         this.widgetProps = { ...this.props.widgetProps };
         if (updatePlugins) {
             this.element = this.props.element;
@@ -94,7 +91,6 @@ export class Editor extends Component<EditorProps> {
 
     shouldRebuildEditor(): boolean {
         if (this.element !== this.props.element) {
-            console.info("Element has changed.");
             return true;
         } else {
             return false;
@@ -112,7 +108,6 @@ export class Editor extends Component<EditorProps> {
                 return false;
             }
             if (prevProps[key] !== nextProps[key]) {
-                console.info("Property " + key + " has changed.");
                 return true;
             } else {
                 return false;
@@ -129,7 +124,6 @@ export class Editor extends Component<EditorProps> {
     }
 
     getNewEditorHookProps(updatePlugins: boolean): EditorHookProps {
-        console.info("Getting new EditorHookProps");
         const onInstanceReady = this.onInstanceReady.bind(this);
         const onPluginsLoaded = this.onPluginsLoaded.bind(this);
         const onDestroy = this.onDestroy.bind(this);
@@ -141,9 +135,7 @@ export class Editor extends Component<EditorProps> {
             type: this.widgetProps.editorType,
             dispatchEvent: ({ type, payload }) => {
                 if (type === CKEditorEventAction.beforeLoad) {
-                    console.info("Before load invoked for editor " + this.widgetProps.name);
                     this.namespace = payload;
-                    console.info("Namespace stored in editor " + this.widgetProps.name);
                 }
             },
             // Here we ignore hook API and instead use
@@ -162,23 +154,19 @@ export class Editor extends Component<EditorProps> {
 
     onInstanceReady(editor: CKEditorInstance): void {
         this.editor = editor;
-        console.info("Instance ready for editor " + this.widgetProps.name);
         this.updateEditorState({
             data: this.widgetProps.stringAttribute.value
         });
     }
 
     onPluginsLoaded(): void {
-        console.info("Plugins loaded for editor " + this.widgetProps.name);
         const datasource = this.widgetProps.templateDatasource;
         if (datasource === undefined) {
             console.warn("Templates datasource not set for editor " + this.widgetProps.name);
         } else if (datasource.status === ValueStatus.Available) {
-            console.info("Templates are available for editor " + this.widgetProps.name);
             const contentTemplates: ContentTemplate[] = [];
             const mxObjects = datasource.items;
             if (mxObjects) {
-                console.info("MxObjects exist");
                 mxObjects.map(mxObject => {
                     const contentTemplate: ContentTemplate = new ContentTemplate(
                         this.widgetProps.templateTitleAttribute.get(mxObject).value || "<title>",
@@ -187,23 +175,13 @@ export class Editor extends Component<EditorProps> {
                         this.widgetProps.templateHtmlAttribute.get(mxObject).value || "[html]"
                     );
                     contentTemplates.push(contentTemplate);
-                    console.info("Found " + JSON.stringify(contentTemplate));
                 });
-            } else {
-                console.info("MxObjects are empty for editor " + this.widgetProps.name);
             }
             var CKEDITOR: CKEditorNamespace = this.namespace;
             CKEDITOR.addTemplates(this.widgetProps.templates, {
                 imagesPath: window.location.origin + "/img/",
                 templates: contentTemplates
             });
-            console.info("Templates added for editor " + this.widgetProps.name);
-        } else if (datasource.status === ValueStatus.Loading) {
-            console.warn("Templates are still loading for editor " + this.widgetProps.name);
-        } else if (datasource.status === ValueStatus.Unavailable) {
-            console.warn("Templates are not available for editor " + this.widgetProps.name);
-        } else {
-            console.error("Template status unknown for editor " + this.widgetProps.name);
         }
     }
 
@@ -280,7 +258,6 @@ export class Editor extends Component<EditorProps> {
     updateEditorState(
         args: { data: string | undefined; readOnly: boolean } | { data: string | undefined } | { readOnly: boolean }
     ): void {
-        console.info("Updating editor state");
         this.removeListeners();
 
         if ("readOnly" in args) {
@@ -301,14 +278,12 @@ export class Editor extends Component<EditorProps> {
         } else {
             this.addListeners();
         }
-        console.info("Editor state updated");
     }
 
     updateEditor(
         prevAttr: RichTextContainerProps["stringAttribute"],
         nextAttr: RichTextContainerProps["stringAttribute"]
     ): void {
-        console.info("Updating editor");
         if (this.editor) {
             const shouldUpdateData = nextAttr.value !== prevAttr.value && nextAttr.value !== this.lastSentValue;
 
@@ -331,11 +306,9 @@ export class Editor extends Component<EditorProps> {
         }
 
         this.lastSentValue = undefined;
-        console.info("Editor updated");
     }
 
     componentDidUpdate(): void {
-        console.info("Update component");
         const prevAttr = this.widgetProps.stringAttribute;
         const nextAttr = this.props.widgetProps.stringAttribute;
 
@@ -343,7 +316,6 @@ export class Editor extends Component<EditorProps> {
             this.widgetProps.stringAttribute = nextAttr;
             this.updateEditor(prevAttr, nextAttr);
         }
-        console.info("Component updated");
     }
 
     render(): JSX.Element | null {

--- a/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
@@ -9,7 +9,11 @@ export function RichText(props: RichTextContainerProps): JSX.Element | null {
     const { width: w, height: h, widthUnit, heightUnit, readOnlyStyle, name, id } = props;
     const [element, setElement] = useState<HTMLElement | null>(null);
 
-    if (props.stringAttribute.status !== "available") {
+    // Also wait for templateDatasource available to avoid editor-element-conflict exception
+    if (
+        props.stringAttribute.status !== "available" ||
+        (props.templateDatasource && props.templateDatasource.status !== "available")
+    ) {
         return <img src={loadingCircleSvg} className="widget-rich-text-loading-spinner" alt="" aria-hidden />;
     }
 

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
@@ -5,7 +5,7 @@ import { CKEditorConfig } from "ckeditor4-react";
 import { getPreset, defineEnterMode, getToolbarGroupByName, defineAdvancedGroups } from "../../utils/ckeditorConfigs";
 import { mount, ReactWrapper } from "enzyme";
 import renderer from "react-test-renderer";
-import { getDimensions, EditableValueBuilder } from "@mendix/pluggable-widgets-commons";
+import { getDimensions, EditableValueBuilder, ListValueBuilder } from "@mendix/pluggable-widgets-commons";
 import { TOOLBAR_GROUP, ToolbarGroup } from "../../utils/ckeditorPresets";
 import { AdvancedConfigType, RichTextContainerProps } from "../../../typings/RichTextProps";
 
@@ -44,7 +44,9 @@ const defaultRichTextProps: RichTextContainerProps = {
     codeHighlight: false,
     allowedContent: "",
     disallowedContent: "",
-    id: "1.Dev.Test_ListenTo.richText1_x_1"
+    id: "1.Dev.Test_ListenTo.richText1_x_1",
+    templates: "default",
+    templateDatasource: ListValueBuilder().simple()
 };
 
 describe("RichText", () => {

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
@@ -5,7 +5,12 @@ import { CKEditorConfig } from "ckeditor4-react";
 import { getPreset, defineEnterMode, getToolbarGroupByName, defineAdvancedGroups } from "../../utils/ckeditorConfigs";
 import { mount, ReactWrapper } from "enzyme";
 import renderer from "react-test-renderer";
-import { getDimensions, EditableValueBuilder, ListValueBuilder } from "@mendix/pluggable-widgets-commons";
+import {
+    getDimensions,
+    EditableValueBuilder,
+    ListValueBuilder,
+    ListAttributeValueBuilder
+} from "@mendix/pluggable-widgets-commons";
 import { TOOLBAR_GROUP, ToolbarGroup } from "../../utils/ckeditorPresets";
 import { AdvancedConfigType, RichTextContainerProps } from "../../../typings/RichTextProps";
 
@@ -46,7 +51,11 @@ const defaultRichTextProps: RichTextContainerProps = {
     disallowedContent: "",
     id: "1.Dev.Test_ListenTo.richText1_x_1",
     templates: "default",
-    templateDatasource: ListValueBuilder().simple()
+    templateDatasource: ListValueBuilder().simple(),
+    templateTitleAttribute: new ListAttributeValueBuilder<string>().build(),
+    templateImageAttribute: new ListAttributeValueBuilder<string>().build(),
+    templateDescriptionAttribute: new ListAttributeValueBuilder<string>().build(),
+    templateHtmlAttribute: new ListAttributeValueBuilder<string>().build()
 };
 
 describe("RichText", () => {

--- a/packages/pluggableWidgets/rich-text-web/src/package.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="RichText" version="2.1.3" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="RichText" version="2.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="RichText.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/rich-text-web/src/ui/RichText.scss
+++ b/packages/pluggableWidgets/rich-text-web/src/ui/RichText.scss
@@ -10,6 +10,7 @@
 @use "~ckeditor4/plugins/emoji/skins/default.css" as emoji;
 @use "~ckeditor4/plugins/preview/styles/screen.css";
 @use "~ckeditor4/plugins/copyformatting/styles/copyformatting.css";
+@use "~ckeditor4/plugins/templates/dialogs/templates.css";
 
 .widget-rich-text {
     &.editor-text {

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
@@ -75,7 +75,6 @@ export function addPlugin(name: PluginName, config: CKEditorConfig): CKEditorCon
         } else {
             config.extraPlugins = plugin.extraPlugins;
         }
-        console.info("extraPlugins: " + config.extraPlugins);
         Object.assign(config, plugin.config);
     }
     return config;
@@ -120,7 +119,6 @@ export function defineAdvancedGroups(widgetProps: RichTextContainerProps): Toolb
 export function getToolbarConfig(widgetProps: RichTextContainerProps, updatePlugins: boolean): CKEditorConfig {
     const { preset, toolbarConfig, templates } = widgetProps;
 
-    console.info("Invoking getToolbarConfig");
     if (preset !== "custom") {
         return getPreset(preset, templates, updatePlugins);
     }

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
@@ -50,11 +50,7 @@ export function defineEnterMode(type: string): number {
     }
 }
 
-export function getPreset(
-    type: PresetEnum,
-    templates: string = "default",
-    updatePlgugins: boolean = false
-): CKEditorConfig {
+export function getPreset(type: PresetEnum, templates = "default", updatePlgugins = false): CKEditorConfig {
     switch (type) {
         case "standard":
             return createPreset("standard");

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
@@ -84,7 +84,11 @@ const TOOLBAR_ITEMS: ToolbarItems[] = [
     { name: "about", items: ["About"] }
 ];
 
-function createPreset(type: "basic" | "standard" | "full"): CKEditorConfig {
+function createPreset(
+    type: "basic" | "standard" | "full",
+    templates: string = "default",
+    updatePlugins: boolean = false
+): CKEditorConfig {
     const config: CKEditorConfig = {};
     let toolbarGroup: Array<ToolbarGroup | string> = [];
     switch (type) {
@@ -107,9 +111,13 @@ function createPreset(type: "basic" | "standard" | "full"): CKEditorConfig {
             toolbarGroup.splice(6, 0, "/");
             config.toolbarGroups = toolbarGroup;
             config.removeButtons = "";
+            console.info("Setting extraPlugins for full toolbar");
             /* TODO temporary removed exportpdf*/
-            config.extraPlugins =
-                "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks";
+            if (updatePlugins) {
+                config.extraPlugins =
+                    "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks";
+            }
+            config.templates = templates;
             break;
         default:
             config.toolbarGroups = [...TOOLBAR_GROUP];
@@ -117,7 +125,12 @@ function createPreset(type: "basic" | "standard" | "full"): CKEditorConfig {
     return config;
 }
 
-function createCustomToolbar(groups: Array<string | ToolbarItems>, withGroupNames = true): CKEditorConfig {
+function createCustomToolbar(
+    groups: Array<string | ToolbarItems>,
+    withGroupNames = true,
+    templates: string = "default",
+    updatePlugins: boolean = false
+): CKEditorConfig {
     if (withGroupNames) {
         return {
             toolbar: groups
@@ -127,11 +140,20 @@ function createCustomToolbar(groups: Array<string | ToolbarItems>, withGroupName
                 .filter(item => item)
         };
     } else {
-        return {
-            extraPlugins:
-                "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks,smiley",
-            toolbar: groups
-        };
+        console.info("Setting extraPlugins for custom toolbar");
+        if (updatePlugins) {
+            return {
+                extraPlugins:
+                    "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks,smiley",
+                toolbar: groups,
+                templates: templates
+            };
+        } else {
+            return {
+                toolbar: groups,
+                templates: templates
+            };
+        }
     }
 }
 

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
@@ -86,8 +86,8 @@ const TOOLBAR_ITEMS: ToolbarItems[] = [
 
 function createPreset(
     type: "basic" | "standard" | "full",
-    templates: string = "default",
-    updatePlugins: boolean = false
+    templates = "default",
+    updatePlugins = false
 ): CKEditorConfig {
     const config: CKEditorConfig = {};
     let toolbarGroup: Array<ToolbarGroup | string> = [];
@@ -127,8 +127,8 @@ function createPreset(
 function createCustomToolbar(
     groups: Array<string | ToolbarItems>,
     withGroupNames = true,
-    templates: string = "default",
-    updatePlugins: boolean = false
+    templates = "default",
+    updatePlugins = false
 ): CKEditorConfig {
     if (withGroupNames) {
         return {
@@ -144,12 +144,12 @@ function createCustomToolbar(
                 extraPlugins:
                     "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks,smiley",
                 toolbar: groups,
-                templates: templates
+                templates
             };
         } else {
             return {
                 toolbar: groups,
-                templates: templates
+                templates
             };
         }
     }

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
@@ -111,7 +111,6 @@ function createPreset(
             toolbarGroup.splice(6, 0, "/");
             config.toolbarGroups = toolbarGroup;
             config.removeButtons = "";
-            console.info("Setting extraPlugins for full toolbar");
             /* TODO temporary removed exportpdf*/
             if (updatePlugins) {
                 config.extraPlugins =
@@ -140,7 +139,6 @@ function createCustomToolbar(
                 .filter(item => item)
         };
     } else {
-        console.info("Setting extraPlugins for custom toolbar");
         if (updatePlugins) {
             return {
                 extraPlugins:

--- a/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
+++ b/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
@@ -3,7 +3,7 @@
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix Widgets Framework Team
  */
-import { ActionValue, EditableValue } from "mendix";
+import { ActionValue, EditableValue, ListValue, ListAttributeValue } from "mendix";
 
 export type EditorTypeEnum = "classic" | "inline";
 
@@ -64,6 +64,12 @@ export interface RichTextContainerProps {
     toolsGroup: boolean;
     othersGroup: boolean;
     advancedConfig: AdvancedConfigType[];
+    templates: string;
+    templateDatasource: ListValue;
+    templateTitleAttribute: ListAttributeValue<string>;
+    templateImageAttribute: ListAttributeValue<string>;
+    templateDescriptionAttribute: ListAttributeValue<string>;
+    templateHtmlAttribute: ListAttributeValue<string>;
     onKeyPress?: ActionValue;
     onChange?: ActionValue;
     enterMode: EnterModeEnum;
@@ -102,6 +108,12 @@ export interface RichTextPreviewProps {
     toolsGroup: boolean;
     othersGroup: boolean;
     advancedConfig: AdvancedConfigPreviewType[];
+    templates: string;
+    templateDatasource: {} | { type: string } | null;
+    templateTitleAttribute: string;
+    templateImageAttribute: string;
+    templateDescriptionAttribute: string;
+    templateHtmlAttribute: string;
     onKeyPress: {} | null;
     onChange: {} | null;
     enterMode: EnterModeEnum;


### PR DESCRIPTION
### **Pull request type**

New feature (non-breaking change which adds functionality)

### **Description**

The Rich Text widget is built around the latest version of CKEditor 4. It already contains the content template plugin, if a "full" toolbar is chosen, or a "custom" tool bar with the "Templates" button configured in the "advanced toolbar groups". However, only the the default templates contained in CKEditor can be used, which is not very useful.

This change allows to configure a new template datasource to provide a list of custom content templates per widget instance 
(https://ckeditor.com/docs/ckeditor4/latest/examples/templates.html). Each content template has for attributes "title", "image", "description" and "html". The image attribute needs to be set in the form {module}${image_collection}${image_name}.{image_format} to access an image from the designated image collection.

Projects that already use the RichText widget, will have to update their widgets, because the XML file has been extended. However, configuring the new properties is optional unless you really want to use the content template feature.

### What should be covered while testing?

The following aspects should be tested:
- RichText widgets with toolbar = "basic" and toolbar = "standard" as well as toolbar = "custom"  and toolbar group = "basic" should work as before. Even if toolbar group is set to "advanced", the new properties should only matter if the "Templates" button is explicitly added to the toolbar.
- RIchText widgets with toolbar = "full" or toolbar = "custom" and toolbar group = "advanced" and the button "Templates" added to the toolbar, have to configure the six attributes. However, sensible defaults have been defined, and if the template name is set to "default" the default content templates from CKEditor should be available as before.
- As opposed to CKEditor, the widget supports only one template name per editor instance. Typically, the template name should match the widget name.
- Any kind of datasource with four columns of type string should be usable as template source, be it database, association, nanoflow, microflow or XPath. 
- Images from an image collection should be used if referred to correctly. No image should be shown otherwise.
