### PR TITLE
feat(image-web): add structure mode previews & fixes

### DIFF
--- a/packages/pluggableWidgets/image-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/image-web/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We improved the structure mode preview for static and dynamic images
+-   We improved the captions in the page explorer
+-   We fixed an issue where the size of icons from the new icon collections was not configurable
+-   We fixed an issue where the image would take too much space when placed outside of containers
+
 ## [1.4.2] - 2023-09-27
 
 ### Fixed

--- a/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
+++ b/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
@@ -174,8 +174,8 @@ export function getPreview(
     ] {
         const imageObject =
             values.imageObject?.type === "static"
-            ? values.imageObject // static image
-            : values.defaultImageDynamic; // default image for dynamic image
+                ? values.imageObject // static image
+                : values.defaultImageDynamic; // default image for dynamic image
         const previewImage = imageObject?.type === "static" && !!imageObject.imageUrl ? imageObject : undefined;
 
         let width: number | undefined;
@@ -222,6 +222,14 @@ export function check(values: ImagePreviewProps): Problem[] {
     return errors;
 }
 
-export function getCustomCaption(values: any): string {
-    return values.datasource || "Image";
+export function getCustomCaption(props: ImagePreviewProps): string {
+    let caption: string;
+    if (!!props.imageObject) {
+        caption = props.imageObject.type === "static" ? props.imageObject.imageUrl : props.imageObject.entity;
+    } else if (!!props.imageIcon) {
+        caption = props.imageIcon.type === "image" ? props.imageIcon.imageUrl : props.imageIcon.iconClass; // until we have a better alternative
+    } else {
+        caption = props.imageUrl;
+    }
+    return caption === "" ? "(none)" : caption;
 }

--- a/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
+++ b/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
@@ -80,7 +80,7 @@ export function getProperties(
         hidePropertyIn(defaultProperties, values, "width");
     }
 
-    if (values.datasource === "icon" && values.imageIcon?.type === "glyph") {
+    if (values.datasource === "icon" && (values.imageIcon?.type === "glyph" || values.imageIcon?.type === "icon")) {
         hidePropertiesIn(defaultProperties, values, ["widthUnit", "width", "heightUnit", "height"]);
     } else {
         hidePropertyIn(defaultProperties, values, "iconSize");

--- a/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
+++ b/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
@@ -224,9 +224,9 @@ export function check(values: ImagePreviewProps): Problem[] {
 
 export function getCustomCaption(props: ImagePreviewProps): string {
     let caption: string;
-    if (!!props.imageObject) {
+    if (props.imageObject) {
         caption = props.imageObject.type === "static" ? props.imageObject.imageUrl : props.imageObject.entity;
-    } else if (!!props.imageIcon) {
+    } else if (props.imageIcon) {
         caption = props.imageIcon.type === "image" ? props.imageIcon.imageUrl : props.imageIcon.iconClass; // until we have a better alternative
     } else {
         caption = props.imageUrl;

--- a/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
+++ b/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
@@ -190,7 +190,7 @@ export function getPreview(
             return [width, height, previewImage];
         }
 
-        const supportsDynamicImageSize = version?.[0] >= 10 && version?.[1] >= 2; // Mx 10.2 supports images to set their own size by default
+        const supportsDynamicImageSize = (version?.[0] === 10 && version?.[1] >= 2) || version?.[0] > 10; // Mx 10.2 supports images to set their own size by default
         return supportsDynamicImageSize && !!previewImage
             ? [undefined, undefined, previewImage]
             : [100, 100, previewImage];

--- a/packages/pluggableWidgets/image-web/src/ui/Image.scss
+++ b/packages/pluggableWidgets/image-web/src/ui/Image.scss
@@ -1,5 +1,4 @@
 .mx-image-viewer {
-    height: 100%;
     width: 100%;
 }
 

--- a/packages/shared/widget-plugin-platform/src/preview/structure-preview-api.ts
+++ b/packages/shared/widget-plugin-platform/src/preview/structure-preview-api.ts
@@ -20,7 +20,8 @@ interface TextStylingProps extends BaseStylingProps {
 export interface ImageProps extends BaseStylingProps {
     type: "Image";
     document?: string; // svg image
-    data?: string; // base64 image. Will only be read if no svg image is passed
+    data?: string; // base64 image
+    property?: object; // widget image property object from Values API
     width?: number; // sets a fixed maximum width
     height?: number; // sets a fixed maximum height
 }


### PR DESCRIPTION
### Features/fixes
* Added structure mode preview for static and dynamic images (the latter only if they have a static default image)
* Improved the captions in the Page Explorer
* fixed an issue where the size of icons from the new icon collections was not configurable
* fixed an issue where the image would take too much space when placed outside of containers

### What to test
**Structure preview**
* If you select a static image, it should show in structure mode (Note: in <10.2 it will always default to size 100*100px because of API limitations)
* If you selecta dynamic image and set a static image as a default, it should show the default in structure mode
* Any other selection should render the original fallback image
* Setting a size in pixels should now affect the rendering size of the image on the canvas (if only a width or height is set, it should set the other proportionally)

**Page explorer captions**
* Static images should show the image path
* Dynamic images should show the entity
* Icons should either show the image path (image icons) or icon class (not ideal but best we can do rn)
* ImageUrls should show Image Urls
* If unset, it should fall back to "(none)"

**Fixes**
* Ensure you can set an icon size for the new Atlas icons (and that it reflects in design mode)
* Ensure that an image (e.g. static image) does not take more height than necessary when put at the bottom of a page (outside of layouts/containers. It should behave the same as core images.