### PR TITLE
fix: [WC-2002] datefilter not fully shown on overflow scrolls

### DIFF
--- a/packages/modules/data-widgets/package.json
+++ b/packages/modules/data-widgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/data-widgets",
   "moduleName": "Data Widgets",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-date-filter-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed the issue where date filter does not fully visible when datagrid pagination option is set to virtual scrolling.
+
 ## [2.6.0] - 2023-08-10
 
 ### Changed

--- a/packages/pluggableWidgets/datagrid-date-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-date-filter-web",
   "widgetName": "DatagridDateFilter",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/DatePicker.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/DatePicker.tsx
@@ -105,6 +105,9 @@ export const DatePicker = forwardRef(
                     onInputClick={() => setOpen(true)}
                     placeholderText={props.placeholder}
                     popperPlacement="bottom-end"
+                    popperProps={{
+                        strategy: "fixed"
+                    }}
                     popperModifiers={[
                         {
                             name: "offset",

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="DatagridDateFilter" version="2.6.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="DatagridDateFilter" version="2.6.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="DatagridDateFilter.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Pull request type
Bug fix:
date filter not fully visible on container overflow : scrolls.

### Description

fixed by changing popper js mode to `position:fixed` instead of `position:absolute` .
popper js will do the calculation for positioning (tethered to input) automatically.
but overflow will works.

https://popper.js.org/docs/v2/constructors/#strategy


### Developer testing:
 - check if popup goes under topbar ✅ [ with latest atlas-core ]
 - check if popup tethered to input when scrolled up✅
 - check if popup maintain correct position when datagrid header filter goes into sticky position ✅ 