### PR TITLE
feat(datagrid-web): add column visible

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -179,6 +179,7 @@ export const getPreview = (
                   dynamicText: "Dynamic text",
                   draggable: false,
                   hidable: "no",
+                  visible: "true",
                   size: 1,
                   sortable: false,
                   alignment: "left",

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -248,27 +248,44 @@ export const getPreview = (
                         : undefined,
                 backgroundColor: isColumnHidden ? modeColor("#4F4F4F", "#DCDCDC") : palette.background.topbarStandard
             })(
-                container({
-                    padding: 8
+                rowLayout({
+                    columnSize: "grow"
                 })(
-                    text({
-                        bold: true,
-                        fontSize: 10,
-                        fontColor: column.header
-                            ? undefined
-                            : isColumnHidden
-                            ? modeColor("#4F4F4F", "#DCDCDC")
-                            : palette.text.secondary
-                    })(column.header ? column.header : "Header")
-                ),
-                ...(hasColumns && values.columnsFilterable
-                    ? [
-                          dropzone(
-                              dropzone.placeholder("Place filter widget here"),
-                              dropzone.hideDataSourceHeaderIf(canHideDataSourceHeader)
-                          )(column.filter)
-                      ]
-                    : [])
+                    container({
+                        grow: 0,
+                        backgroundColor: "#AEEdAA"
+                    })(
+                        container({
+                            padding: column.visible.trim() === "" || column.visible.trim() === "true" ? 0 : 3
+                        })()
+                    ),
+                    container({
+                        padding: 8
+                    })(
+                        container({
+                            grow: 1,
+                            padding: 8
+                        })(
+                            text({
+                                bold: true,
+                                fontSize: 10,
+                                fontColor: column.header
+                                    ? undefined
+                                    : isColumnHidden
+                                    ? modeColor("#4F4F4F", "#DCDCDC")
+                                    : palette.text.secondary
+                            })(column.header ? column.header : "Header")
+                        ),
+                        ...(hasColumns && values.columnsFilterable
+                            ? [
+                                  dropzone(
+                                      dropzone.placeholder("Place filter widget here"),
+                                      dropzone.hideDataSourceHeaderIf(canHideDataSourceHeader)
+                                  )(column.filter)
+                              ]
+                            : [])
+                    )
+                )
             );
             return values.columns.length > 0
                 ? selectable(column, { grow: column.width === "manual" && column.size ? column.size : 1 })(

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -35,6 +35,7 @@ const initColumns: ColumnsPreviewType[] = [
         dynamicText: "Dynamic Text",
         draggable: false,
         hidable: "no",
+        visible: "true",
         size: 1,
         sortable: false,
         alignment: "left",

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -92,7 +92,10 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
     }
 
     const columns = useMemo(
-        () => props.columns.map((col, index) => new Column(col, index, id.current)),
+        () =>
+            props.columns
+                .filter(col => col.visible?.value ?? true)
+                .map((col, index) => new Column(col, index, id.current)),
         [props.columns]
     );
 

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -108,6 +108,11 @@
                                 <description />
                                 <returnType type="String" />
                             </property>
+                            <property key="visible" type="expression" required="false" defaultValue="true">
+                                <caption>Visible</caption>
+                                <description />
+                                <returnType type="Boolean" />
+                            </property>
                         </propertyGroup>
                         <propertyGroup caption="Column capabilities">
                             <property key="sortable" type="boolean" defaultValue="true">
@@ -130,11 +135,6 @@
                                     <enumerationValue key="hidden">Yes, hidden by default</enumerationValue>
                                     <enumerationValue key="no">No</enumerationValue>
                                 </enumerationValues>
-                            </property>
-                            <property key="visible" type="expression" required="false" defaultValue="true">
-                                <caption>Visible</caption>
-                                <description />
-                                <returnType type="Boolean" />
                             </property>
                         </propertyGroup>
                         <propertyGroup caption="Appearance">

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -131,6 +131,11 @@
                                     <enumerationValue key="no">No</enumerationValue>
                                 </enumerationValues>
                             </property>
+                            <property key="visible" type="expression" required="false" defaultValue="true">
+                                <caption>Visible</caption>
+                                <description />
+                                <returnType type="Boolean" />
+                            </property>
                         </propertyGroup>
                         <propertyGroup caption="Appearance">
                             <property key="width" type="enumeration" defaultValue="autoFill">

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -28,11 +28,11 @@ export interface ColumnsType {
     filterAssociation?: ListReferenceValue | ListReferenceSetValue;
     filterAssociationOptions?: ListValue;
     filterAssociationOptionLabel?: ListExpressionValue<string>;
+    visible?: DynamicValue<boolean>;
     sortable: boolean;
     resizable: boolean;
     draggable: boolean;
     hidable: HidableEnum;
-    visible?: DynamicValue<boolean>;
     width: WidthEnum;
     size: number;
     alignment: AlignmentEnum;
@@ -61,11 +61,11 @@ export interface ColumnsPreviewType {
     filterAssociation: string;
     filterAssociationOptions: {} | { caption: string } | { type: string } | null;
     filterAssociationOptionLabel: string;
+    visible: string;
     sortable: boolean;
     resizable: boolean;
     draggable: boolean;
     hidable: HidableEnum;
-    visible: string;
     width: WidthEnum;
     size: number | null;
     alignment: AlignmentEnum;

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -32,6 +32,7 @@ export interface ColumnsType {
     resizable: boolean;
     draggable: boolean;
     hidable: HidableEnum;
+    visible?: DynamicValue<boolean>;
     width: WidthEnum;
     size: number;
     alignment: AlignmentEnum;
@@ -64,6 +65,7 @@ export interface ColumnsPreviewType {
     resizable: boolean;
     draggable: boolean;
     hidable: HidableEnum;
+    visible: string;
     width: WidthEnum;
     size: number | null;
     alignment: AlignmentEnum;


### PR DESCRIPTION
When Using the data grid 2, depending on the the context come columns do not need to be shown. 
By adding  'Visible' expression to the column, the developer can specify when the column need to be shown.
This PR includes an highlight for Visibility in the structured mode.

![image](https://github.com/mendix/web-widgets/assets/6724749/ab03e133-1db8-40d5-b0f1-8725f267e917)


