### PR TITLE
[WC-2018] fix: column hide by default not working

### DIFF
--- a/packages/modules/data-widgets/package.json
+++ b/packages/modules/data-widgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/data-widgets",
   "moduleName": "Data Widgets",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   We fixed an issue with column capabilities hide option that was unable to be hidden by default.
+-   We fixed an issue where columns, which were configured to be hidden by default, remained visible despite visibility settings.
 
 ## [2.8.1] - 2023-08-22
 

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with column capabilities hide option that was unable to be hidden by default.
+
 ## [2.8.1] - 2023-08-22
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/cypress/integration/DataGrid.spec.js
+++ b/packages/pluggableWidgets/datagrid-web/cypress/integration/DataGrid.spec.js
@@ -84,6 +84,25 @@ describe("datagrid-web", () => {
             cy.get(".mx-name-datagrid1 .column-header").first().contains("First Name");
         });
 
+        it("hide column saved on configuration attribute capability", () => {
+            cy.get(".mx-name-datagrid5 .column-selector-button").click();
+            cy.get(".column-selectors > li").first().click();
+            cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+            cy.get(".mx-name-datagrid5 .column-header").first().contains("Last Name");
+            cy.get(".mx-name-textArea1 textarea").should(
+                "have.text",
+                '[{"column":"First Name","sort":false,"sortMethod":"asc","hidden":true,"order":0},{"column":"Last Name","sort":false,"sortMethod":"asc","hidden":false,"order":1}]'
+            );
+        });
+
+        it("hide column by default enabled", () => {
+            cy.get(".mx-name-datagrid6 .column-header").first().contains("First Name");
+            cy.get(".mx-name-datagrid6 .column-selector-button").click();
+            cy.get(".column-selectors > li").first().click();
+            cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+            cy.get(".mx-name-datagrid6 .column-header").first().contains("Id");
+        });
+
         it("do not allow to hide last visible column", () => {
             cy.get(".mx-name-datagrid1 .column-header").first().should("be.visible");
             cy.get(".mx-name-datagrid1 .column-selector-button").click();

--- a/packages/pluggableWidgets/datagrid-web/cypress/integration/DataGridSelection.spec.js
+++ b/packages/pluggableWidgets/datagrid-web/cypress/integration/DataGridSelection.spec.js
@@ -1,20 +1,3 @@
-function terminalLog(violations) {
-    cy.task(
-        "log",
-        `${violations.length} accessibility violation${violations.length === 1 ? "" : "s"} ${
-            violations.length === 1 ? "was" : "were"
-        } detected`
-    );
-    // pluck specific keys to keep the table readable
-    const violationData = violations.map(({ id, impact, description, nodes }) => ({
-        id,
-        impact,
-        description,
-        nodes: nodes.length
-    }));
-
-    cy.task("table", violationData);
-}
 describe("datagrid-web", () => {
     const browserName = Cypress.browser.name;
 
@@ -81,7 +64,7 @@ describe("datagrid-web", () => {
                         values: ["wcag2a"]
                     }
                 },
-                terminalLog
+                cy.terminalLog
             );
         });
     });

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
@@ -60,7 +60,7 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
             }}
         >
             {props.columns.map((column: ColumnProperty, index: number) => {
-                const isVisible = !props.hiddenColumns.includes(column.id);
+                const isVisible = !props.hiddenColumns.includes(column.index.toString());
                 const isLastVisibleColumn = isVisible && isOnlyOneColumnVisible;
                 return column.canHide ? (
                     <li
@@ -68,7 +68,7 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
                         onClick={e => {
                             e.preventDefault();
                             e.stopPropagation();
-                            onClick(isVisible, column.id);
+                            onClick(isVisible, column.index.toString());
                         }}
                         onKeyDown={e => {
                             if (e.key === "Enter" || e.key === " ") {

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -209,10 +209,12 @@ export function Table<T extends ObjectItem>(props: TableProps<T>): ReactElement 
     );
 
     const visibleColumns = useMemo(
-        () => tableColumns.filter(c => !hiddenColumns.includes(c.id)).sort((a, b) => sortColumns(columnOrder, a, b)),
+        () =>
+            tableColumns
+                .filter(c => !hiddenColumns.includes(c.index.toString()))
+                .sort((a, b) => sortColumns(columnOrder, a, b)),
         [tableColumns, hiddenColumns, columnOrder]
     );
-
     const renderCell = useCallback(
         (column: ColumnProperty, value: T, rowIndex: number) =>
             visibleColumns.find(c => c.id === column.id) || preview

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/ColumnSelector.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/ColumnSelector.spec.tsx
@@ -89,11 +89,13 @@ describe("Column Selector", () => {
                         [
                             {
                                 id: "id",
+                                index: 0,
                                 header: "Test",
                                 canHide: true
                             },
                             {
                                 id: "id2",
+                                index: 1,
                                 header: "Test2",
                                 canHide: true
                             }
@@ -127,21 +129,25 @@ describe("Column Selector", () => {
                         [
                             {
                                 id: "id",
+                                index: 0,
                                 header: "Test",
                                 canHide: true
                             },
                             {
                                 id: "id2",
+                                index: 1,
                                 header: "Test2",
                                 canHide: false
                             },
                             {
                                 id: "id3",
+                                index: 2,
                                 header: "Test3",
                                 canHide: true
                             },
                             {
                                 id: "id4",
+                                index: 3,
                                 header: "Test4",
                                 canHide: true
                             }
@@ -177,6 +183,7 @@ function mockColumnSelectorProps(): ColumnSelectorProps {
         columns: [
             {
                 id: "id",
+                index: 1,
                 header: "Test",
                 canHide: true
             }

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.8.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.8.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>


### PR DESCRIPTION

### Pull request type
Bug Fix: this issue relates with previously introduced changed to allow non-numeric ID (fix a11y).
This changes causing "visible column" not working as expected due to the reference with "hidden column" that is still index-based.

### Description
Fix by adjusting correct attribute.