### PR TITLE
fix: map not centered after zoom

### DIFF
--- a/packages/pluggableWidgets/maps-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue where map not centered after automatically zoom into a marker.
+
 ## [3.2.0] - 2023-06-05
 
 ### Changed

--- a/packages/pluggableWidgets/maps-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   We fixed an issue where the map was not centred after automatically zooming into a marker. Now, after zooming, the marker will be put in the centre of the map.
+-   We fixed an issue where the marker was not at the center of the map after you zoom in to the marker. Now after you zoom in to a marker, the map will be centered around the marker.
 
 ## [3.2.0] - 2023-06-05
 

--- a/packages/pluggableWidgets/maps-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   We fixed an issue where map not centered after automatically zoom into a marker.
+-   We fixed an issue where the map was not centred after automatically zooming into a marker. Now, after zooming, the marker will be put in the centre of the map.
 
 ## [3.2.0] - 2023-06-05
 

--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/maps-web",
   "widgetName": "Maps",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Show locations on Maps",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -42,7 +42,7 @@ function SetBoundsComponent(props: Pick<LeafletProps, "autoZoom" | "currentLocat
 
     if (bounds.isValid()) {
         if (autoZoom) {
-            map.fitBounds(bounds, { padding: [0.5, 0.5] }).invalidateSize();
+            map.flyToBounds(bounds, { padding: [0.5, 0.5], animate: false }).invalidateSize();
         } else {
             map.panTo(bounds.getCenter(), { animate: false });
         }

--- a/packages/pluggableWidgets/maps-web/src/package.xml
+++ b/packages/pluggableWidgets/maps-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Maps" version="3.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Maps" version="3.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Maps.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Pull request type
fix map not pan to centered marker location after zoom.

### Description
fix by changing fitToBound with flyToBound to make sure that map is panning to correct marker location after zoom