### PR TITLE
[WC-2151]: Combobox screenreader a11y

### DIFF
--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -77,10 +77,10 @@ export const preview = (props: ComboboxPreviewProps): ReactElement => {
                 removeSelection: props.removeValueAriaLabel
             },
             a11yStatusMessage: {
-                i18nSelectedValue: props.i18nSelectedValue,
-                i18nOptionsAvailable: props.i18nOptionsAvailable,
-                i18nInstructions: props.i18nInstructions,
-                i18nNoOption: props.noOptionsText
+                a11ySelectedValue: props.a11ySelectedValue,
+                a11yOptionsAvailable: props.a11yOptionsAvailable,
+                a11yInstructions: props.a11yInstructions,
+                a11yNoOption: props.noOptionsText
             }
         }
     };

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -70,7 +70,21 @@ export const preview = (props: ComboboxPreviewProps): ReactElement => {
     const commonProps = {
         tabIndex: 1,
         inputId: id,
-        labelId: `${id}-label`
+        labelId: `${id}-label`,
+        a11yConfig: {
+            ariaLabels: {
+                clearSelection: props.clearButtonAriaLabel,
+                removeSelection: props.removeValueAriaLabel
+            },
+            a11yStatusMessage: {
+                i18nSelectedItemSingular: props.i18nSelectedItemSingular,
+                i18nSelectedItemPlural: props.i18nSelectedItemPlural,
+                i18nNoResults: props.i18nNoResults,
+                i18nResultSingle: props.i18nResultSingle,
+                i18nResultPlural: props.i18nResultPlural,
+                i18nInstructions: props.i18nInstructions
+            }
+        }
     };
 
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -77,12 +77,10 @@ export const preview = (props: ComboboxPreviewProps): ReactElement => {
                 removeSelection: props.removeValueAriaLabel
             },
             a11yStatusMessage: {
-                i18nSelectedItemSingular: props.i18nSelectedItemSingular,
-                i18nSelectedItemPlural: props.i18nSelectedItemPlural,
-                i18nNoResults: props.i18nNoResults,
-                i18nResultSingle: props.i18nResultSingle,
-                i18nResultPlural: props.i18nResultPlural,
-                i18nInstructions: props.i18nInstructions
+                i18nSelectedValue: props.i18nSelectedValue,
+                i18nOptionsAvailable: props.i18nOptionsAvailable,
+                i18nInstructions: props.i18nInstructions,
+                i18nNoOption: props.noOptionsText
             }
         }
     };

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
@@ -22,10 +22,10 @@ export default function Combobox(props: ComboboxContainerProps): ReactElement {
                 removeSelection: props.removeValueAriaLabel
             },
             a11yStatusMessage: {
-                i18nSelectedValue: props.i18nSelectedValue,
-                i18nOptionsAvailable: props.i18nOptionsAvailable,
-                i18nInstructions: props.i18nInstructions,
-                i18nNoOption: props.noOptionsText?.value as string
+                a11ySelectedValue: props.a11ySelectedValue,
+                a11yOptionsAvailable: props.a11yOptionsAvailable,
+                a11yInstructions: props.a11yInstructions,
+                a11yNoOption: props.noOptionsText?.value as string
             }
         }
     };

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
@@ -22,12 +22,10 @@ export default function Combobox(props: ComboboxContainerProps): ReactElement {
                 removeSelection: props.removeValueAriaLabel
             },
             a11yStatusMessage: {
-                i18nSelectedItemSingular: props.i18nSelectedItemSingular,
-                i18nSelectedItemPlural: props.i18nSelectedItemPlural,
-                i18nNoResults: props.i18nNoResults,
-                i18nResultSingle: props.i18nResultSingle,
-                i18nResultPlural: props.i18nResultPlural,
-                i18nInstructions: props.i18nInstructions
+                i18nSelectedValue: props.i18nSelectedValue,
+                i18nOptionsAvailable: props.i18nOptionsAvailable,
+                i18nInstructions: props.i18nInstructions,
+                i18nNoOption: props.noOptionsText?.value as string
             }
         }
     };

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
@@ -22,9 +22,9 @@ export default function Combobox(props: ComboboxContainerProps): ReactElement {
                 removeSelection: props.removeValueAriaLabel
             },
             a11yStatusMessage: {
-                a11ySelectedValue: props.a11ySelectedValue,
-                a11yOptionsAvailable: props.a11yOptionsAvailable,
-                a11yInstructions: props.a11yInstructions,
+                a11ySelectedValue: props.a11ySelectedValue?.value as string,
+                a11yOptionsAvailable: props.a11yOptionsAvailable?.value as string,
+                a11yInstructions: props.a11yInstructions?.value as string,
                 a11yNoOption: props.noOptionsText?.value as string
             }
         }

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
@@ -16,9 +16,19 @@ export default function Combobox(props: ComboboxContainerProps): ReactElement {
         inputId: props.id,
         labelId: `${props.id}-label`,
         noOptionsText: props.noOptionsText?.value,
-        clearButtonAriaLabels: {
-            clearSelection: props.clearButtonAriaLabel,
-            removeSelection: props.removeValueAriaLabel
+        a11yConfig: {
+            ariaLabels: {
+                clearSelection: props.clearButtonAriaLabel,
+                removeSelection: props.removeValueAriaLabel
+            },
+            a11yStatusMessage: {
+                i18nSelectedItemSingular: props.i18nSelectedItemSingular,
+                i18nSelectedItemPlural: props.i18nSelectedItemPlural,
+                i18nNoResults: props.i18nNoResults,
+                i18nResultSingle: props.i18nResultSingle,
+                i18nResultPlural: props.i18nResultPlural,
+                i18nInstructions: props.i18nInstructions
+            }
         }
     };
 

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -182,15 +182,15 @@
                 </property>
             </propertyGroup>
             <propertyGroup caption="Accesibility Status Message ">
-                <property key="i18nSelectedValue" type="string" defaultValue="Selected value: " required="true">
+                <property key="a11ySelectedValue" type="string" defaultValue="Selected value: " required="true">
                     <caption>Selected value</caption>
                     <description>Output example: "Selected value: Avocado, Apple, Banana."</description>
                 </property>
-                <property key="i18nOptionsAvailable" type="string" defaultValue="Number of options available:" required="true">
+                <property key="a11yOptionsAvailable" type="string" defaultValue="Number of options available:" required="true">
                     <caption>Options available</caption>
                     <description>Output example: "Number of options available: 1"</description>
                 </property>
-                <property key="i18nInstructions" type="string" defaultValue="Use up and down arrow keys to navigate. Press Enter or Space Bar keys to select." required="true">
+                <property key="a11yInstructions" type="string" defaultValue="Use up and down arrow keys to navigate. Press Enter or Space Bar keys to select." required="true">
                     <caption>Instructions</caption>
                     <description>Instructions to be read after announcing the status.</description>
                 </property>

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -188,10 +188,7 @@
                 </property>
                 <property key="i18nSelectedItemPlural" type="string" defaultValue="Selected items are" required="true">
                     <caption>Selected items (Plural)</caption>
-                    <description>
-                        Used when Multi-selection is enabled and there are multiple
-                        selected items. Output example: Selected items are Avocado, Apple, Banana.
-                    </description>
+                    <description>Used when Multi-selection is enabled and there are multiple selected items. Output example: Selected items are Avocado, Apple, Banana.</description>
                 </property>
                 <property key="i18nNoResults" type="string" defaultValue="No results are available." required="true">
                     <caption>No results</caption>

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -178,7 +178,36 @@
                 </property>
                 <property key="removeValueAriaLabel" type="string" defaultValue="Remove value" required="true">
                     <caption>Remove value</caption>
-                    <description>Used for the individual selected value labels in multi-selection</description>
+                    <description>Used for the individual selected value labels in multi-selection.</description>
+                </property>
+            </propertyGroup>
+            <propertyGroup caption="Accesibility Status Message ">
+                <property key="i18nSelectedItemSingular" type="string" defaultValue="Selected item is" required="true">
+                    <caption>Selected item (Singular)</caption>
+                    <description>Output example: "Selected item is Avocado."</description>
+                </property>
+                <property key="i18nSelectedItemPlural" type="string" defaultValue="Selected items are" required="true">
+                    <caption>Selected items (Plural)</caption>
+                    <description>
+                        Used when Multi-selection is enabled and there are multiple
+                        selected items. Output example: Selected items are Avocado, Apple, Banana.
+                    </description>
+                </property>
+                <property key="i18nNoResults" type="string" defaultValue="No results are available." required="true">
+                    <caption>No results</caption>
+                    <description>Read when there are no search results for the given input value.</description>
+                </property>
+                <property key="i18nResultSingle" type="string" defaultValue="result is available." required="true">
+                    <caption>Result available (Singular)</caption>
+                    <description>Example output: "1 result is available."</description>
+                </property>
+                <property key="i18nResultPlural" type="string" defaultValue="results are available." required="true">
+                    <caption>Results available (Plural)</caption>
+                    <description>Example output: "8 results are available."</description>
+                </property>
+                <property key="i18nInstructions" type="string" defaultValue="Use up and down arrow keys to navigate. Press Enter or Space Bar keys to select." required="true">
+                    <caption>Instructions</caption>
+                    <description>Instructions to be read after announcing the status.</description>
                 </property>
             </propertyGroup>
         </propertyGroup>

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -182,25 +182,13 @@
                 </property>
             </propertyGroup>
             <propertyGroup caption="Accesibility Status Message ">
-                <property key="i18nSelectedItemSingular" type="string" defaultValue="Selected item is" required="true">
-                    <caption>Selected item (Singular)</caption>
-                    <description>Output example: "Selected item is Avocado."</description>
+                <property key="i18nSelectedValue" type="string" defaultValue="Selected value: " required="true">
+                    <caption>Selected value</caption>
+                    <description>Output example: "Selected value: Avocado, Apple, Banana."</description>
                 </property>
-                <property key="i18nSelectedItemPlural" type="string" defaultValue="Selected items are" required="true">
-                    <caption>Selected items (Plural)</caption>
-                    <description>Used when Multi-selection is enabled and there are multiple selected items. Output example: Selected items are Avocado, Apple, Banana.</description>
-                </property>
-                <property key="i18nNoResults" type="string" defaultValue="No results are available." required="true">
-                    <caption>No results</caption>
-                    <description>Read when there are no search results for the given input value.</description>
-                </property>
-                <property key="i18nResultSingle" type="string" defaultValue="result is available." required="true">
-                    <caption>Result available (Singular)</caption>
-                    <description>Example output: "1 result is available."</description>
-                </property>
-                <property key="i18nResultPlural" type="string" defaultValue="results are available." required="true">
-                    <caption>Results available (Plural)</caption>
-                    <description>Example output: "8 results are available."</description>
+                <property key="i18nOptionsAvailable" type="string" defaultValue="Number of options available:" required="true">
+                    <caption>Options available</caption>
+                    <description>Output example: "Number of options available: 1"</description>
                 </property>
                 <property key="i18nInstructions" type="string" defaultValue="Use up and down arrow keys to navigate. Press Enter or Space Bar keys to select." required="true">
                     <caption>Instructions</caption>

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -181,7 +181,7 @@
                     <description>Used for the individual selected value labels in multi-selection.</description>
                 </property>
             </propertyGroup>
-            <propertyGroup caption="Accesibility Status Message ">
+            <propertyGroup caption="Accessibility Status Message ">
                 <property key="a11ySelectedValue" type="textTemplate" required="true">
                     <caption>Selected value</caption>
                     <description>Output example: "Selected value: Avocado, Apple, Banana."</description>

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -182,17 +182,26 @@
                 </property>
             </propertyGroup>
             <propertyGroup caption="Accesibility Status Message ">
-                <property key="a11ySelectedValue" type="string" defaultValue="Selected value: " required="true">
+                <property key="a11ySelectedValue" type="textTemplate" required="true">
                     <caption>Selected value</caption>
                     <description>Output example: "Selected value: Avocado, Apple, Banana."</description>
+                    <translations>
+                        <translation lang="en_US">Selected value:</translation>
+                    </translations>
                 </property>
-                <property key="a11yOptionsAvailable" type="string" defaultValue="Number of options available:" required="true">
+                <property key="a11yOptionsAvailable" type="textTemplate" required="true">
                     <caption>Options available</caption>
                     <description>Output example: "Number of options available: 1"</description>
+                    <translations>
+                        <translation lang="en_US">Number of options available:</translation>
+                    </translations>
                 </property>
-                <property key="a11yInstructions" type="string" defaultValue="Use up and down arrow keys to navigate. Press Enter or Space Bar keys to select." required="true">
+                <property key="a11yInstructions" type="textTemplate" required="true">
                     <caption>Instructions</caption>
                     <description>Instructions to be read after announcing the status.</description>
+                    <translations>
+                        <translation lang="en_US">Use up and down arrow keys to navigate. Press Enter or Space Bar keys to select.</translation>
+                    </translations>
                 </property>
             </propertyGroup>
         </propertyGroup>

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -42,6 +42,7 @@ describe("Combo box (Association)", () => {
             noOptionsText: dynamicValue("no options found"),
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
+            selectionMethod: "checkbox",
             a11ySelectedValue: dynamicValue("Selected value:"),
             a11yOptionsAvailable: dynamicValue("Options available:"),
             a11yInstructions: dynamicValue("a11yInstructions")

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -42,11 +42,8 @@ describe("Combo box (Association)", () => {
             noOptionsText: dynamicValue("no options found"),
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
-            i18nSelectedItemSingular: "i18nSelectedItemSingular",
-            i18nSelectedItemPlural: "i18nSelectedItemPlural",
-            i18nNoResults: "i18nNoResults",
-            i18nResultSingle: "i18nResultSingle",
-            i18nResultPlural: "i18nResultPlural",
+            i18nSelectedValue: "Selected value:",
+            i18nOptionsAvailable: "Options available:",
             i18nInstructions: "i18nInstructions"
         };
         if (defaultProps.optionsSourceAssociationCaptionType === "expression") {

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -42,9 +42,9 @@ describe("Combo box (Association)", () => {
             noOptionsText: dynamicValue("no options found"),
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
-            a11ySelectedValue: "Selected value:",
-            a11yOptionsAvailable: "Options available:",
-            a11yInstructions: "a11yInstructions"
+            a11ySelectedValue: dynamicValue("Selected value:"),
+            a11yOptionsAvailable: dynamicValue("Options available:"),
+            a11yInstructions: dynamicValue("a11yInstructions")
         };
         if (defaultProps.optionsSourceAssociationCaptionType === "expression") {
             defaultProps.optionsSourceAssociationCaptionExpression!.get = i => {

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -42,9 +42,9 @@ describe("Combo box (Association)", () => {
             noOptionsText: dynamicValue("no options found"),
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
-            i18nSelectedValue: "Selected value:",
-            i18nOptionsAvailable: "Options available:",
-            i18nInstructions: "i18nInstructions"
+            a11ySelectedValue: "Selected value:",
+            a11yOptionsAvailable: "Options available:",
+            a11yInstructions: "a11yInstructions"
         };
         if (defaultProps.optionsSourceAssociationCaptionType === "expression") {
             defaultProps.optionsSourceAssociationCaptionExpression!.get = i => {

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -62,10 +62,10 @@ describe("Combo box (Association)", () => {
         const { container } = render(<Combobox {...defaultProps} />);
         expect(container.getElementsByClassName("widget-combobox-placeholder")).toHaveLength(1);
     });
-    it("toggles combobox menu on: input FOCUS / BLUR", async () => {
+    it("toggles combobox menu on: input CLICK(focus) / BLUR", async () => {
         const component = render(<Combobox {...defaultProps} />);
         const toggleButton = await component.findByRole("combobox");
-        fireEvent.focus(toggleButton);
+        fireEvent.click(toggleButton);
         expect(component.getAllByRole("option")).toHaveLength(4);
         fireEvent.blur(toggleButton);
         expect(component.queryAllByRole("option")).toHaveLength(0);
@@ -81,7 +81,7 @@ describe("Combo box (Association)", () => {
     it("adds new item to inital selected item", async () => {
         const component = render(<Combobox {...defaultProps} />);
         const input = (await component.findByRole("combobox")) as HTMLInputElement;
-        fireEvent.focus(input);
+        fireEvent.click(input);
         const option1 = await component.findByText("222");
         fireEvent.click(option1);
         expect(component.container).toMatchSnapshot();
@@ -93,7 +93,7 @@ describe("Combo box (Association)", () => {
         const component = render(<Combobox {...defaultProps} />);
 
         const input = (await component.findByRole("combobox")) as HTMLInputElement;
-        fireEvent.focus(input);
+        fireEvent.click(input);
 
         const option1 = await component.findByText("222");
         fireEvent.click(option1);

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -42,7 +42,12 @@ describe("Combo box (Association)", () => {
             noOptionsText: dynamicValue("no options found"),
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
-            selectionMethod: "checkbox"
+            i18nSelectedItemSingular: "i18nSelectedItemSingular",
+            i18nSelectedItemPlural: "i18nSelectedItemPlural",
+            i18nNoResults: "i18nNoResults",
+            i18nResultSingle: "i18nResultSingle",
+            i18nResultPlural: "i18nResultPlural",
+            i18nInstructions: "i18nInstructions"
         };
         if (defaultProps.optionsSourceAssociationCaptionType === "expression") {
             defaultProps.optionsSourceAssociationCaptionExpression!.get = i => {

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -49,11 +49,8 @@ describe("Combo box (Association)", () => {
             selectedItemsStyle: "text",
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
-            i18nSelectedItemSingular: "i18nSelectedItemSingular",
-            i18nSelectedItemPlural: "i18nSelectedItemPlural",
-            i18nNoResults: "i18nNoResults",
-            i18nResultSingle: "i18nResultSingle",
-            i18nResultPlural: "i18nResultPlural",
+            i18nSelectedValue: "Selected value:",
+            i18nOptionsAvailable: "Options available:",
             i18nInstructions: "i18nInstructions"
         };
         if (defaultProps.optionsSourceAssociationCaptionType === "expression") {

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -49,9 +49,9 @@ describe("Combo box (Association)", () => {
             selectedItemsStyle: "text",
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
-            i18nSelectedValue: "Selected value:",
-            i18nOptionsAvailable: "Options available:",
-            i18nInstructions: "i18nInstructions"
+            a11ySelectedValue: "Selected value:",
+            a11yOptionsAvailable: "Options available:",
+            a11yInstructions: "a11yInstructions"
         };
         if (defaultProps.optionsSourceAssociationCaptionType === "expression") {
             defaultProps.optionsSourceAssociationCaptionExpression!.get = i => {

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -49,6 +49,7 @@ describe("Combo box (Association)", () => {
             selectedItemsStyle: "text",
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
+            selectionMethod: "checkbox",
             a11ySelectedValue: dynamicValue("Selected value:"),
             a11yOptionsAvailable: dynamicValue("Options available:"),
             a11yInstructions: dynamicValue("a11yInstructions")

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -49,7 +49,12 @@ describe("Combo box (Association)", () => {
             selectedItemsStyle: "text",
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
-            selectionMethod: "checkbox"
+            i18nSelectedItemSingular: "i18nSelectedItemSingular",
+            i18nSelectedItemPlural: "i18nSelectedItemPlural",
+            i18nNoResults: "i18nNoResults",
+            i18nResultSingle: "i18nResultSingle",
+            i18nResultPlural: "i18nResultPlural",
+            i18nInstructions: "i18nInstructions"
         };
         if (defaultProps.optionsSourceAssociationCaptionType === "expression") {
             defaultProps.optionsSourceAssociationCaptionExpression!.get = i => {

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -49,9 +49,9 @@ describe("Combo box (Association)", () => {
             selectedItemsStyle: "text",
             clearButtonAriaLabel: "Clear selection",
             removeValueAriaLabel: "Remove value",
-            a11ySelectedValue: "Selected value:",
-            a11yOptionsAvailable: "Options available:",
-            a11yInstructions: "a11yInstructions"
+            a11ySelectedValue: dynamicValue("Selected value:"),
+            a11yOptionsAvailable: dynamicValue("Options available:"),
+            a11yInstructions: dynamicValue("a11yInstructions")
         };
         if (defaultProps.optionsSourceAssociationCaptionType === "expression") {
             defaultProps.optionsSourceAssociationCaptionExpression!.get = i => {

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
@@ -11,7 +11,7 @@ import { MultiSelectionMenu } from "./MultiSelectionMenu";
 export function MultiSelection({
     selector,
     tabIndex,
-    clearButtonAriaLabels,
+    a11yConfig,
     ...options
 }: SelectionBaseProps<MultiSelector>): ReactElement {
     const {
@@ -29,7 +29,7 @@ export function MultiSelection({
         items,
         setSelectedItems,
         toggleSelectedItem
-    } = useDownshiftMultiSelectProps(selector, options);
+    } = useDownshiftMultiSelectProps(selector, options, a11yConfig.a11yStatusMessage);
     const inputRef = useRef<HTMLInputElement>(null);
     const isSelectedItemsBoxStyle = selector.selectedItemsStyle === "boxes";
 
@@ -61,7 +61,7 @@ export function MultiSelection({
                                     {selector.caption.render(selectedItemForRender, "label")}
                                     <span
                                         className="icon widget-combobox-clear-button"
-                                        aria-label={clearButtonAriaLabels?.removeSelection}
+                                        aria-label={a11yConfig.ariaLabels?.removeSelection}
                                         role="button"
                                         onClick={e => {
                                             e.stopPropagation();
@@ -120,7 +120,7 @@ export function MultiSelection({
                         <button
                             tabIndex={tabIndex}
                             className="widget-combobox-clear-button"
-                            aria-label={clearButtonAriaLabels?.clearSelection}
+                            aria-label={a11yConfig.ariaLabels?.clearSelection}
                             onClick={e => {
                                 e.stopPropagation();
                                 inputRef.current?.focus();

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
@@ -87,7 +87,6 @@ export function MultiSelection({
                                 { suppressRefError: true }
                             ),
                             ref: inputRef,
-                            onClick: e => e.stopPropagation(),
                             onKeyDown: (event: KeyboardEvent) => {
                                 if (
                                     (event.key === "Backspace" && inputRef.current?.selectionStart === 0) ||

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -10,7 +10,7 @@ import { SingleSelectionMenu } from "./SingleSelectionMenu";
 export function SingleSelection({
     selector,
     tabIndex = 0,
-    clearButtonAriaLabels,
+    a11yConfig,
     ...options
 }: SelectionBaseProps<SingleSelector>): ReactElement {
     const {
@@ -22,7 +22,7 @@ export function SingleSelection({
         reset,
         isOpen,
         highlightedIndex
-    } = useDownshiftSingleSelectProps(selector, options);
+    } = useDownshiftSingleSelectProps(selector, options, a11yConfig.a11yStatusMessage);
     const inputRef = useRef<HTMLInputElement>(null);
     return (
         <Fragment>
@@ -63,7 +63,7 @@ export function SingleSelection({
                     <button
                         tabIndex={tabIndex}
                         className="widget-combobox-clear-button"
-                        aria-label={clearButtonAriaLabels?.clearSelection}
+                        aria-label={a11yConfig.ariaLabels?.clearSelection}
                         onClick={e => {
                             e.stopPropagation();
                             inputRef.current?.focus();

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
@@ -24,7 +24,7 @@ export function SingleSelectionMenu({
     return (
         <ComboboxMenuWrapper
             isOpen={isOpen}
-            isEmpty={items.length <= 0}
+            isEmpty={items?.length <= 0}
             getMenuProps={getMenuProps}
             noOptionsText={noOptionsText}
         >

--- a/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
@@ -74,8 +74,20 @@ export interface SelectionBaseProps<Selector> {
     inputId: string;
     labelId?: string;
     noOptionsText?: string;
-    clearButtonAriaLabels?: {
-        clearSelection: string;
-        removeSelection: string;
+    a11yConfig: {
+        ariaLabels: {
+            clearSelection: string;
+            removeSelection: string;
+        };
+        a11yStatusMessage: A11yStatusMessage;
     };
+}
+
+export interface A11yStatusMessage {
+    i18nSelectedItemSingular: string;
+    i18nSelectedItemPlural: string;
+    i18nNoResults: string;
+    i18nResultSingle: string;
+    i18nResultPlural: string;
+    i18nInstructions: string;
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
@@ -84,8 +84,8 @@ export interface SelectionBaseProps<Selector> {
 }
 
 export interface A11yStatusMessage {
-    i18nSelectedValue: string;
-    i18nOptionsAvailable: string;
-    i18nInstructions: string;
-    i18nNoOption: string;
+    a11ySelectedValue: string;
+    a11yOptionsAvailable: string;
+    a11yInstructions: string;
+    a11yNoOption: string;
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
@@ -84,10 +84,8 @@ export interface SelectionBaseProps<Selector> {
 }
 
 export interface A11yStatusMessage {
-    i18nSelectedItemSingular: string;
-    i18nSelectedItemPlural: string;
-    i18nNoResults: string;
-    i18nResultSingle: string;
-    i18nResultPlural: string;
+    i18nSelectedValue: string;
+    i18nOptionsAvailable: string;
     i18nInstructions: string;
+    i18nNoOption: string;
 }

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -156,18 +156,18 @@ function useComboboxProps(
                 return message;
             },
             itemToString: (v: string | null) => selector.caption.get(v),
-            stateReducer(_state: UseComboboxState<string>, actionAndChanges: UseComboboxStateChangeOptions<string>) {
+            stateReducer(state: UseComboboxState<string>, actionAndChanges: UseComboboxStateChangeOptions<string>) {
                 const { changes, type } = actionAndChanges;
                 switch (type) {
                     case useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem:
                         return {
                             ...changes,
-                            inputValue: _state.inputValue
+                            inputValue: state.inputValue
                         };
                     case useCombobox.stateChangeTypes.InputFocus:
                         return {
                             ...changes,
-                            isOpen: false
+                            isOpen: state.isOpen
                         };
                     case useCombobox.stateChangeTypes.InputKeyDownEnter:
                     case useCombobox.stateChangeTypes.ItemClick:

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -8,7 +8,7 @@ import {
     useMultipleSelection
 } from "downshift";
 import { useMemo } from "react";
-import { MultiSelector } from "../helpers/types";
+import { A11yStatusMessage, MultiSelector } from "../helpers/types";
 
 export type UseDownshiftMultiSelectPropsReturnValue = UseMultipleSelectionReturnValue<string> &
     Pick<
@@ -34,7 +34,8 @@ interface Options {
 
 export function useDownshiftMultiSelectProps(
     selector: MultiSelector,
-    options?: Options
+    options: Options,
+    a11yStatusMessage: A11yStatusMessage
 ): UseDownshiftMultiSelectPropsReturnValue {
     const {
         getSelectedItemProps,
@@ -77,7 +78,17 @@ export function useDownshiftMultiSelectProps(
         getItemProps,
         inputValue,
         setInputValue
-    } = useCombobox(useComboboxProps(selector, selectedItems, items, removeSelectedItem, setSelectedItems, options));
+    } = useCombobox(
+        useComboboxProps(
+            selector,
+            selectedItems,
+            items,
+            removeSelectedItem,
+            setSelectedItems,
+            a11yStatusMessage,
+            options
+        )
+    );
 
     const toggleSelectedItem = (index: number): void => {
         const item = items[index];
@@ -121,6 +132,7 @@ function useComboboxProps(
     items: string[],
     removeSelectedItem: (item: string) => void,
     setSelectedItems: (item: string[]) => void,
+    a11yStatusMessage: A11yStatusMessage,
     options?: Options
 ): UseComboboxProps<string> {
     return useMemo(() => {
@@ -135,22 +147,26 @@ function useComboboxProps(
             getA11yStatusMessage(options) {
                 let message =
                     selectedItems.length > 0
-                        ? `Selected item${selectedItems.length === 1 ? " is" : "s are"} ${selectedItems
-                              .map(itemId => selector.caption.get(itemId))
-                              .join(",")}.`
+                        ? `${
+                              selectedItems.length === 1
+                                  ? a11yStatusMessage.i18nSelectedItemSingular
+                                  : a11yStatusMessage.i18nSelectedItemPlural
+                          } ${selectedItems.map(itemId => selector.caption.get(itemId)).join(",")}.`
                         : "";
                 if (!options.isOpen) {
                     message += "";
                 }
 
                 if (!options.resultCount) {
-                    message += "No results are available.";
+                    message += a11yStatusMessage.i18nNoResults;
                 }
 
                 if (options.resultCount !== options.previousResultCount) {
-                    message += `${options.resultCount} result${
-                        options.resultCount === 1 ? " is" : "s are"
-                    } available, use up and down arrow keys to navigate. Press Enter or Space Bar keys to select.`;
+                    message += `${options.resultCount} ${
+                        options.resultCount === 1
+                            ? a11yStatusMessage.i18nResultSingle
+                            : a11yStatusMessage.i18nResultPlural
+                    } ${a11yStatusMessage.i18nInstructions}`;
                 }
 
                 return message;

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -152,10 +152,12 @@ function useComboboxProps(
                               .join(",")}. `
                         : "";
 
-                if (options.resultCount > 0) {
-                    message += `${a11yStatusMessage.a11yOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.a11yInstructions}`;
-                } else {
-                    message += a11yStatusMessage.a11yNoOption;
+                if (options.previousResultCount !== options.resultCount) {
+                    if (options.resultCount > 0) {
+                        message += `${a11yStatusMessage.a11yOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.a11yInstructions}`;
+                    } else {
+                        message += a11yStatusMessage.a11yNoOption;
+                    }
                 }
 
                 return message;

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -141,7 +141,11 @@ function useComboboxProps(
                             ...changes,
                             inputValue: _state.inputValue
                         };
-
+                    case useCombobox.stateChangeTypes.InputFocus:
+                        return {
+                            ...changes,
+                            isOpen: false
+                        };
                     case useCombobox.stateChangeTypes.InputKeyDownEnter:
                     case useCombobox.stateChangeTypes.ItemClick:
                         return {

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -147,28 +147,18 @@ function useComboboxProps(
             getA11yStatusMessage(options) {
                 let message =
                     selectedItems.length > 0
-                        ? `${
-                              selectedItems.length === 1
-                                  ? a11yStatusMessage.i18nSelectedItemSingular
-                                  : a11yStatusMessage.i18nSelectedItemPlural
-                          } ${selectedItems.map(itemId => selector.caption.get(itemId)).join(",")}.`
+                        ? `${a11yStatusMessage.i18nSelectedValue} ${selectedItems
+                              .map(itemId => selector.caption.get(itemId))
+                              .join(",")}. `
                         : "";
-                if (!options.isOpen) {
-                    message += "";
+
+                if (options.resultCount > 0) {
+                    message += `${a11yStatusMessage.i18nOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.i18nInstructions}`;
+                } else {
+                    message += a11yStatusMessage.i18nNoOption;
                 }
 
-                if (!options.resultCount) {
-                    message += a11yStatusMessage.i18nNoResults;
-                }
-
-                if (options.resultCount !== options.previousResultCount) {
-                    message += `${options.resultCount} ${
-                        options.resultCount === 1
-                            ? a11yStatusMessage.i18nResultSingle
-                            : a11yStatusMessage.i18nResultPlural
-                    } ${a11yStatusMessage.i18nInstructions}`;
-                }
-
+                console.log(message);
                 return message;
             },
             itemToString: (v: string | null) => selector.caption.get(v),

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -215,5 +215,16 @@ function useComboboxProps(
         };
         // disable eslint rule as probably we should update props whenever currentValue changes.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selector, selectedItems, items, selector.currentValue, removeSelectedItem, setSelectedItems]);
+    }, [
+        selector,
+        selectedItems,
+        items,
+        selector.currentValue,
+        removeSelectedItem,
+        setSelectedItems,
+        a11yStatusMessage.a11ySelectedValue,
+        a11yStatusMessage.a11yOptionsAvailable,
+        a11yStatusMessage.a11yNoOption,
+        a11yStatusMessage.a11yInstructions
+    ]);
 }

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -132,6 +132,29 @@ function useComboboxProps(
             onInputValueChange({ inputValue }) {
                 selector.options.setSearchTerm(inputValue!);
             },
+            getA11yStatusMessage(options) {
+                let message =
+                    selectedItems.length > 0
+                        ? `Selected item${selectedItems.length === 1 ? " is" : "s are"} ${selectedItems
+                              .map(itemId => selector.caption.get(itemId))
+                              .join(",")}.`
+                        : "";
+                if (!options.isOpen) {
+                    message += "";
+                }
+
+                if (!options.resultCount) {
+                    message += "No results are available.";
+                }
+
+                if (options.resultCount !== options.previousResultCount) {
+                    message += `${options.resultCount} result${
+                        options.resultCount === 1 ? " is" : "s are"
+                    } available, use up and down arrow keys to navigate. Press Enter or Space Bar keys to select.`;
+                }
+
+                return message;
+            },
             itemToString: (v: string | null) => selector.caption.get(v),
             stateReducer(_state: UseComboboxState<string>, actionAndChanges: UseComboboxStateChangeOptions<string>) {
                 const { changes, type } = actionAndChanges;

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -147,18 +147,17 @@ function useComboboxProps(
             getA11yStatusMessage(options) {
                 let message =
                     selectedItems.length > 0
-                        ? `${a11yStatusMessage.i18nSelectedValue} ${selectedItems
+                        ? `${a11yStatusMessage.a11ySelectedValue} ${selectedItems
                               .map(itemId => selector.caption.get(itemId))
                               .join(",")}. `
                         : "";
 
                 if (options.resultCount > 0) {
-                    message += `${a11yStatusMessage.i18nOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.i18nInstructions}`;
+                    message += `${a11yStatusMessage.a11yOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.a11yInstructions}`;
                 } else {
-                    message += a11yStatusMessage.i18nNoOption;
+                    message += a11yStatusMessage.a11yNoOption;
                 }
 
-                console.log(message);
                 return message;
             },
             itemToString: (v: string | null) => selector.caption.get(v),

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftMultiSelectProps.ts
@@ -48,6 +48,10 @@ export function useDownshiftMultiSelectProps(
         addSelectedItem
     } = useMultipleSelection({
         selectedItems: selector.currentValue ?? [],
+        itemToString: (v: string) => selector.caption.get(v),
+        getA11yRemovalMessage(options) {
+            return `${options.itemToString(options.removedSelectedItem)} has been removed.`;
+        },
         onSelectedItemsChange({ selectedItems }) {
             selector.setValue(selectedItems ?? []);
         },
@@ -151,13 +155,14 @@ function useComboboxProps(
                               .map(itemId => selector.caption.get(itemId))
                               .join(",")}. `
                         : "";
-
-                if (options.previousResultCount !== options.resultCount) {
-                    if (options.resultCount > 0) {
-                        message += `${a11yStatusMessage.a11yOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.a11yInstructions}`;
-                    } else {
-                        message += a11yStatusMessage.a11yNoOption;
-                    }
+                if (!options.resultCount) {
+                    return a11yStatusMessage.a11yNoOption;
+                }
+                if (!options.isOpen) {
+                    return message;
+                }
+                if (options.previousResultCount !== options.resultCount || !options.highlightedItem) {
+                    message += `${a11yStatusMessage.a11yOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.a11yInstructions}`;
                 }
 
                 return message;

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
@@ -37,12 +37,12 @@ export function useDownshiftSingleSelectProps(
             },
             getA11yStatusMessage(options) {
                 const selectedItem = selector.caption.get(selector.currentValue);
-                let message = selectedItem ? `${a11yStatusMessage.i18nSelectedValue} ${selectedItem}. ` : "";
+                let message = selectedItem ? `${a11yStatusMessage.a11ySelectedValue} ${selectedItem}. ` : "";
 
                 if (options.resultCount > 0) {
-                    message += `${a11yStatusMessage.i18nOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.i18nInstructions}`;
+                    message += `${a11yStatusMessage.a11yOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.a11yInstructions}`;
                 } else {
-                    message += a11yStatusMessage.i18nNoOption;
+                    message += a11yStatusMessage.a11yNoOption;
                 }
 
                 return message;

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
@@ -37,21 +37,12 @@ export function useDownshiftSingleSelectProps(
             },
             getA11yStatusMessage(options) {
                 const selectedItem = selector.caption.get(selector.currentValue);
-                let message = selectedItem ? a11yStatusMessage.i18nSelectedItemSingular : "";
-                if (!options.isOpen) {
-                    message += "";
-                }
+                let message = selectedItem ? `${a11yStatusMessage.i18nSelectedValue} ${selectedItem}. ` : "";
 
-                if (!options.resultCount) {
-                    message += a11yStatusMessage.i18nNoResults;
-                }
-
-                if (options.resultCount !== options.previousResultCount) {
-                    message += `${options.resultCount} ${
-                        options.resultCount === 1
-                            ? a11yStatusMessage.i18nResultSingle
-                            : a11yStatusMessage.i18nResultPlural
-                    } ${a11yStatusMessage.i18nInstructions}`;
+                if (options.resultCount > 0) {
+                    message += `${a11yStatusMessage.i18nOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.i18nInstructions}`;
+                } else {
+                    message += a11yStatusMessage.i18nNoOption;
                 }
 
                 return message;

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
@@ -96,7 +96,15 @@ export function useDownshiftSingleSelectProps(
             inputId,
             labelId
         };
-    }, [selector, inputId, labelId]);
+    }, [
+        selector,
+        inputId,
+        labelId,
+        a11yStatusMessage.a11ySelectedValue,
+        a11yStatusMessage.a11yOptionsAvailable,
+        a11yStatusMessage.a11yNoOption,
+        a11yStatusMessage.a11yInstructions
+    ]);
 
     return useCombobox({
         ...downshiftProps,

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
@@ -8,7 +8,7 @@ import {
 } from "downshift";
 
 import { useMemo } from "react";
-import { SingleSelector } from "../helpers/types";
+import { A11yStatusMessage, SingleSelector } from "../helpers/types";
 
 interface Options {
     inputId?: string;
@@ -17,7 +17,8 @@ interface Options {
 
 export function useDownshiftSingleSelectProps(
     selector: SingleSelector,
-    options: Options = {}
+    options: Options = {},
+    a11yStatusMessage: A11yStatusMessage
 ): UseComboboxReturnValue<string> {
     const { inputId, labelId } = options;
 
@@ -33,6 +34,27 @@ export function useDownshiftSingleSelectProps(
             },
             onInputValueChange({ inputValue }) {
                 selector.options.setSearchTerm(inputValue!);
+            },
+            getA11yStatusMessage(options) {
+                const selectedItem = selector.caption.get(selector.currentValue);
+                let message = selectedItem ? a11yStatusMessage.i18nSelectedItemSingular : "";
+                if (!options.isOpen) {
+                    message += "";
+                }
+
+                if (!options.resultCount) {
+                    message += a11yStatusMessage.i18nNoResults;
+                }
+
+                if (options.resultCount !== options.previousResultCount) {
+                    message += `${options.resultCount} ${
+                        options.resultCount === 1
+                            ? a11yStatusMessage.i18nResultSingle
+                            : a11yStatusMessage.i18nResultPlural
+                    } ${a11yStatusMessage.i18nInstructions}`;
+                }
+
+                return message;
             },
             defaultHighlightedIndex: 0,
             selectedItem: null,

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useDownshiftSingleSelectProps.ts
@@ -37,12 +37,21 @@ export function useDownshiftSingleSelectProps(
             },
             getA11yStatusMessage(options) {
                 const selectedItem = selector.caption.get(selector.currentValue);
-                let message = selectedItem ? `${a11yStatusMessage.a11ySelectedValue} ${selectedItem}. ` : "";
-
+                let message = selectedItem
+                    ? selector.currentValue
+                        ? `${a11yStatusMessage.a11ySelectedValue} ${selectedItem}. `
+                        : "No options selected."
+                    : "";
+                if (!options.isOpen) {
+                    return message;
+                }
+                if (!options.resultCount) {
+                    return a11yStatusMessage.a11yNoOption;
+                }
                 if (options.resultCount > 0) {
                     message += `${a11yStatusMessage.a11yOptionsAvailable} ${options.resultCount}. ${a11yStatusMessage.a11yInstructions}`;
                 } else {
-                    message += a11yStatusMessage.a11yNoOption;
+                    return a11yStatusMessage.a11yNoOption;
                 }
 
                 return message;

--- a/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
+++ b/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
@@ -4,7 +4,17 @@
  * @author Mendix Widgets Framework Team
  */
 import { ComponentType, ReactNode } from "react";
-import { ActionValue, DynamicValue, EditableValue, ListValue, ListAttributeValue, ListExpressionValue, ListWidgetValue, ReferenceValue, ReferenceSetValue } from "mendix";
+import {
+    ActionValue,
+    DynamicValue,
+    EditableValue,
+    ListValue,
+    ListAttributeValue,
+    ListExpressionValue,
+    ListWidgetValue,
+    ReferenceValue,
+    ReferenceSetValue
+} from "mendix";
 
 export type OptionsSourceTypeEnum = "association" | "enumeration" | "boolean";
 
@@ -44,9 +54,9 @@ export interface ComboboxContainerProps {
     ariaRequired: boolean;
     clearButtonAriaLabel: string;
     removeValueAriaLabel: string;
-    i18nSelectedValue: string;
-    i18nOptionsAvailable: string;
-    i18nInstructions: string;
+    a11ySelectedValue: string;
+    a11yOptionsAvailable: string;
+    a11yInstructions: string;
 }
 
 export interface ComboboxPreviewProps {
@@ -64,8 +74,10 @@ export interface ComboboxPreviewProps {
     noOptionsText: string;
     clearable: boolean;
     optionsSourceAssociationCustomContentType: OptionsSourceAssociationCustomContentTypeEnum;
-    optionsSourceAssociationCustomContent: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
-    selectionMethod: SelectionMethodEnum;
+    optionsSourceAssociationCustomContent: {
+        widgetCount: number;
+        renderer: ComponentType<{ children: ReactNode; caption?: string }>;
+    };
     selectedItemsStyle: SelectedItemsStyleEnum;
     onChangeEvent: {} | null;
     onEnterEvent: {} | null;
@@ -73,7 +85,7 @@ export interface ComboboxPreviewProps {
     ariaRequired: boolean;
     clearButtonAriaLabel: string;
     removeValueAriaLabel: string;
-    i18nSelectedValue: string;
-    i18nOptionsAvailable: string;
-    i18nInstructions: string;
+    a11ySelectedValue: string;
+    a11yOptionsAvailable: string;
+    a11yInstructions: string;
 }

--- a/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
+++ b/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
@@ -4,17 +4,7 @@
  * @author Mendix Widgets Framework Team
  */
 import { ComponentType, ReactNode } from "react";
-import {
-    ActionValue,
-    DynamicValue,
-    EditableValue,
-    ListValue,
-    ListAttributeValue,
-    ListExpressionValue,
-    ListWidgetValue,
-    ReferenceValue,
-    ReferenceSetValue
-} from "mendix";
+import { ActionValue, DynamicValue, EditableValue, ListValue, ListAttributeValue, ListExpressionValue, ListWidgetValue, ReferenceValue, ReferenceSetValue } from "mendix";
 
 export type OptionsSourceTypeEnum = "association" | "enumeration" | "boolean";
 
@@ -54,9 +44,9 @@ export interface ComboboxContainerProps {
     ariaRequired: boolean;
     clearButtonAriaLabel: string;
     removeValueAriaLabel: string;
-    a11ySelectedValue: string;
-    a11yOptionsAvailable: string;
-    a11yInstructions: string;
+    a11ySelectedValue: DynamicValue<string>;
+    a11yOptionsAvailable: DynamicValue<string>;
+    a11yInstructions: DynamicValue<string>;
 }
 
 export interface ComboboxPreviewProps {
@@ -74,10 +64,7 @@ export interface ComboboxPreviewProps {
     noOptionsText: string;
     clearable: boolean;
     optionsSourceAssociationCustomContentType: OptionsSourceAssociationCustomContentTypeEnum;
-    optionsSourceAssociationCustomContent: {
-        widgetCount: number;
-        renderer: ComponentType<{ children: ReactNode; caption?: string }>;
-    };
+    optionsSourceAssociationCustomContent: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     selectedItemsStyle: SelectedItemsStyleEnum;
     onChangeEvent: {} | null;
     onEnterEvent: {} | null;

--- a/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
+++ b/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
@@ -65,6 +65,7 @@ export interface ComboboxPreviewProps {
     clearable: boolean;
     optionsSourceAssociationCustomContentType: OptionsSourceAssociationCustomContentTypeEnum;
     optionsSourceAssociationCustomContent: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
+    selectionMethod: SelectionMethodEnum;
     selectedItemsStyle: SelectedItemsStyleEnum;
     onChangeEvent: {} | null;
     onEnterEvent: {} | null;

--- a/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
+++ b/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
@@ -44,11 +44,8 @@ export interface ComboboxContainerProps {
     ariaRequired: boolean;
     clearButtonAriaLabel: string;
     removeValueAriaLabel: string;
-    i18nSelectedItemSingular: string;
-    i18nSelectedItemPlural: string;
-    i18nNoResults: string;
-    i18nResultSingle: string;
-    i18nResultPlural: string;
+    i18nSelectedValue: string;
+    i18nOptionsAvailable: string;
     i18nInstructions: string;
 }
 
@@ -76,10 +73,7 @@ export interface ComboboxPreviewProps {
     ariaRequired: boolean;
     clearButtonAriaLabel: string;
     removeValueAriaLabel: string;
-    i18nSelectedItemSingular: string;
-    i18nSelectedItemPlural: string;
-    i18nNoResults: string;
-    i18nResultSingle: string;
-    i18nResultPlural: string;
+    i18nSelectedValue: string;
+    i18nOptionsAvailable: string;
     i18nInstructions: string;
 }

--- a/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
+++ b/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
@@ -44,6 +44,12 @@ export interface ComboboxContainerProps {
     ariaRequired: boolean;
     clearButtonAriaLabel: string;
     removeValueAriaLabel: string;
+    i18nSelectedItemSingular: string;
+    i18nSelectedItemPlural: string;
+    i18nNoResults: string;
+    i18nResultSingle: string;
+    i18nResultPlural: string;
+    i18nInstructions: string;
 }
 
 export interface ComboboxPreviewProps {
@@ -70,4 +76,10 @@ export interface ComboboxPreviewProps {
     ariaRequired: boolean;
     clearButtonAriaLabel: string;
     removeValueAriaLabel: string;
+    i18nSelectedItemSingular: string;
+    i18nSelectedItemPlural: string;
+    i18nNoResults: string;
+    i18nResultSingle: string;
+    i18nResultPlural: string;
+    i18nInstructions: string;
 }


### PR DESCRIPTION
<!--
IMPORTANT: Please read and follow instructions below on how to
open and submit your pull request.

REQUIRED STEPS:
1. Specify correct pull request type.
2. Write meaningful description.
3. Run `pnpm lint` and `pnpm test` in packages you changed and make sure they have no errors.
4. Add new tests (if needed) to cover new functionality.
5. Read checklist below.

CHECKLIST:
- Do you have a JIRA story for your pull request?
    - If yes, please format the PR title to match the `[XX-000]: description` pattern.
    - If no, please write your PR title using conventional commit rules.
- Does your change require a new version of the widget/module?
    - If yes, run `pnpm -w changelog` or update the `CHANGELOG.md` and bump the version manually.
    - If no, ignore.
- Do you have related PRs in other Mendix repositories?
    - If yes, please link all related pull requests in the description.
    - If no, ignore.
- Does your change touch XML, or is it a new feature or behavior?
    - If yes, if necessary, please create a PR with updates in the documentation (https://github.com/mendix/docs).
    - If no, ignore.
 - Is your change a bug fix or a new feature?
      - If yes, please add a description (last section in the template) of what should be tested and what steps are needed to test it.
     - If no, ignore.
-->

<!--
What type of changes does your PR introduce?
Uncomment relevant sections below by removing `<!--` at the beginning of the line.
-->

### Pull request type

<!-- No code changes (changes to documentation, CI, metadata, etc.)
<!---->

<!-- Dependency changes (any modification to dependencies in `package.json`)
<!---->

<!-- Refactoring (e.g. file rename, variable rename, etc.)
<!---->

<!-- Bug fix (non-breaking change which fixes an issue)
<!---->

<!-- New feature (non-breaking change which adds functionality)
<!---->

Breaking change (fix or feature that would cause existing functionality to change)
<!---->

<!-- Test related change (New E2E test, test automation, etc.)
<!---->

---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description
Override the default screen reader `getA11yStatusMessage` method inside Downshift to include the selected items in announcement when reading the combobox. 

Now users can modify the a11yStatusMessage which is read by screen readers while using combobox, by changing the default message in the Accessibility tab in SP.

Also, since to this story initially was focusing on Multi selection, we noticed there is a mismatch in behaviour with Single and Multi selection; 

Single selection doesn't open menu when tab focused, but does when click focused. (_correct behaviour_)
Multi selection did open menu both when tab and click focused, so aligned it with Single now.
<!--
Please uncomment and fill in the following section
to describe which part of the package needs to be tested
and how it can be tested.
-->

### What should be covered while testing?

- Focusing on Multi selection both with tab and click, using screenreader utilities and making sure we have the selected values announced.  
- Multi selection changed behaviour in terms of focusing, it doesn't open the dropdown anymore on Tab focus. 
- Added config to Accessibility tab to modify the screen reader announcements. 
