### PR TITLE
[WC-1763]: barcode scanner improvements

### DIFF
--- a/packages/pluggableWidgets/barcode-scanner-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/barcode-scanner-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with 1D barcode scanning, now 1D barcodes recognition is improved when using the mask (#180937)
+
 ## [2.2.3] - 2023-01-04
 
 ### Changed

--- a/packages/pluggableWidgets/barcode-scanner-web/package.json
+++ b/packages/pluggableWidgets/barcode-scanner-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "barcode-scanner-web",
   "widgetName": "BarcodeScanner",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Displays a barcode scanner",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.tsx
@@ -13,13 +13,15 @@ export const BarcodeScanner: FunctionComponent<BarcodeScannerContainerProps> = p
             if (data !== props.datasource.value) {
                 props.datasource.setValue(data);
             }
-            executeAction(props.onDetect);
+            if (props.onDetect?.canExecute) {
+                executeAction(props.onDetect);
+            }
         },
         [props.onDetect, props.datasource]
     );
     return (
         <BarcodeScannerComponent
-            onDetect={props.onDetect ? onDetect : undefined}
+            onDetect={onDetect}
             showMask={props.showMask}
             class={props.class}
             heightUnit={props.heightUnit}

--- a/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.tsx
@@ -13,9 +13,7 @@ export const BarcodeScanner: FunctionComponent<BarcodeScannerContainerProps> = p
             if (data !== props.datasource.value) {
                 props.datasource.setValue(data);
             }
-            if (props.onDetect?.canExecute) {
-                executeAction(props.onDetect);
-            }
+            executeAction(props.onDetect);
         },
         [props.onDetect, props.datasource]
     );

--- a/packages/pluggableWidgets/barcode-scanner-web/src/components/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/components/BarcodeScanner.tsx
@@ -57,7 +57,11 @@ export function BarcodeScanner({
     ...dimensions
 }: BarcodeScannerProps): ReactElement | null {
     const [errorMessage, setError] = useCustomErrorMessage();
-    const videoRef = useReader({ onSuccess: onDetect, onError: setError, showMask });
+    const videoRef = useReader({
+        onSuccess: onDetect,
+        onError: setError,
+        showMask
+    });
     const supportsCameraAccess = typeof navigator?.mediaDevices?.getUserMedia === "function";
     const onCanPlay = useCallback((event: SyntheticEvent<HTMLVideoElement>) => {
         if (event.currentTarget.paused) {

--- a/packages/pluggableWidgets/barcode-scanner-web/src/components/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/components/BarcodeScanner.tsx
@@ -57,7 +57,7 @@ export function BarcodeScanner({
     ...dimensions
 }: BarcodeScannerProps): ReactElement | null {
     const [errorMessage, setError] = useCustomErrorMessage();
-    const videoRef = useReader({ onSuccess: onDetect, onError: setError });
+    const videoRef = useReader({ onSuccess: onDetect, onError: setError, showMask });
     const supportsCameraAccess = typeof navigator?.mediaDevices?.getUserMedia === "function";
     const onCanPlay = useCallback((event: SyntheticEvent<HTMLVideoElement>) => {
         if (event.currentTarget.paused) {

--- a/packages/pluggableWidgets/barcode-scanner-web/src/components/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/components/BarcodeScanner.tsx
@@ -60,7 +60,7 @@ export function BarcodeScanner({
     const videoRef = useReader({
         onSuccess: onDetect,
         onError: setError,
-        showMask
+        useCrop: showMask
     });
     const supportsCameraAccess = typeof navigator?.mediaDevices?.getUserMedia === "function";
     const onCanPlay = useCallback((event: SyntheticEvent<HTMLVideoElement>) => {

--- a/packages/pluggableWidgets/barcode-scanner-web/src/hooks/useReader.ts
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/hooks/useReader.ts
@@ -95,6 +95,7 @@ export const useReader: UseReaderHook = args => {
                     if (args.showMask) {
                         videoRef.current!.srcObject = stream;
                         videoRef.current!.autofocus = true;
+                        videoRef.current.playsInline = true; // Fix error in Safari
                         await videoRef.current.play();
                         const captureCanvas = reader.createCaptureCanvas(videoRef.current!);
                         captureCanvas.width = videoRef.current!.videoWidth;

--- a/packages/pluggableWidgets/barcode-scanner-web/src/hooks/useReader.ts
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/hooks/useReader.ts
@@ -39,8 +39,7 @@ export const useReader: UseReaderHook = args => {
     const videoRef = useRef<HTMLVideoElement>(null);
     const onSuccess = useEventCallback(args.onSuccess);
     const onError = useEventCallback(args.onError);
-    const scale = 0.5;
-
+    const scale = 0.3;
     const scanWithCropOnce = (reader: BrowserMultiFormatReader, canvas: HTMLCanvasElement): Promise<Result> => {
         const loop: any = (resolve: (value?: Result) => void, reject: (reason?: any) => void) => {
             try {
@@ -48,8 +47,8 @@ export const useReader: UseReaderHook = args => {
                 if (canvasContext !== null) {
                     canvasContext.drawImage(
                         videoRef.current!,
-                        (videoRef.current!.videoWidth - videoRef.current!.videoWidth * scale) / 2,
-                        (videoRef.current!.videoHeight - videoRef.current!.videoHeight * scale) / 2,
+                        (videoRef.current!.videoWidth * (1 - scale)) / 2,
+                        (videoRef.current!.videoHeight * (1 - scale)) / 2,
                         videoRef.current!.videoWidth * scale,
                         videoRef.current!.videoHeight * scale,
                         0,
@@ -93,13 +92,13 @@ export const useReader: UseReaderHook = args => {
                 reader.timeBetweenDecodingAttempts = 500;
                 if (!stopped && videoRef.current) {
                     if (args.showMask) {
-                        videoRef.current!.srcObject = stream;
-                        videoRef.current!.autofocus = true;
+                        videoRef.current.srcObject = stream;
+                        videoRef.current.autofocus = true;
                         videoRef.current.playsInline = true; // Fix error in Safari
                         await videoRef.current.play();
                         const captureCanvas = reader.createCaptureCanvas(videoRef.current!);
-                        captureCanvas.width = videoRef.current!.videoWidth;
-                        captureCanvas.height = videoRef.current!.videoHeight;
+                        captureCanvas.width = videoRef.current.videoWidth * scale;
+                        captureCanvas.height = videoRef.current.videoHeight * scale;
                         const result = await scanWithCropOnce(reader, captureCanvas);
                         onSuccess(result.getText());
                     } else {

--- a/packages/pluggableWidgets/barcode-scanner-web/src/hooks/useReader.ts
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/hooks/useReader.ts
@@ -48,17 +48,16 @@ export const useReader: UseReaderHook = args => {
                     canvasContext.drawImage(
                         videoRef.current!,
                         (videoRef.current!.videoWidth * (1 - scale)) / 2,
-                        (videoRef.current!.videoHeight * (1 - scale)) / 2,
+                        (videoRef.current!.videoHeight - videoRef.current!.videoWidth * scale) / 2,
                         videoRef.current!.videoWidth * scale,
-                        videoRef.current!.videoHeight * scale,
+                        videoRef.current!.videoWidth * scale,
                         0,
                         0,
                         canvas.width,
-                        canvas.height
+                        canvas.width
                     );
                     const luminanceSource = new HTMLCanvasElementLuminanceSource(canvas);
                     const binaryBitmap = new BinaryBitmap(new HybridBinarizer(luminanceSource));
-                    reader.hints = hints;
                     const result = reader.decodeBitmap(binaryBitmap);
                     resolve(result);
                 }
@@ -98,7 +97,7 @@ export const useReader: UseReaderHook = args => {
                         await videoRef.current.play();
                         const captureCanvas = reader.createCaptureCanvas(videoRef.current!);
                         captureCanvas.width = videoRef.current.videoWidth * scale;
-                        captureCanvas.height = videoRef.current.videoHeight * scale;
+                        captureCanvas.height = videoRef.current.videoWidth * scale;
                         const result = await scanWithCropOnce(reader, captureCanvas);
                         onSuccess(result.getText());
                     } else {

--- a/packages/pluggableWidgets/barcode-scanner-web/src/package.xml
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Barcode Scanner" version="2.2.3" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Barcode Scanner" version="2.2.4" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="BarcodeScanner.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
@@ -43,7 +43,6 @@
             .canvas-middle {
                 flex: 0;
                 flex-basis: 30%;
-                border: 1px solid blue;
                 display: flex;
                 flex-direction: column;
 
@@ -55,7 +54,6 @@
                     flex: 0;
                     padding-top: 100%;
                     position: relative;
-                    border: 1px solid red;
                     $corner-offset: 13px;
                     .corner {
                         position: absolute;

--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
@@ -33,7 +33,8 @@
             }
 
             .canvas-left {
-                flex: 1;
+                flex: 0;
+                flex-basis: 35%;
             }
 
             $screen-md: 768px;
@@ -41,16 +42,8 @@
             $screen-xl: 1200px;
             .canvas-middle {
                 flex: 0;
-                flex-basis: 60%;
-                @media screen and (min-width: $screen-md) {
-                    flex-basis: 50%;
-                }
-                @media screen and (min-width: $screen-lg) {
-                    flex-basis: 40%;
-                }
-                @media screen and (min-width: $screen-xl) {
-                    flex-basis: 30%;
-                }
+                flex-basis: 30%;
+                border: 1px solid blue;
                 display: flex;
                 flex-direction: column;
 
@@ -62,7 +55,7 @@
                     flex: 0;
                     padding-top: 100%;
                     position: relative;
-
+                    border: 1px solid red;
                     $corner-offset: 13px;
                     .corner {
                         position: absolute;
@@ -101,7 +94,8 @@
             }
 
             .canvas-right {
-                flex: 1;
+                flex: 0;
+                flex-basis: 35%;
             }
         }
     }

--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
@@ -34,7 +34,7 @@
 
             .canvas-left {
                 flex: 0;
-                flex-basis: 35%;
+                flex-basis: 30%;
             }
 
             $screen-md: 768px;
@@ -42,7 +42,7 @@
             $screen-xl: 1200px;
             .canvas-middle {
                 flex: 0;
-                flex-basis: 30%;
+                flex-basis: 40%;
                 display: flex;
                 flex-direction: column;
 
@@ -93,7 +93,7 @@
 
             .canvas-right {
                 flex: 0;
-                flex-basis: 35%;
+                flex-basis: 30%;
             }
         }
     }


### PR DESCRIPTION
### Pull request type
Bug fix (non-breaking change which fixes an issue)

---

### Description
- Adds a different scan method when the mask is enabled, this should only scan part of the screen instead of all. This improves scan accuracy for 1 dimensional codes in particular. 
- Changes implementation of Detect callback to always fire, since a datasource will always be attached but an event is not required. This causes the barcode scanner to 'fail' silently when first using it and having a datasource connected but no event set. 

---

### What should be covered while testing?
- Non masked version of the widget should have no changes from current implementation (apart from Detect callback change), but the masked option should now have improved accuracy for 1 dimensional codes. 
