### PR TITLE
Wc 1980 dg2 right border issue

### DIFF
--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue where a data grid's border went missing if the Hiding property (found in Column capabilities) was set to No.
+
 ## [2.8.4] DataWidgets - 2023-07-13
 
 ### [2.7.5] Datagrid

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid-design-properties.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid-design-properties.scss
@@ -28,35 +28,33 @@
 }
 
 .table-bordered-all {
-    .th {
-        border-top-width: 1px;
-        border-top-style: solid;
+    .th,
+    .td {
         border-left-width: 1px;
         border-left-style: solid;
 
         // Column for the visibility when a column can be hidden
         &.column-selector {
             border-left-width: 0;
+        }
+
+        &:last-child,
+        &.column-selector {
             border-right-width: 1px;
             border-right-style: solid;
         }
+    }
+    .th {
+        border-top-width: 1px;
+        border-top-style: solid;
     }
 
     .td {
         border-bottom-width: 1px;
         border-bottom-style: solid;
-        border-left-width: 1px;
-        border-left-style: solid;
 
         &.td-borders {
             border-top-width: 1px;
-        }
-
-        // Column for the visibility when a column can be hidden
-        &.column-selector {
-            border-left-width: 0;
-            border-right-width: 1px;
-            border-right-style: solid;
         }
     }
 }


### PR DESCRIPTION

### Pull request type

Bug fix: right border not shown if hiding column capabilities disabled.

### Description

Try select "no" on hiding column in personalization tab on Datagrid 2.
previously, right border is missing.
this PR will fix it.
