### PR TITLE
[WC-1297]feat(combo-box): Custom content dropzone

### DIFF
--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorConfig.ts
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorConfig.ts
@@ -2,7 +2,8 @@ import { Properties, hidePropertiesIn } from "@mendix/pluggable-widgets-tools";
 import {
     ContainerProps,
     StructurePreviewProps,
-    structurePreviewPalette
+    structurePreviewPalette,
+    dropzone
 } from "@mendix/widget-plugin-platform/preview/structure-preview-api";
 import { ComboboxPreviewProps } from "../typings/ComboboxProps";
 import { getDatasourcePlaceholderText } from "./helpers/utils";
@@ -18,6 +19,8 @@ export function getProperties(values: ComboboxPreviewProps, defaultProperties: P
             "optionsSourceAssociationCaptionAttribute",
             "optionsSourceAssociationCaptionExpression",
             "optionsSourceAssociationDataSource",
+            "optionsSourceAssociationCustomContentType",
+            "optionsSourceAssociationCustomContent",
             "selectedItemsStyle"
         ]);
         if (values.optionsSourceType === "boolean") {
@@ -36,6 +39,12 @@ export function getProperties(values: ComboboxPreviewProps, defaultProperties: P
 
         if (values.optionsSourceAssociationDataSource === null) {
             hidePropertiesIn(defaultProperties, values, ["optionsSourceAssociationCaptionType"]);
+        }
+
+        if (values.optionsSourceAssociationCustomContentType === "no") {
+            hidePropertiesIn(defaultProperties, values, ["optionsSourceAssociationCustomContent"]);
+        } else {
+            hidePropertiesIn(defaultProperties, values, ["selectedItemsStyle"]);
         }
     }
 
@@ -80,11 +89,17 @@ export function getPreview(_values: ComboboxPreviewProps, isDarkMode: boolean): 
                 grow: 1,
                 padding: 4,
                 children: [
-                    {
-                        type: "Text",
-                        content: getDatasourcePlaceholderText(_values),
-                        fontColor: palette.text.data
-                    }
+                    _values.optionsSourceType === "association" &&
+                    _values.optionsSourceAssociationCustomContentType !== "no"
+                        ? dropzone(
+                              dropzone.placeholder("Configure the combo box: Place widgets here"),
+                              dropzone.hideDataSourceHeaderIf(false)
+                          )(_values.optionsSourceAssociationCustomContent)
+                        : {
+                              type: "Text",
+                              content: getDatasourcePlaceholderText(_values),
+                              fontColor: palette.text.data
+                          }
                 ]
             },
             {

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -5,7 +5,7 @@ import { ComboboxPreviewProps, OptionsSourceAssociationCustomContentTypeEnum } f
 import { SingleSelection } from "./components/SingleSelection/SingleSelection";
 import { AssociationSimpleCaptionsProvider } from "./helpers/Association/AssociationSimpleCaptionsProvider";
 import { BaseAssociationSelector } from "./helpers/Association/BaseAssociationSelector";
-import { SingleSelector } from "./helpers/types";
+import { CaptionPlacement, SingleSelector } from "./helpers/types";
 import { getDatasourcePlaceholderText } from "./helpers/utils";
 import "./ui/Combobox.scss";
 
@@ -27,7 +27,7 @@ class AssociationPreviewCaptionsProvider extends AssociationSimpleCaptionsProvid
         }
         if (this.customContentType !== "no") {
             return (
-                <this.customContentRenderer caption="test">
+                <this.customContentRenderer caption={"CUSTOM CONTENT"}>
                     <div />
                 </this.customContentRenderer>
             );
@@ -37,6 +37,11 @@ class AssociationPreviewCaptionsProvider extends AssociationSimpleCaptionsProvid
     updatePreviewProps(props: PreviewProps): void {
         this.customContentRenderer = props.customContentRenderer;
         this.customContentType = props.customContentType;
+    }
+
+    render(value: string | null, placement: CaptionPlacement): ReactNode {
+        // always render custom content dropzone in design mode if type is options only
+        return super.render(value, placement === "label" ? "options" : placement);
     }
 }
 class AssociationPreviewSelector extends BaseAssociationSelector<string, ReferenceValue> implements SingleSelector {
@@ -52,6 +57,11 @@ class AssociationPreviewSelector extends BaseAssociationSelector<string, Referen
             customContentRenderer: props.optionsSourceAssociationCustomContent.renderer,
             customContentType: props.optionsSourceAssociationCustomContentType
         });
+
+        if (props.optionsSourceAssociationCustomContentType === "listItem") {
+            // always render custom content dropzone in design mode if type is options only
+            this.customContentType = "yes";
+        }
     }
 }
 

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -98,6 +98,19 @@
                     <caption>Clearable</caption>
                     <description />
                 </property>
+                <property key="optionsSourceAssociationCustomContentType" type="enumeration" defaultValue="no" required="true">
+                    <caption>Custom content</caption>
+                    <description />
+                    <enumerationValues>
+                        <enumerationValue key="yes">Yes</enumerationValue>
+                        <enumerationValue key="listItem">List items only</enumerationValue>
+                        <enumerationValue key="no">No</enumerationValue>
+                    </enumerationValues>
+                </property>
+                <property key="optionsSourceAssociationCustomContent" type="widgets" required="true" dataSource="optionsSourceAssociationDataSource">
+                    <caption>Custom content</caption>
+                    <description />
+                </property>
                 <property key="selectedItemsStyle" type="enumeration" defaultValue="text" required="true">
                     <caption>Show selected items as</caption>
                     <description />

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -32,6 +32,8 @@ describe("Combo box (Association)", () => {
             optionsSourceAssociationCaptionType: "expression",
             optionsSourceAssociationCaptionAttribute: new ListAttributeValueBuilder<string>().build(),
             optionsSourceAssociationCaptionExpression: buildListExpression("$currentObject/CountryName"),
+            optionsSourceAssociationCustomContentType: "no",
+            optionsSourceAssociationCustomContent: undefined,
             emptyOptionText: dynamicValue("Select an option 111"),
             ariaRequired: true,
             clearable: true,

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -91,7 +91,7 @@ describe("Combo box (Association)", () => {
 
         const input = await getInput(component);
         const labelText = await component.container.querySelector(
-            ".widget-combobox-placeholder-text .widget-combobox-caption"
+            ".widget-combobox-placeholder-text .widget-combobox-caption-text"
         );
         const toggleButton = await getToggleButton(component);
         fireEvent.click(toggleButton);

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -14,7 +14,7 @@ import { ComboboxContainerProps } from "../../typings/ComboboxProps";
 import Combobox from "../Combobox";
 
 // function helper to ease DOM changes in development
-async function getToggleButton(component: RenderResult) {
+async function getToggleButton(component: RenderResult): Promise<Element> {
     return component.container.querySelector(".widget-combobox-down-arrow")!;
 }
 async function getInput(component: RenderResult): Promise<HTMLInputElement> {
@@ -90,7 +90,9 @@ describe("Combo box (Association)", () => {
         const component = render(<Combobox {...defaultProps} />);
 
         const input = await getInput(component);
-        const labelText = await component.container.getElementsByClassName("widget-combobox-text-label")[0];
+        const labelText = await component.container.querySelector(
+            ".widget-combobox-text-label .widget-combobox-caption"
+        );
         const toggleButton = await getToggleButton(component);
         fireEvent.click(toggleButton);
 

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -91,7 +91,7 @@ describe("Combo box (Association)", () => {
 
         const input = await getInput(component);
         const labelText = await component.container.querySelector(
-            ".widget-combobox-text-label .widget-combobox-caption"
+            ".widget-combobox-label-text .widget-combobox-caption"
         );
         const toggleButton = await getToggleButton(component);
         fireEvent.click(toggleButton);

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -91,7 +91,7 @@ describe("Combo box (Association)", () => {
 
         const input = await getInput(component);
         const labelText = await component.container.querySelector(
-            ".widget-combobox-label-text .widget-combobox-caption"
+            ".widget-combobox-placeholder-text .widget-combobox-caption"
         );
         const toggleButton = await getToggleButton(component);
         fireEvent.click(toggleButton);

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -40,6 +40,8 @@ describe("Combo box (Association)", () => {
             optionsSourceAssociationCaptionType: "expression",
             optionsSourceAssociationCaptionAttribute: new ListAttributeValueBuilder<string>().build(),
             optionsSourceAssociationCaptionExpression: buildListExpression("$currentObject/CountryName"),
+            optionsSourceAssociationCustomContentType: "no",
+            optionsSourceAssociationCustomContent: undefined,
             emptyOptionText: dynamicValue("Select an option 111"),
             ariaRequired: true,
             clearable: true,
@@ -103,7 +105,7 @@ describe("Combo box (Association)", () => {
         const clearButton = await component.container.getElementsByClassName("widget-combobox-clear-button")[0];
         fireEvent.click(clearButton);
 
-        expect(labelText.innerHTML).toEqual(defaultProps.emptyOptionText?.value);
+        expect(labelText?.innerHTML).toEqual(defaultProps.emptyOptionText?.value);
         expect(defaultProps.attributeAssociation?.value).toEqual(undefined);
     });
 });

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
           value=""
         />
         <div
-          class="widget-combobox-text-label"
+          class="widget-combobox-label-text"
         >
           111
         </div>
@@ -250,7 +250,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
           value=""
         />
         <div
-          class="widget-combobox-text-label"
+          class="widget-combobox-label-text"
         >
           111
         </div>

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
           value=""
         />
         <div
-          class="widget-combobox-label-text"
+          class="widget-combobox-placeholder-text"
         >
           111
         </div>
@@ -250,7 +250,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
           value=""
         />
         <div
-          class="widget-combobox-label-text"
+          class="widget-combobox-placeholder-text"
         >
           111
         </div>

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
@@ -111,7 +111,7 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
             </svg>
           </span>
           <span
-            class="widget-combobox-caption"
+            class="widget-combobox-caption-text"
           >
             111
           </span>
@@ -144,7 +144,7 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
             </svg>
           </span>
           <span
-            class="widget-combobox-caption"
+            class="widget-combobox-caption-text"
           >
             222
           </span>
@@ -177,7 +177,7 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
             </svg>
           </span>
           <span
-            class="widget-combobox-caption"
+            class="widget-combobox-caption-text"
           >
             333
           </span>
@@ -210,7 +210,7 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
             </svg>
           </span>
           <span
-            class="widget-combobox-caption"
+            class="widget-combobox-caption-text"
           >
             444
           </span>

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
@@ -28,11 +28,11 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
           role="combobox"
           value=""
         />
-        <span
+        <div
           class="widget-combobox-text-label"
         >
           111
-        </span>
+        </div>
       </div>
       <button
         class="widget-combobox-clear-button"
@@ -249,11 +249,11 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
           role="combobox"
           value=""
         />
-        <span
+        <div
           class="widget-combobox-text-label"
         >
           111
-        </span>
+        </div>
       </div>
       <button
         class="widget-combobox-clear-button"

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
@@ -33,7 +33,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
           class="widget-combobox-placeholder-text"
         >
           <span
-            class="widget-combobox-caption"
+            class="widget-combobox-caption-text"
           >
             111
           </span>

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
@@ -29,7 +29,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
           tabindex="0"
           value="111"
         />
-        <span
+        <div
           class="widget-combobox-text-label"
         >
           <span
@@ -37,7 +37,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
           >
             111
           </span>
-        </span>
+        </div>
       </div>
       <button
         class="widget-combobox-clear-button"

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
@@ -30,7 +30,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
           value="111"
         />
         <div
-          class="widget-combobox-text-label"
+          class="widget-combobox-label-text"
         >
           <span
             class="widget-combobox-caption"

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
@@ -32,7 +32,11 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
         <span
           class="widget-combobox-text-label"
         >
-          111
+          <span
+            class="widget-combobox-caption"
+          >
+            111
+          </span>
         </span>
       </div>
       <button

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
@@ -30,7 +30,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
           value="111"
         />
         <div
-          class="widget-combobox-label-text"
+          class="widget-combobox-placeholder-text"
         >
           <span
             class="widget-combobox-caption"

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
@@ -39,7 +39,7 @@ export function MultiSelection({ selector, tabIndex, ...options }: SelectionBase
                     {(selector.selectedItemsStyle === "boxes" || selector.customContentType === "yes") &&
                         selectedItems.map((selectedItemForRender, index) => {
                             return (
-                                <span
+                                <div
                                     className="widget-combobox-selected-item"
                                     key={selectedItemForRender}
                                     {...getSelectedItemProps({
@@ -57,7 +57,7 @@ export function MultiSelection({ selector, tabIndex, ...options }: SelectionBase
                                     >
                                         <ClearButton size={10} />
                                     </span>
-                                </span>
+                                </div>
                             );
                         })}
                     <input

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
@@ -36,7 +36,7 @@ export function MultiSelection({ selector, tabIndex, ...options }: SelectionBase
                         `widget-combobox-${selector.selectedItemsStyle}`
                     )}
                 >
-                    {selector.selectedItemsStyle === "boxes" &&
+                    {(selector.selectedItemsStyle === "boxes" || selector.customContentType === "yes") &&
                         selectedItems.map((selectedItemForRender, index) => {
                             return (
                                 <span
@@ -47,7 +47,7 @@ export function MultiSelection({ selector, tabIndex, ...options }: SelectionBase
                                         index
                                     })}
                                 >
-                                    {selector.caption.render(selectedItemForRender)}
+                                    {selector.caption.render(selectedItemForRender, "label")}
                                     <span
                                         className="icon widget-combobox-clear-button"
                                         onClick={e => {

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
@@ -45,7 +45,7 @@ export function MultiSelectionMenu({
                             index={index}
                         >
                             <Checkbox checked={isSelected} />
-                            {selector.caption.render(item)}
+                            {selector.caption.render(item, "options")}
                         </ComboboxOptionWrapper>
                     );
                 })}

--- a/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { PropsWithChildren, ReactElement, createElement } from "react";
+import { PropsWithChildren, ReactElement, createElement, Fragment } from "react";
 import { DownArrow } from "../assets/icons";
 
 export function Placeholder(): ReactElement {
@@ -22,8 +22,13 @@ export function NoOptionsPlaceholder(props: PropsWithChildren): ReactElement {
 
 interface InputPlaceholderProps extends PropsWithChildren {
     isEmpty: boolean;
+    useWrapper?: boolean;
 }
 export function InputPlaceholder(props: InputPlaceholderProps): ReactElement {
+    if (props.useWrapper === false) {
+        return <Fragment>{props.children}</Fragment>;
+    }
+
     return (
         <span
             className={classNames("widget-combobox-text-label", {

--- a/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
@@ -27,8 +27,8 @@ interface InputPlaceholderProps extends PropsWithChildren {
 export function InputPlaceholder(props: InputPlaceholderProps): ReactElement {
     return (
         <div
-            className={classNames(props.className || "widget-combobox-label-text", {
-                "widget-combobox-label-text-placeholder": props.isEmpty
+            className={classNames(props.className || "widget-combobox-placeholder-text", {
+                "widget-combobox-placeholder-empty": props.isEmpty
             })}
         >
             {props.children}

--- a/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { PropsWithChildren, ReactElement, createElement, Fragment } from "react";
+import { PropsWithChildren, ReactElement, createElement } from "react";
 import { DownArrow } from "../assets/icons";
 
 export function Placeholder(): ReactElement {
@@ -22,17 +22,13 @@ export function NoOptionsPlaceholder(props: PropsWithChildren): ReactElement {
 
 interface InputPlaceholderProps extends PropsWithChildren {
     isEmpty: boolean;
-    useWrapper?: boolean;
+    className?: string;
 }
 export function InputPlaceholder(props: InputPlaceholderProps): ReactElement {
-    if (props.useWrapper === false) {
-        return <Fragment>{props.children}</Fragment>;
-    }
-
     return (
         <div
-            className={classNames("widget-combobox-text-label", {
-                "widget-combobox-text-label-placeholder": props.isEmpty
+            className={classNames(props.className || "widget-combobox-label-text", {
+                "widget-combobox-label-text-placeholder": props.isEmpty
             })}
         >
             {props.children}

--- a/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
@@ -22,12 +22,12 @@ export function NoOptionsPlaceholder(props: PropsWithChildren): ReactElement {
 
 interface InputPlaceholderProps extends PropsWithChildren {
     isEmpty: boolean;
-    className?: string;
+    type?: "text" | "custom";
 }
 export function InputPlaceholder(props: InputPlaceholderProps): ReactElement {
     return (
         <div
-            className={classNames(props.className || "widget-combobox-placeholder-text", {
+            className={classNames(`widget-combobox-placeholder-${props.type ?? "text"}`, {
                 "widget-combobox-placeholder-empty": props.isEmpty
             })}
         >

--- a/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/Placeholder.tsx
@@ -30,12 +30,12 @@ export function InputPlaceholder(props: InputPlaceholderProps): ReactElement {
     }
 
     return (
-        <span
+        <div
             className={classNames("widget-combobox-text-label", {
                 "widget-combobox-text-label-placeholder": props.isEmpty
             })}
         >
             {props.children}
-        </span>
+        </div>
     );
 }

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -42,8 +42,11 @@ export function SingleSelection({
                         )}
                         placeholder=" "
                     />
-                    <InputPlaceholder isEmpty={!selector.currentValue}>
-                        {selector.caption.get(selectedItem)}
+                    <InputPlaceholder
+                        isEmpty={!selector.currentValue}
+                        useWrapper={selector.customContentType !== "yes"}
+                    >
+                        {selector.caption.render(selectedItem, "label")}
                     </InputPlaceholder>
                 </div>
                 {!selector.readOnly && selector.clearable && selector.currentValue !== null && (

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -48,7 +48,7 @@ export function SingleSelection({
                     />
                     <InputPlaceholder
                         isEmpty={!selector.currentValue}
-                        useWrapper={selector.customContentType !== "yes"}
+                        className={selector.customContentType === "yes" ? "widget-combobox-label-custom" : undefined}
                     >
                         {selector.caption.render(selectedItem, "label")}
                     </InputPlaceholder>

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -26,7 +26,11 @@ export function SingleSelection({
     return (
         <Fragment>
             <ComboboxWrapper isOpen={isOpen} readOnly={selector.readOnly} getToggleButtonProps={getToggleButtonProps}>
-                <div className="widget-combobox-selected-items">
+                <div
+                    className={classNames("widget-combobox-selected-items", {
+                        "widget-combobox-custom-content": selector.customContentType === "yes"
+                    })}
+                >
                     <input
                         className={classNames("widget-combobox-input", {
                             "widget-combobox-input-nofilter": selector.options.filterType === "none"

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -48,9 +48,7 @@ export function SingleSelection({
                     />
                     <InputPlaceholder
                         isEmpty={!selector.currentValue}
-                        className={
-                            selector.customContentType === "yes" ? "widget-combobox-placeholder-custom" : undefined
-                        }
+                        type={selector.customContentType === "yes" ? "custom" : "text"}
                     >
                         {selector.caption.render(selectedItem, "label")}
                     </InputPlaceholder>

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -48,7 +48,9 @@ export function SingleSelection({
                     />
                     <InputPlaceholder
                         isEmpty={!selector.currentValue}
-                        className={selector.customContentType === "yes" ? "widget-combobox-label-custom" : undefined}
+                        className={
+                            selector.customContentType === "yes" ? "widget-combobox-placeholder-custom" : undefined
+                        }
                     >
                         {selector.caption.render(selectedItem, "label")}
                     </InputPlaceholder>

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
@@ -38,7 +38,7 @@ export function SingleSelectionMenu({
                         getItemProps={getItemProps}
                         index={index}
                     >
-                        {selector.caption.render(item)}
+                        {selector.caption.render(item, "options")}
                     </ComboboxOptionWrapper>
                 ))}
         </ComboboxMenuWrapper>

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationSimpleCaptionsProvider.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationSimpleCaptionsProvider.tsx
@@ -1,15 +1,20 @@
+import { DynamicValue, ListAttributeValue, ListExpressionValue, ListWidgetValue, ObjectItem } from "mendix";
 import { ReactNode, createElement } from "react";
-import { DynamicValue, ListAttributeValue, ListExpressionValue, ObjectItem } from "mendix";
-import { CaptionsProvider } from "../types";
+import { OptionsSourceAssociationCustomContentTypeEnum } from "../../../typings/ComboboxProps";
+import { CaptionPlacement, CaptionsProvider } from "../types";
 
-interface Props {
+export interface Props {
     emptyOptionText?: DynamicValue<string>;
     formattingAttributeOrExpression: ListExpressionValue<string> | ListAttributeValue<string>;
+    customContent?: ListWidgetValue | undefined;
+    customContentType: OptionsSourceAssociationCustomContentTypeEnum;
 }
 
 export class AssociationSimpleCaptionsProvider implements CaptionsProvider {
     private unavailableCaption = "<...>";
     private formatter?: ListExpressionValue<string> | ListAttributeValue<string>;
+    protected customContent?: ListWidgetValue;
+    protected customContentType: OptionsSourceAssociationCustomContentTypeEnum = "no";
     emptyCaption = "";
 
     constructor(private optionsMap: Map<string, ObjectItem>) {}
@@ -22,6 +27,8 @@ export class AssociationSimpleCaptionsProvider implements CaptionsProvider {
         }
 
         this.formatter = props.formattingAttributeOrExpression;
+        this.customContent = props.customContent;
+        this.customContentType = props.customContentType;
     }
 
     get(value: string | null): string {
@@ -35,6 +42,7 @@ export class AssociationSimpleCaptionsProvider implements CaptionsProvider {
         if (!item) {
             return this.unavailableCaption;
         }
+
         const captionValue = this.formatter.get(item);
         if (captionValue.status === "unavailable") {
             return this.unavailableCaption;
@@ -43,7 +51,25 @@ export class AssociationSimpleCaptionsProvider implements CaptionsProvider {
         return captionValue.value ?? "";
     }
 
-    render(value: string | null): ReactNode {
-        return <span className="widget-combobox-caption">{this.get(value)}</span>;
+    getCustomContent(value: string | null): ReactNode | null {
+        if (value === null) {
+            return null;
+        }
+        const item = this.optionsMap.get(value);
+        if (!item) {
+            return null;
+        }
+
+        return this.customContent?.get(item);
+    }
+
+    render(value: string | null, placement: CaptionPlacement): ReactNode {
+        const { customContentType } = this;
+
+        return customContentType === "no" || (placement === "label" && customContentType === "listItem") ? (
+            <span className="widget-combobox-caption">{this.get(value)}</span>
+        ) : (
+            <div className="widget-combobox-custom-caption">{this.getCustomContent(value)}</div>
+        );
     }
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationSimpleCaptionsProvider.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationSimpleCaptionsProvider.tsx
@@ -3,7 +3,7 @@ import { ReactNode, createElement } from "react";
 import { OptionsSourceAssociationCustomContentTypeEnum } from "../../../typings/ComboboxProps";
 import { CaptionPlacement, CaptionsProvider } from "../types";
 
-export interface Props {
+interface Props {
     emptyOptionText?: DynamicValue<string>;
     formattingAttributeOrExpression: ListExpressionValue<string> | ListAttributeValue<string>;
     customContent?: ListWidgetValue | undefined;
@@ -69,7 +69,7 @@ export class AssociationSimpleCaptionsProvider implements CaptionsProvider {
         return customContentType === "no" || (placement === "label" && customContentType === "listItem") ? (
             <span className="widget-combobox-caption">{this.get(value)}</span>
         ) : (
-            <div className="widget-combobox-custom-caption">{this.getCustomContent(value)}</div>
+            <div className="widget-combobox-caption-custom">{this.getCustomContent(value)}</div>
         );
     }
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationSimpleCaptionsProvider.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationSimpleCaptionsProvider.tsx
@@ -69,7 +69,7 @@ export class AssociationSimpleCaptionsProvider implements CaptionsProvider {
         return customContentType === "no" ||
             (placement === "label" && customContentType === "listItem") ||
             value === null ? (
-            <span className="widget-combobox-caption">{this.get(value)}</span>
+            <span className="widget-combobox-caption-text">{this.get(value)}</span>
         ) : (
             <div className="widget-combobox-caption-custom">{this.getCustomContent(value)}</div>
         );

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationSimpleCaptionsProvider.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationSimpleCaptionsProvider.tsx
@@ -66,7 +66,9 @@ export class AssociationSimpleCaptionsProvider implements CaptionsProvider {
     render(value: string | null, placement: CaptionPlacement): ReactNode {
         const { customContentType } = this;
 
-        return customContentType === "no" || (placement === "label" && customContentType === "listItem") ? (
+        return customContentType === "no" ||
+            (placement === "label" && customContentType === "listItem") ||
+            value === null ? (
             <span className="widget-combobox-caption">{this.get(value)}</span>
         ) : (
             <div className="widget-combobox-caption-custom">{this.getCustomContent(value)}</div>

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/BaseAssociationSelector.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/BaseAssociationSelector.ts
@@ -1,5 +1,5 @@
 import { ObjectItem, ReferenceValue, ReferenceSetValue, ActionValue } from "mendix";
-import { ComboboxContainerProps } from "../../../typings/ComboboxProps";
+import { ComboboxContainerProps, OptionsSourceAssociationCustomContentTypeEnum } from "../../../typings/ComboboxProps";
 import { Status } from "../types";
 import { AssociationOptionsProvider } from "./AssociationOptionsProvider";
 import { AssociationSimpleCaptionsProvider } from "./AssociationSimpleCaptionsProvider";
@@ -13,6 +13,7 @@ export class BaseAssociationSelector<T extends string | string[], R extends Refe
     currentValue: T | null = null;
     caption: AssociationSimpleCaptionsProvider;
     readOnly = false;
+    customContentType: OptionsSourceAssociationCustomContentTypeEnum = "no";
     protected _attr: R | undefined;
     private onChangeEvent?: ActionValue;
 
@@ -24,12 +25,23 @@ export class BaseAssociationSelector<T extends string | string[], R extends Refe
     }
 
     updateProps(props: ComboboxContainerProps): void {
-        const [attr, ds, captionProvider, emptyOption, clearable, filterType, onChangeEvent] =
-            extractAssociationProps(props);
+        const [
+            attr,
+            ds,
+            captionProvider,
+            emptyOption,
+            clearable,
+            filterType,
+            onChangeEvent,
+            customContent,
+            customContentType
+        ] = extractAssociationProps(props);
         this._attr = attr as R;
         this.caption.updateProps({
             emptyOptionText: emptyOption,
-            formattingAttributeOrExpression: captionProvider
+            formattingAttributeOrExpression: captionProvider,
+            customContent,
+            customContentType
         });
 
         this.options._updateProps({
@@ -57,6 +69,7 @@ export class BaseAssociationSelector<T extends string | string[], R extends Refe
         this.status = attr.status;
         this.readOnly = attr.readOnly;
         this.onChangeEvent = onChangeEvent;
+        this.customContentType = customContentType;
     }
 
     setValue(_value: T | null): void {

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/utils.ts
@@ -3,11 +3,16 @@ import {
     ReferenceValue,
     ReferenceSetValue,
     ListValue,
+    ListWidgetValue,
     ListAttributeValue,
     ListExpressionValue,
     DynamicValue
 } from "mendix";
-import { ComboboxContainerProps, FilterTypeEnum } from "../../../typings/ComboboxProps";
+import {
+    ComboboxContainerProps,
+    FilterTypeEnum,
+    OptionsSourceAssociationCustomContentTypeEnum
+} from "../../../typings/ComboboxProps";
 
 type ExtractionReturnValue = [
     ReferenceValue | ReferenceSetValue,
@@ -16,7 +21,9 @@ type ExtractionReturnValue = [
     DynamicValue<string> | undefined,
     boolean,
     FilterTypeEnum,
-    ActionValue | undefined
+    ActionValue | undefined,
+    ListWidgetValue | undefined,
+    OptionsSourceAssociationCustomContentTypeEnum
 ];
 
 export function extractAssociationProps(props: ComboboxContainerProps): ExtractionReturnValue {
@@ -50,6 +57,8 @@ export function extractAssociationProps(props: ComboboxContainerProps): Extracti
     }
     const emptyOption = props.emptyOptionText;
     const clearable = props.clearable;
+    const customContent = props.optionsSourceAssociationCustomContent;
+    const customContentType = props.optionsSourceAssociationCustomContentType;
 
     return [
         attr,
@@ -58,6 +67,8 @@ export function extractAssociationProps(props: ComboboxContainerProps): Extracti
         emptyOption,
         clearable,
         filterType,
-        onChangeEvent
+        onChangeEvent,
+        customContent,
+        customContentType
     ];
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/EnumBool/EnumAndBooleanSimpleCaptionsProvider.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/EnumBool/EnumAndBooleanSimpleCaptionsProvider.tsx
@@ -28,6 +28,6 @@ export class EnumAndBooleanSimpleCaptionsProvider implements CaptionsProvider {
     }
 
     render(value: string | null): ReactNode {
-        return <span className="widget-combobox-caption">{this.get(value)}</span>;
+        return <span className="widget-combobox-caption-text">{this.get(value)}</span>;
     }
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/EnumBool/EnumAndBooleanSimpleCaptionsProvider.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/EnumBool/EnumAndBooleanSimpleCaptionsProvider.tsx
@@ -28,6 +28,6 @@ export class EnumAndBooleanSimpleCaptionsProvider implements CaptionsProvider {
     }
 
     render(value: string | null): ReactNode {
-        return <span>{this.get(value)}</span>;
+        return <span className="widget-combobox-caption">{this.get(value)}</span>;
     }
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/EnumBool/EnumBoolSingleSelector.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/EnumBool/EnumBoolSingleSelector.tsx
@@ -1,6 +1,6 @@
 import { executeAction } from "@mendix/widget-plugin-platform/framework/execute-action";
 import { ActionValue, EditableValue } from "mendix";
-import { ComboboxContainerProps } from "../../../typings/ComboboxProps";
+import { ComboboxContainerProps, OptionsSourceAssociationCustomContentTypeEnum } from "../../../typings/ComboboxProps";
 import { SingleSelector, Status } from "../types";
 import { EnumAndBooleanSimpleCaptionsProvider } from "./EnumAndBooleanSimpleCaptionsProvider";
 import { EnumBoolOptionsProvider } from "./EnumBoolOptionsProvider";
@@ -16,6 +16,7 @@ export class EnumBooleanSingleSelector implements SingleSelector {
     currentValue: string | null = null;
     caption: EnumAndBooleanSimpleCaptionsProvider;
     options: EnumBoolOptionsProvider<string | boolean>;
+    customContentType: OptionsSourceAssociationCustomContentTypeEnum = "no";
     clearable = true;
     readOnly = false;
 

--- a/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
@@ -1,13 +1,19 @@
 import { ReactNode } from "react";
-import { ComboboxContainerProps, FilterTypeEnum, SelectedItemsStyleEnum } from "../../typings/ComboboxProps";
+import {
+    ComboboxContainerProps,
+    FilterTypeEnum,
+    OptionsSourceAssociationCustomContentTypeEnum,
+    SelectedItemsStyleEnum
+} from "../../typings/ComboboxProps";
 
 export type Status = "unavailable" | "loading" | "available";
+export type CaptionPlacement = "label" | "options";
 export type SelectionType = "single" | "multi";
 export type Selector = SingleSelector | MultiSelector;
 
 export interface CaptionsProvider {
     get(value: string | null): string;
-    render(value: string | null): ReactNode;
+    render(value: string | null, placement?: CaptionPlacement): ReactNode;
     emptyCaption: string;
 }
 
@@ -49,6 +55,8 @@ interface SelectorBase<T, V> {
 
     currentValue: V | null;
     setValue(value: V | null): void;
+
+    customContentType: OptionsSourceAssociationCustomContentTypeEnum;
 }
 
 export interface SingleSelector extends SelectorBase<"single", string> {}

--- a/packages/pluggableWidgets/combobox-web/src/helpers/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/utils.ts
@@ -6,7 +6,7 @@ export function getSelectedCaptionsPlaceholder(selector: MultiSelector, selected
         return selector.caption.emptyCaption;
     }
 
-    if (selector.selectedItemsStyle !== "text") {
+    if (selector.selectedItemsStyle !== "text" || selector.customContentType === "yes") {
         return "";
     }
     return selectedItems.map(v => selector.caption.get(v)).join(", ");

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
@@ -27,6 +27,9 @@ export function useDownshiftSingleSelectProps(
             itemToString: (v: string | null) => selector.caption.get(v),
             onSelectedItemChange({ selectedItem }: UseComboboxStateChange<string>) {
                 selector.setValue(selectedItem ?? null);
+                if (inputId) {
+                    document.getElementById(inputId)?.blur();
+                }
             },
             onInputValueChange({ inputValue }) {
                 selector.options.setSearchTerm(inputValue!);
@@ -36,7 +39,7 @@ export function useDownshiftSingleSelectProps(
             initialInputValue: selector.caption.get(selector.currentValue),
             stateReducer(state: UseComboboxState<string>, actionAndChanges: UseComboboxStateChangeOptions<string>) {
                 const { changes, type } = actionAndChanges;
-
+                console.log(changes, type);
                 switch (type) {
                     case useCombobox.stateChangeTypes.ToggleButtonClick:
                         return {

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
@@ -39,7 +39,6 @@ export function useDownshiftSingleSelectProps(
             initialInputValue: selector.caption.get(selector.currentValue),
             stateReducer(state: UseComboboxState<string>, actionAndChanges: UseComboboxStateChangeOptions<string>) {
                 const { changes, type } = actionAndChanges;
-                console.log(changes, type);
                 switch (type) {
                     case useCombobox.stateChangeTypes.ToggleButtonClick:
                         return {

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -147,9 +147,7 @@ $disabled-text-color: #6c7180;
         justify-content: flex-end !important;
         border: 1px solid #e7e7e9;
         cursor: not-allowed;
-    }
 
-    &-label {
         &-text {
             color: $typography-color;
             position: absolute;
@@ -162,10 +160,10 @@ $disabled-text-color: #6c7180;
             white-space: nowrap;
             pointer-events: none;
             display: none;
+        }
 
-            &.widget-combobox-label-text-placeholder {
-                color: $gray-dark;
-            }
+        &-empty {
+            color: $gray-dark;
         }
     }
 
@@ -184,7 +182,7 @@ $disabled-text-color: #6c7180;
                 right: 0;
                 bottom: 0;
             }
-            &:focus:not(:placeholder-shown) + .widget-combobox-label-custom {
+            &:focus:not(:placeholder-shown) + .widget-combobox-placeholder-custom {
                 display: none;
             }
         }
@@ -209,7 +207,7 @@ $disabled-text-color: #6c7180;
 
             input:placeholder-shown,
             input:not(:focus) {
-                & + .widget-combobox-label-text {
+                & + .widget-combobox-placeholder-text {
                     display: block;
                 }
             }

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -173,12 +173,18 @@ $disabled-text-color: #6c7180;
         flex-grow: 1;
         flex-direction: column;
 
-        .widget-combobox-input:not(:focus) {
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
+        .widget-combobox-input {
+            &:not(:focus),
+            &:placeholder-shown {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+            }
+            &:focus:not(:placeholder-shown) + .widget-combobox-custom-caption {
+                display: none;
+            }
         }
     }
 

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -63,7 +63,7 @@ $disabled-text-color: #6c7180;
             margin-right: 10px;
         }
 
-        .widget-combobox-caption {
+        .widget-combobox-caption-text {
             text-overflow: ellipsis;
             overflow: hidden;
             white-space: nowrap;

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -67,6 +67,7 @@ $disabled-text-color: #6c7180;
             text-overflow: ellipsis;
             overflow: hidden;
             white-space: nowrap;
+            flex: 1;
         }
 
         &.widget-combobox-no-options {
@@ -163,6 +164,21 @@ $disabled-text-color: #6c7180;
 
         &.widget-combobox-text-label-placeholder {
             color: $gray-dark;
+        }
+    }
+
+    &-custom-content {
+        position: relative;
+        display: flex;
+        flex-grow: 1;
+        flex-direction: column;
+
+        .widget-combobox-input:not(:focus) {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
         }
     }
 

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -149,21 +149,23 @@ $disabled-text-color: #6c7180;
         cursor: not-allowed;
     }
 
-    &-text-label {
-        color: $typography-color;
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 0;
-        bottom: 0;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-        pointer-events: none;
-        display: none;
+    &-label {
+        &-text {
+            color: $typography-color;
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            pointer-events: none;
+            display: none;
 
-        &.widget-combobox-text-label-placeholder {
-            color: $gray-dark;
+            &.widget-combobox-label-text-placeholder {
+                color: $gray-dark;
+            }
         }
     }
 
@@ -182,7 +184,7 @@ $disabled-text-color: #6c7180;
                 right: 0;
                 bottom: 0;
             }
-            &:focus:not(:placeholder-shown) + .widget-combobox-custom-caption {
+            &:focus:not(:placeholder-shown) + .widget-combobox-label-custom {
                 display: none;
             }
         }
@@ -207,7 +209,7 @@ $disabled-text-color: #6c7180;
 
             input:placeholder-shown,
             input:not(:focus) {
-                & + .widget-combobox-text-label {
+                & + .widget-combobox-label-text {
                     display: block;
                 }
             }

--- a/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
+++ b/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
@@ -3,13 +3,16 @@
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix Widgets Framework Team
  */
-import { ActionValue, DynamicValue, EditableValue, ListValue, ListAttributeValue, ListExpressionValue, ReferenceValue, ReferenceSetValue } from "mendix";
+import { ComponentType, ReactNode } from "react";
+import { ActionValue, DynamicValue, EditableValue, ListValue, ListAttributeValue, ListExpressionValue, ListWidgetValue, ReferenceValue, ReferenceSetValue } from "mendix";
 
 export type OptionsSourceTypeEnum = "association" | "enumeration" | "boolean";
 
 export type OptionsSourceAssociationCaptionTypeEnum = "attribute" | "expression";
 
 export type FilterTypeEnum = "contains" | "startsWith" | "none";
+
+export type OptionsSourceAssociationCustomContentTypeEnum = "yes" | "listItem" | "no";
 
 export type SelectedItemsStyleEnum = "text" | "boxes";
 
@@ -29,6 +32,8 @@ export interface ComboboxContainerProps {
     filterType: FilterTypeEnum;
     noOptionsText?: DynamicValue<string>;
     clearable: boolean;
+    optionsSourceAssociationCustomContentType: OptionsSourceAssociationCustomContentTypeEnum;
+    optionsSourceAssociationCustomContent?: ListWidgetValue;
     selectedItemsStyle: SelectedItemsStyleEnum;
     onChangeEvent?: ActionValue;
     onEnterEvent?: ActionValue;
@@ -50,6 +55,8 @@ export interface ComboboxPreviewProps {
     filterType: FilterTypeEnum;
     noOptionsText: string;
     clearable: boolean;
+    optionsSourceAssociationCustomContentType: OptionsSourceAssociationCustomContentTypeEnum;
+    optionsSourceAssociationCustomContent: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     selectedItemsStyle: SelectedItemsStyleEnum;
     onChangeEvent: {} | null;
     onEnterEvent: {} | null;


### PR DESCRIPTION
### Pull request type

New feature:
Add custom content dropzone on combo-box



### Description
adding new property:
`optionsSourceAssociationCustomContentType` -> Yes, List Item, No
`optionsSourceAssociationCustomContent` -> widgets

general implementation:
Association-Caption  has to know when to render custom content and normal text, thus the load of figuring out which one to render falls into the caption-renderer.

upon implmentation:
- caption-renderer must know where to render: `type CaptionPlacement = "label" | "options";`
- this placement then matched with `optionsSourceAssociationCustomContentType` property to help caption-renderer figuring out correct component to render
- apparently, custom content must be rendered before input element, this adds logic complexity in SingleSelection, which is solved by using different classnames.
- as for multiSelection, custom content will always rendered using "boxes" styling, with "x" to clear option available on each item.