### PR TITLE
fix(tree-node): refresh when children updated

### DIFF
--- a/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   We fixed Atlas icon not displaying properly.
--   We fixed treenode children not refreshed when updated
+-   We fixed Atlas icon unable to be shown on tree node.
+-   We fixed the condition where tree child not directly refreshed after updating the data.
 
 ## [1.1.1] - 2023-05-26
 

--- a/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 -   We fixed Atlas icon unable to be shown on tree node.
--   We fixed the condition where tree child not directly refreshed after updating the data.
+-   We fixed an issue where tree child not directly refreshed after updating the data.
 
 ## [1.1.1] - 2023-05-26
 

--- a/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/tree-node-web/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 -   We fixed Atlas icon not displaying properly.
+-   We fixed treenode children not refreshed when updated
 
 ## [1.1.1] - 2023-05-26
 

--- a/packages/pluggableWidgets/tree-node-web/src/components/TreeNode.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/components/TreeNode.tsx
@@ -176,6 +176,10 @@ function TreeNodeBranch(props: TreeNodeBranchProps): ReactElement {
     );
     const [isActualLeafNode, setIsActualLeafNode] = useState<boolean>(props.isUserDefinedLeafNode || !props.children);
 
+    useEffect(() => {
+        setIsActualLeafNode(props.isUserDefinedLeafNode || !props.children);
+    }, [props.children]);
+
     const informParentOfChildNodes = useCallback<TreeNodeBranchContextProps["informParentOfChildNodes"]>(
         numberOfNodes => {
             if (numberOfNodes !== undefined) {


### PR DESCRIPTION

### Pull request type

Bug fix: tree node not re-rendered when number of children updated

### Description

updated "isActualLeafNode" variables when number of children updated.
