### PR TITLE
fix: mx-icon not displayed properly

### DIFF
--- a/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   fix atlas icon not displaying properly
+-   We fix atlas icon not displaying properly
 
 ## [1.1.1] - 2023-05-26
 

--- a/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   fix atlas icon not displaying properly
+
 ## [1.1.1] - 2023-05-26
 
 ### Changed

--- a/packages/pluggableWidgets/tree-node-web/jest.config.js
+++ b/packages/pluggableWidgets/tree-node-web/jest.config.js
@@ -1,0 +1,10 @@
+const { join } = require("path");
+const base = require("@mendix/pluggable-widgets-tools/test-config/jest.config");
+
+module.exports = {
+    ...base,
+    moduleNameMapper: {
+        ...base.moduleNameMapper,
+        "mendix/components/web/Icon": join(__dirname, "src/__mocks__/WebIcon")
+    }
+};

--- a/packages/pluggableWidgets/tree-node-web/package.json
+++ b/packages/pluggableWidgets/tree-node-web/package.json
@@ -31,7 +31,7 @@
     "build": "pluggable-widgets-tools build:web",
     "format": "prettier --write .",
     "lint": "eslint --ext .jsx,.js,.ts,.tsx src/ cypress/",
-    "test": "pluggable-widgets-tools test:unit:web",
+    "test": "jest --projects jest.config.js",
     "release": "pluggable-widgets-tools release:web",
     "verify": "rui-verify-package-format",
     "update-changelog": "rui-update-changelog-widget",

--- a/packages/pluggableWidgets/tree-node-web/package.json
+++ b/packages/pluggableWidgets/tree-node-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/tree-node-web",
   "widgetName": "TreeNode",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A Mendix pluggable widget to display a tree view structure.",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.tsx
@@ -18,8 +18,8 @@ export function TreeNode(props: TreeNodeContainerProps): ReactElement {
             ? props.datasource.items?.map(item => mapDataSourceItemToTreeNodeObject(item, props)) ?? []
             : null;
 
-    const expandedIcon = props.expandedIcon?.status === ValueStatus.Available ? props.expandedIcon.value : null;
-    const collapsedIcon = props.collapsedIcon?.status === ValueStatus.Available ? props.collapsedIcon.value : null;
+    const expandedIcon = props.expandedIcon?.status === ValueStatus.Available ? props.expandedIcon.value : undefined;
+    const collapsedIcon = props.collapsedIcon?.status === ValueStatus.Available ? props.collapsedIcon.value : undefined;
 
     return (
         <TreeNodeComponent

--- a/packages/pluggableWidgets/tree-node-web/src/__mocks__/WebIcon.js
+++ b/packages/pluggableWidgets/tree-node-web/src/__mocks__/WebIcon.js
@@ -1,0 +1,18 @@
+const { createElement } = require("react");
+
+module.exports = {
+    Icon: ({ icon }) => {
+        if (icon && icon.type) {
+            if (icon?.type === "glyph") {
+                return createElement("span", { className: "glyphicon " + icon?.iconClass });
+            }
+            if (icon?.type === "image") {
+                console.log(icon.iconUrl, "iconUrl");
+                return createElement("img", { src: icon.iconUrl });
+            }
+            if (icon?.type === "icon") {
+                return createElement("span", { className: icon?.iconClass });
+            }
+        }
+    }
+};

--- a/packages/pluggableWidgets/tree-node-web/src/components/Icons.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/components/Icons.tsx
@@ -19,9 +19,7 @@ export const ChevronIcon = ({ className }: { className: string }): ReactElement 
 export const CustomHeaderIcon = ({ icon }: { icon: WebIcon }): ReactElement => {
     let currentIcon = icon;
     if (icon && icon.type !== "image") {
-        currentIcon = Object.assign({}, icon, {
-            iconClass: classNames(icon.iconClass, "widget-tree-node-branch-header-icon")
-        });
+        currentIcon = { ...icon, iconClass: classNames(icon.iconClass, "widget-tree-node-branch-header-icon") };
     }
     return <Icon icon={currentIcon} />;
 };

--- a/packages/pluggableWidgets/tree-node-web/src/components/Icons.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/components/Icons.tsx
@@ -1,4 +1,7 @@
 import { createElement, ReactElement } from "react";
+import { WebIcon } from "mendix";
+import classNames from "classnames";
+import { Icon } from "mendix/components/web/Icon";
 
 export const ChevronIcon = ({ className }: { className: string }): ReactElement => (
     <svg
@@ -12,3 +15,13 @@ export const ChevronIcon = ({ className }: { className: string }): ReactElement 
         <path d="M1.64598 4.64601C1.69242 4.59945 1.7476 4.5625 1.80834 4.5373C1.86909 4.51209 1.93421 4.49911 1.99998 4.49911C2.06575 4.49911 2.13087 4.51209 2.19161 4.5373C2.25236 4.5625 2.30753 4.59945 2.35398 4.64601L7.99998 10.293L13.646 4.64601C13.6925 4.59952 13.7477 4.56264 13.8084 4.53749C13.8691 4.51233 13.9342 4.49938 14 4.49938C14.0657 4.49938 14.1308 4.51233 14.1916 4.53749C14.2523 4.56264 14.3075 4.59952 14.354 4.64601C14.4005 4.6925 14.4373 4.74769 14.4625 4.80842C14.4877 4.86916 14.5006 4.93426 14.5006 5.00001C14.5006 5.06575 14.4877 5.13085 14.4625 5.19159C14.4373 5.25233 14.4005 5.30752 14.354 5.35401L8.35398 11.354C8.30753 11.4006 8.25236 11.4375 8.19161 11.4627C8.13087 11.4879 8.06575 11.5009 7.99998 11.5009C7.93421 11.5009 7.86909 11.4879 7.80834 11.4627C7.7476 11.4375 7.69242 11.4006 7.64598 11.354L1.64598 5.35401C1.59942 5.30756 1.56247 5.25239 1.53727 5.19164C1.51206 5.1309 1.49908 5.06578 1.49908 5.00001C1.49908 4.93424 1.51206 4.86912 1.53727 4.80837C1.56247 4.74763 1.59942 4.69245 1.64598 4.64601V4.64601Z" />
     </svg>
 );
+
+export const CustomHeaderIcon = ({ icon }: { icon: WebIcon }): ReactElement => {
+    let currentIcon = icon;
+    if (icon && icon.type !== "image") {
+        currentIcon = Object.assign({}, icon, {
+            iconClass: classNames(icon.iconClass, "widget-tree-node-branch-header-icon")
+        });
+    }
+    return <Icon icon={currentIcon} />;
+};

--- a/packages/pluggableWidgets/tree-node-web/src/components/TreeNode.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/components/TreeNode.tsx
@@ -15,7 +15,6 @@ import {
     useState
 } from "react";
 import classNames from "classnames";
-import { Icon } from "mendix/components/web/Icon";
 import { ShowIconEnum, TreeNodeContainerProps } from "../../typings/TreeNodeProps";
 import {
     TreeNodeBranchContextProps,
@@ -29,7 +28,7 @@ import {
     useTreeNodeBranchKeyboardHandler,
     useTreeNodeFocusChangeHandler
 } from "./hooks/TreeNodeAccessibility";
-import { ChevronIcon } from "./ChevronIcon";
+import { ChevronIcon, CustomHeaderIcon } from "./Icons";
 import { useTreeNodeLazyLoading } from "./hooks/lazyLoading";
 import { useAnimatedTreeNodeContentHeight } from "./hooks/useAnimatedHeight";
 
@@ -75,10 +74,7 @@ export function TreeNode({
             }
             const treeNodeIsExpanded = treeNodeState === TreeNodeState.EXPANDED;
             return showCustomIcon ? (
-                <Icon
-                    icon={treeNodeIsExpanded ? expandedIcon : collapsedIcon}
-                    // iconClass="widget-tree-node-branch-header-icon"
-                />
+                <CustomHeaderIcon icon={treeNodeIsExpanded ? expandedIcon : collapsedIcon} />
             ) : (
                 <ChevronIcon
                     className={classNames("widget-tree-node-branch-header-icon", {

--- a/packages/pluggableWidgets/tree-node-web/src/components/TreeNode.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/components/TreeNode.tsx
@@ -15,7 +15,7 @@ import {
     useState
 } from "react";
 import classNames from "classnames";
-import { Icon } from "@mendix/pluggable-widgets-commons/components/web";
+import { Icon } from "mendix/components/web/Icon";
 import { ShowIconEnum, TreeNodeContainerProps } from "../../typings/TreeNodeProps";
 import {
     TreeNodeBranchContextProps,
@@ -46,8 +46,8 @@ export interface TreeNodeProps extends Pick<TreeNodeContainerProps, "tabIndex"> 
     startExpanded: TreeNodeBranchProps["startExpanded"];
     showCustomIcon: boolean;
     iconPlacement: TreeNodeBranchProps["iconPlacement"];
-    expandedIcon: WebIcon | null;
-    collapsedIcon: WebIcon | null;
+    expandedIcon?: WebIcon;
+    collapsedIcon?: WebIcon;
     animateIcon: boolean;
     animateTreeNodeContent: TreeNodeBranchProps["animateTreeNodeContent"];
 }
@@ -77,7 +77,7 @@ export function TreeNode({
             return showCustomIcon ? (
                 <Icon
                     icon={treeNodeIsExpanded ? expandedIcon : collapsedIcon}
-                    className="widget-tree-node-branch-header-icon"
+                    // iconClass="widget-tree-node-branch-header-icon"
                 />
             ) : (
                 <ChevronIcon

--- a/packages/pluggableWidgets/tree-node-web/src/components/__tests__/TreeNode.spec.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/components/__tests__/TreeNode.spec.tsx
@@ -131,7 +131,7 @@ describe("TreeNode", () => {
     const customIconProps: Partial<TreeNodeProps> = {
         showCustomIcon: true,
         expandedIcon: { type: "glyph", iconClass: "expanded-icon" },
-        collapsedIcon: { type: "image", iconUrl: "collapsed-image" }
+        collapsedIcon: { type: "image", iconUrl: "image.png" }
     };
 
     function getExpandedIconFromBranchHeader(header: ReactWrapper<any>): ReactWrapper<any> {
@@ -141,7 +141,7 @@ describe("TreeNode", () => {
     }
 
     function getCollapsedImageFromBranchHeader(header: ReactWrapper<any>): ReactWrapper<any> {
-        return header.findWhere(node => node.type() === "img" && node.prop("src") === "collapsed-image");
+        return header.findWhere(node => node.type() === "img" && node.prop("src") === "image.png");
     }
 
     it("shows custom expanded icon accordingly", () => {

--- a/packages/pluggableWidgets/tree-node-web/src/components/__tests__/TreeNode.spec.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/components/__tests__/TreeNode.spec.tsx
@@ -20,8 +20,8 @@ const defaultProps: TreeNodeProps = {
     startExpanded: false,
     showCustomIcon: false,
     iconPlacement: "right",
-    expandedIcon: null,
-    collapsedIcon: null,
+    expandedIcon: undefined,
+    collapsedIcon: undefined,
     animateIcon: false,
     animateTreeNodeContent: false
 };

--- a/packages/shared/pluggable-widgets-commons/src/components/web/components.tsx
+++ b/packages/shared/pluggable-widgets-commons/src/components/web/components.tsx
@@ -28,6 +28,9 @@ export const Icon = ({ icon, className = "", fallback }: IconProps): ReactElemen
     if (icon?.type === "image") {
         return <img className={className} src={icon.iconUrl} aria-hidden alt="" />;
     }
+    if (icon?.type === "icon") {
+        return <span className={classNames(className, icon.iconClass)} aria-hidden />;
+    }
     return fallback || null;
 };
 


### PR DESCRIPTION
fix atlas icon not displaying properly on treenode.

test: use test project from WC-1925 or create treenode with atlas icon chosen as collapse and expanded icon.
make sure icon display properly.