### PR TITLE
[WC-1349]: fix: scrolling on datagrid 2

### DIFF
--- a/packages/shared/pluggable-widgets-commons/src/components/web/InfiniteBody.tsx
+++ b/packages/shared/pluggable-widgets-commons/src/components/web/InfiniteBody.tsx
@@ -28,8 +28,11 @@ export function InfiniteBody(props: PropsWithChildren<InfiniteBodyProps>): React
         e => {
             /**
              * In Windows OS the result of first expression returns a non integer and result in never loading more, require floor to solve.
+             * note: Math floor sometimes result in incorrect integer value,
+             * causing mismatch by 1 pixel point, thus, add magic number 2 as buffer.
              */
-            const bottom = Math.floor(e.target.scrollHeight - e.target.scrollTop) === Math.floor(e.target.clientHeight);
+            const bottom =
+                Math.floor(e.target.scrollHeight - e.target.scrollTop) <= Math.floor(e.target.clientHeight) + 2;
             if (bottom) {
                 if (hasMoreItems && setPage) {
                     setPage(prev => prev + 1);


### PR DESCRIPTION
Bug fix:
scrolling in Datagrid 2.

the issue occurs due to Math.Floor issue having problems with rounded integer, which could cause discrepancy in boolean comparison such as `2 === 1`
which resulting in fetch new page not triggered.

linked ticket: https://mendixsupport.zendesk.com/agent/tickets/167627

