### PR TITLE
[WC-1914]: Fix tabIndex image-web

### DIFF
--- a/packages/pluggableWidgets/image-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/image-web/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+-   We fixed an issue with tabIndex being ignored.
+
 ## [1.4.0] - 2023-06-05
 
 ### Changed

--- a/packages/pluggableWidgets/image-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/image-web/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
 -   We fixed an issue with tabIndex being ignored.
 
 ## [1.4.0] - 2023-06-05

--- a/packages/pluggableWidgets/image-web/package.json
+++ b/packages/pluggableWidgets/image-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/image-web",
   "widgetName": "Image",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Display an image and enlarge it on click",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/image-web/src/Image.tsx
+++ b/packages/pluggableWidgets/image-web/src/Image.tsx
@@ -69,6 +69,7 @@ export const Image: FunctionComponent<ImageContainerProps> = props => {
             width={props.width}
             heightUnit={props.heightUnit}
             height={props.height}
+            tabIndex={props.tabIndex}
             iconSize={props.iconSize}
             responsive={props.responsive}
             onClickType={props.onClickType}

--- a/packages/pluggableWidgets/image-web/src/components/Image/Image.tsx
+++ b/packages/pluggableWidgets/image-web/src/components/Image/Image.tsx
@@ -19,6 +19,7 @@ export interface ImageProps extends ImageType {
     width: number;
     heightUnit: HeightUnitEnum;
     height: number;
+    tabIndex?: number;
     iconSize: number;
     responsive: boolean;
     onClickType: OnClickTypeEnum;
@@ -46,6 +47,7 @@ export const Image: FunctionComponent<ImageProps> = ({
     width,
     heightUnit,
     height,
+    tabIndex,
     iconSize,
     responsive,
     onClickType,
@@ -83,6 +85,7 @@ export const Image: FunctionComponent<ImageProps> = ({
     const hasClickHandler = (onClickType === "action" && onClick) || onClickType === "enlarge";
     const sharedContentProps: ImageContentProps = {
         style,
+        tabIndex: tabIndex ?? 0,
         onClick: hasClickHandler ? onImageClick : undefined,
         altText
     };

--- a/packages/pluggableWidgets/image-web/src/components/Image/ui.tsx
+++ b/packages/pluggableWidgets/image-web/src/components/Image/ui.tsx
@@ -26,6 +26,7 @@ export interface ImageWrapperProps {
 
 export interface ImageContentProps {
     style?: CSSProperties;
+    tabIndex?: number;
     onClick?: ReactEventHandler<HTMLElement>;
     altText?: string;
 }
@@ -65,6 +66,7 @@ function ContentIcon(props: ImageContentIcon): ReactElement {
         <span
             className={classNames(props.icon, { glyphicon: props.isGlyph })}
             style={{ ...props.style, fontSize: `${props.size}px` }}
+            tabIndex={props.tabIndex ?? 0}
             {...accessibilityProps}
             {...onClickProps}
         />
@@ -86,6 +88,7 @@ function ContentImage(props: ImageContentImage): ReactElement {
         <img
             className={props.className}
             src={props.image}
+            tabIndex={props.tabIndex ?? 0}
             style={{
                 ...props.style,
                 height: getStyle(props.height, props.heightUnit),
@@ -104,7 +107,6 @@ function getImageContentOnClickProps(onClick: ImageContentProps["onClick"]): HTM
     return {
         onClick,
         role: "button",
-        tabIndex: 0,
         onKeyDown: event => {
             if (event.key === "Enter" || event.key === " ") {
                 onClick(event);

--- a/packages/pluggableWidgets/image-web/src/package.xml
+++ b/packages/pluggableWidgets/image-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Image" version="1.4.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Image" version="1.4.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Image.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Pull request type
Bug fix (non-breaking change which fixes an issue)

---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description

Adding the tabindex as a value to both ContentIcon and ContentImage, the change was not applied to BackgroundImage since that shouldn't have to be able to be tabbed to. Previously this was always set to 0.

### What should be covered while testing?
There's a test project available which indicated the issue, with the new version of the widget, this should tab over the images correctly. By using `Image type` 
- Image -> Background image No
- Icon 
- Image -> Background image Yes

This should cover the scenario's, we're expecting the first two to be effected by the tab order, but not the last one. 