### PR TITLE
[WC-2147] open combobox menu on clicking container

### DIFF
--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -13,9 +13,9 @@ import { createElement } from "react";
 import { ComboboxContainerProps } from "../../typings/ComboboxProps";
 import Combobox from "../Combobox";
 
-//function helper to ease DOM changes in development
+// function helper to ease DOM changes in development
 async function getToggleButton(component: RenderResult) {
-    return await component.container.querySelector(".widget-combobox-down-arrow")!;
+    return component.container.querySelector(".widget-combobox-down-arrow")!;
 }
 async function getInput(component: RenderResult): Promise<HTMLInputElement> {
     return (await component.findByRole("combobox")) as HTMLInputElement;

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -7,11 +7,19 @@ import {
     ReferenceValueBuilder
 } from "@mendix/widget-plugin-test-utils";
 import "@testing-library/jest-dom";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, RenderResult } from "@testing-library/react";
 import { ObjectItem, DynamicValue } from "mendix";
 import { createElement } from "react";
 import { ComboboxContainerProps } from "../../typings/ComboboxProps";
 import Combobox from "../Combobox";
+
+//function helper to ease DOM changes in development
+async function getToggleButton(component: RenderResult) {
+    return await component.container.querySelector(".widget-combobox-down-arrow")!;
+}
+async function getInput(component: RenderResult): Promise<HTMLInputElement> {
+    return (await component.findByRole("combobox")) as HTMLInputElement;
+}
 
 describe("Combo box (Association)", () => {
     let defaultProps: ComboboxContainerProps;
@@ -56,17 +64,9 @@ describe("Combo box (Association)", () => {
         const { container } = render(<Combobox {...defaultProps} />);
         expect(container.getElementsByClassName("widget-combobox-placeholder")).toHaveLength(1);
     });
-    it("toggles combobox menu on: input FOCUS / BLUR", async () => {
-        const component = render(<Combobox {...defaultProps} />);
-        const toggleButton = await component.findByRole("combobox");
-        fireEvent.focus(toggleButton);
-        expect(component.getAllByRole("option")).toHaveLength(4);
-        fireEvent.blur(toggleButton);
-        expect(component.queryAllByRole("option")).toHaveLength(0);
-    });
     it("toggles combobox menu on: input TOGGLE BUTTON", async () => {
         const component = render(<Combobox {...defaultProps} />);
-        const toggleButton = await component.container.querySelector(".widget-combobox-down-arrow")!;
+        const toggleButton = await getToggleButton(component);
         fireEvent.click(toggleButton);
         expect(component.getAllByRole("option")).toHaveLength(4);
         fireEvent.click(toggleButton);
@@ -74,8 +74,9 @@ describe("Combo box (Association)", () => {
     });
     it("sets option to selected item", async () => {
         const component = render(<Combobox {...defaultProps} />);
-        const input = (await component.findByRole("combobox")) as HTMLInputElement;
-        fireEvent.focus(input);
+        const input = await getInput(component);
+        const toggleButton = await getToggleButton(component);
+        fireEvent.click(toggleButton);
         const option1 = await component.findByText("222");
         fireEvent.click(option1);
         expect(input.value).toEqual("222");
@@ -86,9 +87,10 @@ describe("Combo box (Association)", () => {
     it("removes selected item", async () => {
         const component = render(<Combobox {...defaultProps} />);
 
-        const input = (await component.findByRole("combobox")) as HTMLInputElement;
+        const input = await getInput(component);
         const labelText = await component.container.getElementsByClassName("widget-combobox-text-label")[0];
-        fireEvent.focus(input);
+        const toggleButton = await getToggleButton(component);
+        fireEvent.click(toggleButton);
 
         const option1 = await component.findByText("222");
         fireEvent.click(option1);

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
@@ -6,7 +6,10 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
     class="widget-combobox"
   >
     <div
+      aria-controls="downshift-12-menu"
+      aria-expanded="true"
       class="form-control widget-combobox-input-container widget-combobox-input-container-active"
+      id="downshift-12-toggle-button"
       tabindex="-1"
     >
       <div
@@ -54,11 +57,7 @@ exports[`Combo box (Association) adds new item to inital selected item 1`] = `
         </span>
       </button>
       <div
-        aria-controls="downshift-12-menu"
-        aria-expanded="true"
         class="widget-combobox-down-arrow"
-        id="downshift-12-toggle-button"
-        tabindex="-1"
       >
         <span
           class="widget-combobox-icon-container"
@@ -228,7 +227,10 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
     class="widget-combobox"
   >
     <div
+      aria-controls="downshift-0-menu"
+      aria-expanded="false"
       class="form-control widget-combobox-input-container"
+      id="downshift-0-toggle-button"
       tabindex="-1"
     >
       <div
@@ -276,11 +278,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
         </span>
       </button>
       <div
-        aria-controls="downshift-0-menu"
-        aria-expanded="false"
         class="widget-combobox-down-arrow"
-        id="downshift-0-toggle-button"
-        tabindex="-1"
       >
         <span
           class="widget-combobox-icon-container"

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/SingleSelection.spec.tsx.snap
@@ -6,7 +6,10 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
     class="widget-combobox"
   >
     <div
+      aria-controls="downshift-0-menu"
+      aria-expanded="false"
       class="form-control widget-combobox-input-container"
+      id="downshift-0-toggle-button"
       tabindex="-1"
     >
       <div
@@ -56,11 +59,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
         </span>
       </button>
       <div
-        aria-controls="downshift-0-menu"
-        aria-expanded="false"
         class="widget-combobox-down-arrow"
-        id="downshift-0-toggle-button"
-        tabindex="-1"
       >
         <span
           class="widget-combobox-icon-container"

--- a/packages/pluggableWidgets/combobox-web/src/components/ComboboxWrapper.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/ComboboxWrapper.tsx
@@ -1,18 +1,17 @@
 import classNames from "classnames";
 import { UseComboboxGetToggleButtonPropsOptions } from "downshift/typings";
-import { MouseEventHandler, PropsWithChildren, ReactElement, RefObject, createElement, forwardRef } from "react";
+import { PropsWithChildren, ReactElement, RefObject, createElement, forwardRef } from "react";
 import { DownArrow } from "../assets/icons";
 
 interface ComboboxWrapperProps extends PropsWithChildren {
     isOpen: boolean;
     readOnly: boolean;
-    onClick?: MouseEventHandler<HTMLDivElement>;
     getToggleButtonProps: (options?: UseComboboxGetToggleButtonPropsOptions | undefined) => any;
 }
 
 export const ComboboxWrapper = forwardRef(
     (props: ComboboxWrapperProps, ref: RefObject<HTMLDivElement>): ReactElement => {
-        const { isOpen, readOnly, getToggleButtonProps, children, onClick } = props;
+        const { isOpen, readOnly, getToggleButtonProps, children } = props;
         return (
             <div
                 ref={ref}
@@ -21,10 +20,10 @@ export const ComboboxWrapper = forwardRef(
                     "widget-combobox-input-container-active": isOpen,
                     "widget-combobox-input-container-disabled": readOnly
                 })}
-                onClick={onClick}
+                {...getToggleButtonProps()}
             >
                 {children}
-                <div className="widget-combobox-down-arrow" {...getToggleButtonProps()}>
+                <div className="widget-combobox-down-arrow">
                     <DownArrow isOpen={isOpen} />
                 </div>
             </div>

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -6,7 +6,6 @@ import { useDownshiftSingleSelectProps } from "../../hooks/useDownshiftSingleSel
 import { ComboboxWrapper } from "../ComboboxWrapper";
 import { InputPlaceholder } from "../Placeholder";
 import { SingleSelectionMenu } from "./SingleSelectionMenu";
-import { useEventCallback } from "@mendix/widget-plugin-hooks/useEventCallback";
 
 export function SingleSelection({
     selector,
@@ -21,24 +20,12 @@ export function SingleSelection({
         getMenuProps,
         reset,
         isOpen,
-        highlightedIndex,
-        openMenu
+        highlightedIndex
     } = useDownshiftSingleSelectProps(selector, options);
     const inputRef = useRef<HTMLInputElement>(null);
-
-    const onContainerClick = useEventCallback(() => {
-        if (selector?.options.filterType === "none" && !isOpen && inputRef?.current === document.activeElement) {
-            openMenu();
-        }
-    });
     return (
         <Fragment>
-            <ComboboxWrapper
-                isOpen={isOpen}
-                onClick={onContainerClick}
-                readOnly={selector.readOnly}
-                getToggleButtonProps={getToggleButtonProps}
-            >
+            <ComboboxWrapper isOpen={isOpen} readOnly={selector.readOnly} getToggleButtonProps={getToggleButtonProps}>
                 <div className="widget-combobox-selected-items">
                     <input
                         className={classNames("widget-combobox-input", {

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
@@ -57,6 +57,7 @@ export function useDownshiftSingleSelectProps(
                     case useCombobox.stateChangeTypes.InputFocus:
                         return {
                             ...changes,
+                            isOpen: state.isOpen,
                             inputValue: "",
                             highlightedIndex: changes.selectedItem ? -1 : this.defaultHighlightedIndex
                         };
@@ -66,6 +67,7 @@ export function useDownshiftSingleSelectProps(
                     case undefined:
                         return {
                             ...changes,
+                            isOpen: false,
                             inputValue:
                                 changes.selectedItem || selector.currentValue
                                     ? selector.caption.get(selector.currentValue)


### PR DESCRIPTION
### Pull request type
New Feature:
Allow clicking on container to toggle open/close combobox.

### Description

- this is achieved by removing toggle button props from the real toggle button, and move it to the container instead. (toggle button is not focusable anyway)
- click event still propagated down, and allows clear button, input focus, etc to occurs.
- found problem with previous behavior whereas options menu open "on input focus" event, 
- - this is handled by keeping whichever open state currently when "on input focus" event occurs.