### PR TITLE
fix: inconsistent behavior with editor set data

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fix an issue with Editor intermittenly not displaying data.
+
 ## [2.2.2] - 2023-10-12
 
 ### Breaking changes

--- a/packages/pluggableWidgets/rich-text-web/package.json
+++ b/packages/pluggableWidgets/rich-text-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/rich-text-web",
   "widgetName": "RichText",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Rich inline or toolbar text editing",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -35,6 +35,7 @@ export class Editor extends Component<EditorProps> {
     element: HTMLElement;
     lastSentValue: string | undefined;
     applyChangesDebounce: () => void;
+    setDataDebounce: (data: string | undefined) => void;
     cancelRAF: (() => void) | undefined;
     hasFocus: boolean;
 
@@ -47,6 +48,7 @@ export class Editor extends Component<EditorProps> {
         this.editorHookProps = this.getNewEditorHookProps();
         this.onChange = this.onChange.bind(this);
         this.applyChangesDebounce = debounce(this.applyChangesImmediately.bind(this), 500)[0];
+        this.setDataDebounce = debounce(data => this.editor?.setData(data, () => this.addListeners()), 50)[0];
         this.onKeyPress = this.onKeyPress.bind(this);
         this.onPasteContent = this.onPasteContent.bind(this);
         this.onDropContent = this.onDropContent.bind(this);
@@ -228,7 +230,7 @@ export class Editor extends Component<EditorProps> {
         // call addListeners immediately.
         // https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-setData
         if ("data" in args) {
-            setTimeout(() => this.editor?.setData(args.data, () => this.addListeners()), 50);
+            this.setDataDebounce(args.data);
         } else {
             this.addListeners();
         }

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -228,7 +228,7 @@ export class Editor extends Component<EditorProps> {
         // call addListeners immediately.
         // https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-setData
         if ("data" in args) {
-            this.editor?.setData(args.data, () => this.addListeners());
+            setTimeout(() => this.editor?.setData(args.data, () => this.addListeners()), 50);
         } else {
             this.addListeners();
         }

--- a/packages/pluggableWidgets/rich-text-web/src/package.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="RichText" version="2.2.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="RichText" version="2.2.3" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="RichText.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Pull request type
Bug fix: Editor not displaying data sometimes.

### Description
it seems like there’s a racing condition on updating the editor’s data.
this probably because unsync DOM with React’s component.
we could try debugging more and making a proper fix, but that would require a lot of refactoring.
delaying setData for 50ms seems works for now.