### PR TITLE
[WC-1605]: group chart items where grouping value is not reachable as '(empty)'

### DIFF
--- a/packages/pluggableWidgets/charts-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/charts-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   Before, if some items in a series for a chart were missing an association value, the chart might not display properly. However, this issue has been resolved. Now, if an item in the series is missing an association value, it will be grouped under a new label called "(empty)".
+
 ## [4.0.3] Charts - 2023-01-09
 
 ### Changed

--- a/packages/pluggableWidgets/charts-web/package.json
+++ b/packages/pluggableWidgets/charts-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "charts-web",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Chart widgets collection for data visualization",
   "license": "Apache-2.0",
   "private": false,

--- a/packages/pluggableWidgets/charts-web/src/package.xml
+++ b/packages/pluggableWidgets/charts-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Charts" version="4.0.3" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Charts" version="4.0.4" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="AreaChart/AreaChart.xml" />
             <widgetFile path="BarChart/BarChart.xml" />

--- a/packages/shared/charts/package.json
+++ b/packages/shared/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/shared-charts",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Shared components for charts",
   "private": true,
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",


### PR DESCRIPTION

### Pull request type


Bug fix (non-breaking change which fixes an issue)
and
New feature (non-breaking change which adds functionality)

---

### Description
Previously, when some items had no data for grouping the chart was never displayed, this change introduces new `(empty)` group for those items and groups those items.

### What should be covered while testing?

Charts display data in the situation while it wasn't previously.
