### PR TITLE
fix(video-player): youtube video not mute on load

### DIFF
--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   We fixed the issue where youtube video cannot mute on first load.
+-   We fixed an issue with the "Muted" setting not working correctly for YouTube videos.
 
 ## [3.2.0] - 2023-06-06
 

--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed the issue where youtube video cannot mute on first load.
+
 ## [3.2.0] - 2023-06-06
 
 ### Changed

--- a/packages/pluggableWidgets/video-player-web/cypress/integration/VideoPlayer.spec.js
+++ b/packages/pluggableWidgets/video-player-web/cypress/integration/VideoPlayer.spec.js
@@ -22,7 +22,7 @@ describe("Video Player", () => {
                 .should("contain", "youtube.com")
                 .and("contain", "autoplay=1")
                 .and("contain", "controls=0")
-                .and("contain", "muted=0")
+                .and("contain", "mute=0")
                 .and("contain", "loop=0");
         });
 

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/video-player-web",
   "widgetName": "VideoPlayer",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Player for YouTube, Dailymotion, Vimeo and Mp4 videos",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/video-player-web/src/components/Youtube.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/Youtube.tsx
@@ -55,7 +55,7 @@ export class Youtube extends Component<YoutubeProps> {
         let attributes = "?modestbranding=1&rel=0";
         attributes += "&autoplay=" + (this.props.autoPlay ? "1" : "0");
         attributes += "&controls=" + (this.props.showControls ? "1" : "0");
-        attributes += "&muted=" + (this.props.muted ? "1" : "0");
+        attributes += "&mute=" + (this.props.muted ? "1" : "0");
         attributes += "&loop=" + (this.props.loop ? "1" : "0");
         return attributes;
     }

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Youtube.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Youtube.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`YoutubePlayer Player should renders correctly 1`] = `
   allowFullScreen={true}
   className="widget-video-player-iframe"
   frameBorder="0"
-  src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=0&muted=0&loop=0"
+  src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=0&mute=0&loop=0"
 />
 `;
 
@@ -16,7 +16,7 @@ exports[`YoutubePlayer Player should renders correctly with autoplay 1`] = `
   allowFullScreen={true}
   className="widget-video-player-iframe"
   frameBorder="0"
-  src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=1&controls=0&muted=0&loop=0"
+  src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=1&controls=0&mute=0&loop=0"
 />
 `;
 
@@ -26,7 +26,7 @@ exports[`YoutubePlayer Player should renders correctly with controls 1`] = `
   allowFullScreen={true}
   className="widget-video-player-iframe"
   frameBorder="0"
-  src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=1&muted=0&loop=0"
+  src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=1&mute=0&loop=0"
 />
 `;
 
@@ -36,6 +36,6 @@ exports[`YoutubePlayer Player should renders correctly with muted 1`] = `
   allowFullScreen={true}
   className="widget-video-player-iframe"
   frameBorder="0"
-  src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=0&muted=1&loop=0"
+  src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=0&mute=1&loop=0"
 />
 `;

--- a/packages/pluggableWidgets/video-player-web/src/package.xml
+++ b/packages/pluggableWidgets/video-player-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="VideoPlayer" version="3.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="VideoPlayer" version="3.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="VideoPlayer.xml" />
         </widgetFiles>


### PR DESCRIPTION

### Pull request type

Bug fix: Youtube video cannot mute on first load if the setting is set to Mute.

### Description

youtube video has different parameters for mute on load,
previously it was "muted=1", changed to "mute=1"
