### PR TITLE
feat(combo-box): [WC-2049][WC-2050] Add design mode and page explorer text

### DIFF
--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorConfig.ts
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorConfig.ts
@@ -1,6 +1,7 @@
 import { StructurePreviewProps } from "@mendix/widget-plugin-platform/preview/structure-preview-api";
 import { hidePropertiesIn, Properties } from "@mendix/pluggable-widgets-tools";
 import { ComboboxPreviewProps } from "../typings/ComboboxProps";
+import { getDatasourcePlaceholderText } from "./helpers/utils";
 
 export function getProperties(values: ComboboxPreviewProps, defaultProperties: Properties): Properties {
     if (["enumeration", "boolean"].includes(values.optionsSourceType)) {
@@ -62,4 +63,8 @@ export function getPreview(_values: ComboboxPreviewProps, isDarkMode: boolean): 
             }
         ]
     };
+}
+
+export function getCustomCaption(values: ComboboxPreviewProps): string {
+    return getDatasourcePlaceholderText(values);
 }

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -1,36 +1,11 @@
-import { createElement, ReactElement } from "react";
-import { ComboboxPreviewProps } from "../typings/ComboboxProps";
 import classNames from "classnames";
 import Downshift from "downshift";
+import { createElement, ReactElement } from "react";
+import { ComboboxPreviewProps } from "../typings/ComboboxProps";
 import { ClearButton, DownArrow } from "./assets/icons";
 import { InputPlaceholder } from "./components/Placeholder";
+import { getDatasourcePlaceholderText } from "./helpers/utils";
 import "./ui/Combobox.scss";
-
-function getDesignModePlaceholderText(args: ComboboxPreviewProps): string | undefined {
-    const {
-        optionsSourceType,
-        optionsSourceAssociationDataSource,
-        attributeEnumeration,
-        attributeBoolean,
-        emptyOptionText
-    } = args;
-    let returnVal: string | undefined = "";
-    switch (optionsSourceType) {
-        case "association":
-            returnVal = (optionsSourceAssociationDataSource as { caption?: string })?.caption;
-            break;
-        case "enumeration":
-            returnVal = `[${optionsSourceType}, ${attributeEnumeration}]`;
-            break;
-        case "boolean":
-            returnVal = `[${optionsSourceType}, ${attributeBoolean}]`;
-            break;
-        default:
-            returnVal = `[${emptyOptionText}]`;
-    }
-
-    return returnVal;
-}
 
 export const preview = (props: ComboboxPreviewProps): ReactElement => {
     const backgroundColor = props.readOnly ? "#C8C8C8" : undefined;
@@ -52,7 +27,7 @@ export const preview = (props: ComboboxPreviewProps): ReactElement => {
                                 {...getInputProps()}
                                 placeholder=" "
                             />
-                            <InputPlaceholder isEmpty>{getDesignModePlaceholderText(props)}</InputPlaceholder>
+                            <InputPlaceholder isEmpty>{getDatasourcePlaceholderText(props)}</InputPlaceholder>
                         </div>
                         {props.clearable && (
                             <button className="widget-combobox-clear-button">

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -1,45 +1,50 @@
-import classNames from "classnames";
-import Downshift from "downshift";
-import { createElement, ReactElement } from "react";
+import { generateUUID } from "@mendix/widget-plugin-platform/framework/generate-uuid";
+import { ReferenceValue } from "mendix";
+import { createElement, ReactElement, ReactNode, useMemo } from "react";
 import { ComboboxPreviewProps } from "../typings/ComboboxProps";
-import { ClearButton, DownArrow } from "./assets/icons";
-import { InputPlaceholder } from "./components/Placeholder";
+import { SingleSelection } from "./components/SingleSelection/SingleSelection";
+import { AssociationSimpleCaptionsProvider } from "./helpers/Association/AssociationSimpleCaptionsProvider";
+import { BaseAssociationSelector } from "./helpers/Association/BaseAssociationSelector";
+import { SingleSelector } from "./helpers/types";
 import { getDatasourcePlaceholderText } from "./helpers/utils";
 import "./ui/Combobox.scss";
 
+class AssociationPreviewCaptionsProvider extends AssociationSimpleCaptionsProvider {
+    emptyCaption = "Combo box";
+    get(value: string | null): string {
+        return value || this.emptyCaption;
+    }
+    render(value: string | null): ReactNode {
+        return <span className="widget-combobox-caption">{this.get(value)}</span>;
+    }
+}
+class AssociationPreviewSelector extends BaseAssociationSelector<string, ReferenceValue> implements SingleSelector {
+    type = "single" as const;
+    constructor(props: ComboboxPreviewProps) {
+        super();
+        this.caption = new AssociationPreviewCaptionsProvider(new Map());
+        this.readOnly = props.readOnly;
+        this.clearable = props.clearable;
+        this.currentValue = getDatasourcePlaceholderText(props);
+    }
+}
+
 export const preview = (props: ComboboxPreviewProps): ReactElement => {
-    const backgroundColor = props.readOnly ? "#C8C8C8" : undefined;
+    const id = generateUUID().toString();
+    const commonProps = {
+        tabIndex: 1,
+        inputId: id,
+        labelId: `${id}-label`
+    };
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const selector: SingleSelector = useMemo(() => {
+        return new AssociationPreviewSelector(props);
+    }, [props]);
+
     return (
-        <Downshift>
-            {({ getInputProps, isOpen, getToggleButtonProps }) => (
-                <div className="widget-combobox">
-                    <div
-                        style={{ backgroundColor }}
-                        className={classNames("form-control", "widget-combobox-input-container", {
-                            "widget-combobox-input-container-active": isOpen
-                        })}
-                        {...getToggleButtonProps()}
-                    >
-                        <div className="widget-combobox-selected-items">
-                            <input
-                                style={{ backgroundColor }}
-                                className="widget-combobox-input"
-                                {...getInputProps()}
-                                placeholder=" "
-                            />
-                            <InputPlaceholder isEmpty>{getDatasourcePlaceholderText(props)}</InputPlaceholder>
-                        </div>
-                        {props.clearable && (
-                            <button className="widget-combobox-clear-button">
-                                <ClearButton />
-                            </button>
-                        )}
-                        <div className="widget-combobox-down-arrow">
-                            <DownArrow />
-                        </div>
-                    </div>
-                </div>
-            )}
-        </Downshift>
+        <div className="widget-combobox widget-combobox-editor-preview">
+            <SingleSelection selector={selector} {...commonProps} />
+        </div>
     );
 };

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -6,6 +6,32 @@ import { ClearButton, DownArrow } from "./assets/icons";
 import { InputPlaceholder } from "./components/Placeholder";
 import "./ui/Combobox.scss";
 
+function getDesignModePlaceholderText(args: ComboboxPreviewProps): string | undefined {
+    const {
+        optionsSourceType,
+        optionsSourceAssociationDataSource,
+        attributeEnumeration,
+        attributeBoolean,
+        emptyOptionText
+    } = args;
+    let returnVal: string | undefined = "";
+    switch (optionsSourceType) {
+        case "association":
+            returnVal = (optionsSourceAssociationDataSource as { caption?: string })?.caption;
+            break;
+        case "enumeration":
+            returnVal = `[${optionsSourceType}, ${attributeEnumeration}]`;
+            break;
+        case "boolean":
+            returnVal = `[${optionsSourceType}, ${attributeBoolean}]`;
+            break;
+        default:
+            returnVal = `[${emptyOptionText}]`;
+    }
+
+    return returnVal || `[${emptyOptionText}]`;
+}
+
 export const preview = (props: ComboboxPreviewProps): ReactElement => {
     const backgroundColor = props.readOnly ? "#C8C8C8" : undefined;
     return (
@@ -26,10 +52,7 @@ export const preview = (props: ComboboxPreviewProps): ReactElement => {
                                 {...getInputProps()}
                                 placeholder=" "
                             />
-                            <InputPlaceholder isEmpty>
-                                {(props.optionsSourceAssociationDataSource as { caption?: string })?.caption ||
-                                    props.emptyOptionText}
-                            </InputPlaceholder>
+                            <InputPlaceholder isEmpty>{getDesignModePlaceholderText(props)}</InputPlaceholder>
                         </div>
                         {props.clearable && (
                             <button className="widget-combobox-clear-button">

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -29,7 +29,7 @@ function getDesignModePlaceholderText(args: ComboboxPreviewProps): string | unde
             returnVal = `[${emptyOptionText}]`;
     }
 
-    return returnVal || `[${emptyOptionText}]`;
+    return returnVal;
 }
 
 export const preview = (props: ComboboxPreviewProps): ReactElement => {

--- a/packages/pluggableWidgets/combobox-web/src/helpers/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/utils.ts
@@ -1,3 +1,5 @@
+import { datasource } from "@mendix/widget-plugin-platform/preview/structure-preview-api";
+import { ComboboxPreviewProps } from "typings/ComboboxProps";
 import { MultiSelector } from "./types";
 
 export function getSelectedCaptionsPlaceholder(selector: MultiSelector, selectedItems: string[]): string {
@@ -9,4 +11,27 @@ export function getSelectedCaptionsPlaceholder(selector: MultiSelector, selected
     }
 
     return selectedItems.map(v => selector.caption.get(v)).join(", ");
+}
+
+export function getDatasourcePlaceholderText(args: ComboboxPreviewProps): string {
+    const {
+        optionsSourceType,
+        optionsSourceAssociationDataSource,
+        attributeEnumeration,
+        attributeBoolean,
+        emptyOptionText
+    } = args;
+    const emptyStringFormat = emptyOptionText ? `[${emptyOptionText}]` : "Combo box";
+    switch (optionsSourceType) {
+        case "association":
+            type DsProperty = { caption?: string };
+            const dsProperty: DsProperty = datasource(optionsSourceAssociationDataSource)().property ?? {};
+            return dsProperty.caption || emptyStringFormat;
+        case "enumeration":
+            return `[${optionsSourceType}, ${attributeEnumeration}]`;
+        case "boolean":
+            return `[${optionsSourceType}, ${attributeBoolean}]`;
+        default:
+            return emptyStringFormat;
+    }
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/utils.ts
@@ -1,4 +1,3 @@
-import { datasource } from "@mendix/widget-plugin-platform/preview/structure-preview-api";
 import { ComboboxPreviewProps } from "typings/ComboboxProps";
 import { MultiSelector } from "./types";
 
@@ -24,9 +23,7 @@ export function getDatasourcePlaceholderText(args: ComboboxPreviewProps): string
     const emptyStringFormat = emptyOptionText ? `[${emptyOptionText}]` : "Combo box";
     switch (optionsSourceType) {
         case "association":
-            type DsProperty = { caption?: string };
-            const dsProperty: DsProperty = datasource(optionsSourceAssociationDataSource)().property ?? {};
-            return dsProperty.caption || emptyStringFormat;
+            return (optionsSourceAssociationDataSource as { caption?: string })?.caption || emptyStringFormat;
         case "enumeration":
             return `[${optionsSourceType}, ${attributeEnumeration}]`;
         case "boolean":


### PR DESCRIPTION
### Pull request type
feature (combobox) : add proper text for design mode and page explorer preview


### Description
For Association type: Association caption
For Enumeration type: [enumeration, Attribute]
For Boolean type: [boolean, Attribute]


![image](https://github.com/mendix/web-widgets/assets/1436036/ecaf09f8-1474-4a4f-839f-f1e278083362)

![image](https://github.com/mendix/web-widgets/assets/1436036/55922be7-2b4e-4c0a-a9d1-cb4fdfcc6c4e)

