### PR TITLE
[WC-1897] allowing multiple "config" commands in Google Tag

### DIFF
--- a/packages/modules/google-tag/package.json
+++ b/packages/modules/google-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/google-tag",
   "moduleName": "Google Tag module",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/modules/google-tag/src/javascriptsource/googletagmodule/actions/GoogleTagAction.js
+++ b/packages/modules/google-tag/src/javascriptsource/googletagmodule/actions/GoogleTagAction.js
@@ -60,8 +60,8 @@ export async function GoogleTagAction(command, tagID, eventName, parameters) {
 
 	switch (cmd) {
         case "config": {
-            document.mxGtag.ensureGtagIncluded(tagId);
-            document.mxGtag.getGtag()(cmd, tagId, params);
+            document.mxGtag.ensureGtagIncluded(tagID);
+            document.mxGtag.getGtag()(cmd, tagID, params);
             break;
         }
         case "event": {

--- a/packages/modules/google-tag/src/javascriptsource/googletagmodule/actions/GoogleTagAction.js
+++ b/packages/modules/google-tag/src/javascriptsource/googletagmodule/actions/GoogleTagAction.js
@@ -5,6 +5,7 @@
 // - the code between BEGIN USER CODE and END USER CODE
 // - the code between BEGIN EXTRA CODE and END EXTRA CODE
 // Other code you write will be lost the next time you deploy the project.
+import "mx-global";
 import { Big } from "big.js";
 
 // BEGIN EXTRA CODE
@@ -41,7 +42,7 @@ if (document.mxGtag === undefined) {
 // END EXTRA CODE
 
 /**
- * @param {"GoogleTagModule.GoogleTagCommandType.Config"|"GoogleTagModule.GoogleTagCommandType.Event"} command - Event can be used to send an event. Config can be used to configure advanced configuration parameters and can only be used once.
+ * @param {"GoogleTagModule.GoogleTagCommandType.Config"|"GoogleTagModule.GoogleTagCommandType.Event"} command - Event can be used to send an event. Config can be used to configure advanced configuration parameters.
  * @param {string} tagID - Examples of tag IDs include GT-XXXXXXXXX, G-XXXXXXXXX, and AW-XXXXXXXXX
  * @param {string} eventName
  * @param {MxObject[]} parameters
@@ -55,8 +56,6 @@ export async function GoogleTagAction(command, tagID, eventName, parameters) {
 		return a; 
 	}, {});
 	const cmd = command.split(".").pop().toLowerCase();
-
-	console.log(cmd, params);
 
 	switch (cmd) {
         case "config": {

--- a/packages/pluggableWidgets/google-tag-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/google-tag-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   It is now possible to configure additional tags via "config" command in Advanced mode.
+
 ## [1.1.0] - 2023-06-05
 
 ### Changed

--- a/packages/pluggableWidgets/google-tag-web/package.json
+++ b/packages/pluggableWidgets/google-tag-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/google-tag-web",
   "widgetName": "GoogleTag",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "gtag.js integration widget",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/google-tag-web/src/GoogleTag.xml
+++ b/packages/pluggableWidgets/google-tag-web/src/GoogleTag.xml
@@ -64,7 +64,7 @@
             <!-- Advanced config options -->
             <property key="command" type="enumeration" required="true" defaultValue="event">
                 <caption>Command</caption>
-                <description>Event can be used to send an event. Config can be used to configure advanced configuration parameters and can only be used once.</description>
+                <description>Event can be used to send an event. Config can be used to configure advanced configuration parameters.</description>
                 <enumerationValues>
                     <enumerationValue key="event">Event</enumerationValue>
                     <enumerationValue key="config">Config</enumerationValue>

--- a/packages/pluggableWidgets/google-tag-web/src/package.xml
+++ b/packages/pluggableWidgets/google-tag-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="GoogleTag" version="1.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="GoogleTag" version="1.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="GoogleTag.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/google-tag-web/src/utils.ts
+++ b/packages/pluggableWidgets/google-tag-web/src/utils.ts
@@ -59,9 +59,8 @@ export function executeCommand(
 ): void {
     switch (command) {
         case "config": {
-            if (commonGtag!.ensureGtagIncluded(tagId)) {
-                commonGtag!.getGtag()(command, tagId, params);
-            }
+            commonGtag!.ensureGtagIncluded(tagId);
+            commonGtag!.getGtag()(command, tagId, params);
             break;
         }
         case "event": {


### PR DESCRIPTION
### Pull request type

New feature (non-breaking change which adds functionality)
<!---->

---

### Description

Don't suppress sub-sequential "config" commands in the widget.