### PR TITLE
[WC-1776]: don't re-render on onChange or onKeyPress prop change

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue when Rich Text widget loosing focus after running onChange or onKeyPress microflow.
+
 ## [2.1.4] - 2023-03-22
 
 ### Fixed

--- a/packages/pluggableWidgets/rich-text-web/package.json
+++ b/packages/pluggableWidgets/rich-text-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rich-text-web",
   "widgetName": "RichText",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Rich inline or toolbar text editing",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -80,6 +80,14 @@ export class Editor extends Component<EditorProps> {
                 return false;
             }
 
+            if (key === "onChange") {
+                return false;
+            }
+
+            if (key === "onKeyPress") {
+                return false;
+            }
+
             return prevProps[key] !== nextProps[key];
         });
     }

--- a/packages/pluggableWidgets/rich-text-web/src/package.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="RichText" version="2.1.4" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="RichText" version="2.1.5" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="RichText.xml" />
         </widgetFiles>


### PR DESCRIPTION


### Pull request type

Bug fix (non-breaking change which fixes an issue)
<!---->

---

### Description

Don't re-init the editor when event props as onChange and onKeyPress change in props.