### PR TITLE
[WC-1759]: fix id clash for widgets with the same name

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with Rich Text widget not working correctly when another Rich Text widget is opened in a popup.
+
 ## [2.1.3] - 2023-01-31
 
 ### Fixed

--- a/packages/pluggableWidgets/rich-text-web/package.json
+++ b/packages/pluggableWidgets/rich-text-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rich-text-web",
   "widgetName": "RichText",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Rich inline or toolbar text editing",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
@@ -6,7 +6,7 @@ import classNames from "classnames";
 import { Editor } from "./Editor";
 
 export function RichText(props: RichTextContainerProps): JSX.Element | null {
-    const { width: w, height: h, widthUnit, heightUnit, readOnlyStyle, name, id } = props;
+    const { width: w, height: h, widthUnit, heightUnit, readOnlyStyle, id } = props;
     const [element, setElement] = useState<HTMLElement | null>(null);
 
     if (props.stringAttribute.status !== "available") {
@@ -28,7 +28,7 @@ export function RichText(props: RichTextContainerProps): JSX.Element | null {
             className={classNames("widget-rich-text", `${readOnly ? `editor-${readOnlyStyle}` : ""}`)}
             style={{ width, height }}
         >
-            <div ref={setElement} id={name} />
+            <div ref={setElement} />
             {element ? <Editor element={element} widgetProps={props} /> : null}
         </div>
     );

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/__snapshots__/RichText.spec.tsx.snap
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/__snapshots__/RichText.spec.tsx.snap
@@ -11,8 +11,6 @@ exports[`RichText render DOM structure 1`] = `
     }
   }
 >
-  <div
-    id="RichText_Div"
-  />
+  <div />
 </div>
 `;

--- a/packages/pluggableWidgets/rich-text-web/src/package.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="RichText" version="2.1.3" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="RichText" version="2.1.4" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="RichText.xml" />
         </widgetFiles>


### PR DESCRIPTION


### Pull request type

Bug fix (non-breaking change which fixes an issue)
<!---->


---



### Description

Fix issue with two widget with the same name putting same ID in the document.
