### PR TITLE
feat(datagrid-web): double click action

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -372,11 +372,12 @@ const checkSortingSettings = (
 };
 
 const checkSelectionSettings = (values: DatagridPreviewProps): Problem[] => {
-    if (values.itemSelection !== "None" && values.onClick !== null) {
+    if (values.itemSelection !== "None" && values.onClick !== null && values.onClickTrigger === "single") {
         return [
             {
                 property: "onClick",
-                message: '"On click action" must be set to "Do nothing" when "Selection" is enabled'
+                message:
+                    '"On click action" must be set to "Do nothing" when "Selection" is enabled, or change the click trigger to "Double click" '
             }
         ];
     }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -108,6 +108,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             pagingPosition={props.pagingPosition}
             preview
             processedRows={0}
+            actionTrigger={props.onClickTrigger}
             styles={parseStyle(props.style)}
             setHidden={() => {
                 return undefined;

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -218,6 +218,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
                 },
                 [props.columns]
             )}
+            actionTrigger={props.onClickTrigger}
             rowAction={props.onClick}
             selectionProps={selectionProps}
             selectionStatus={selectionHelper?.type === "Multi" ? selectionHelper.selectionStatus : "unknown"}

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -213,6 +213,14 @@
                 </property>
             </propertyGroup>
             <propertyGroup caption="Events">
+                <property key="onClickTrigger" type="enumeration" defaultValue="single">
+                    <caption>On Click trigger</caption>
+                    <description />
+                    <enumerationValues>
+                        <enumerationValue key="single">Single click</enumerationValue>
+                        <enumerationValue key="double">Double click</enumerationValue>
+                    </enumerationValues>
+                </property>
                 <property key="onClick" type="action" required="false" dataSource="datasource">
                     <caption>On click action</caption>
                     <description />

--- a/packages/pluggableWidgets/datagrid-web/src/components/Row.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Row.tsx
@@ -6,6 +6,7 @@ import { useRowInteractionProps } from "../helpers/useRowInteractionProps";
 import { CellComponent } from "../typings/CellComponent";
 import { GridColumn } from "../typings/GridColumn";
 import { CellElement } from "./CellElement";
+import { OnClickTriggerEnum } from "typings/DatagridProps";
 
 export interface RowProps<C extends GridColumn> {
     className?: string;
@@ -14,6 +15,7 @@ export interface RowProps<C extends GridColumn> {
     item: ObjectItem;
     index: number;
     showSelectorCell?: boolean;
+    actionTrigger: OnClickTriggerEnum;
     rowAction?: ListActionValue;
     preview: boolean;
     selectableWrapper: (column: number, children: React.ReactElement) => React.ReactElement;
@@ -31,6 +33,7 @@ export function Row<C extends GridColumn>(props: RowProps<C>): ReactElement {
     const [interactionProps, { cellClickableClass }] = useRowInteractionProps(
         props.item,
         selectionProps,
+        props.actionTrigger,
         props.rowAction
     );
 

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -14,7 +14,7 @@ import {
     useMemo,
     useState
 } from "react";
-import { PagingPositionEnum } from "../../typings/DatagridProps";
+import { OnClickTriggerEnum, PagingPositionEnum } from "../../typings/DatagridProps";
 import { ColumnWidthConfig, SortingRule, useSettings } from "../features/settings";
 import { WidgetPropsProvider } from "../helpers/useWidgetProps";
 import { CellComponent } from "../typings/CellComponent";
@@ -67,6 +67,7 @@ export interface WidgetProps<C extends GridColumn, T extends ObjectItem = Object
     settings?: EditableValue<string>;
     styles?: CSSProperties;
     valueForSort: (value: T, columnIndex: number) => string | Big | boolean | Date | undefined;
+    actionTrigger: OnClickTriggerEnum;
     rowAction?: ListActionValue;
     selectionProps: GridSelectionProps;
     selectionStatus: SelectionStatus;
@@ -259,6 +260,7 @@ export function Widget<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
                                         index={rowIndex}
                                         item={item}
                                         key={`row_${item.id}`}
+                                        actionTrigger={props.actionTrigger}
                                         rowAction={props.rowAction}
                                         showSelectorCell={columnsHidable}
                                         preview={preview ?? false}

--- a/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
@@ -80,6 +80,7 @@ export function mockWidgetProps(): WidgetProps<GridColumn, ObjectItem> {
         setHidden: jest.fn(),
         setOrder: jest.fn(),
         valueForSort: () => "dummy",
+        actionTrigger: "single",
         selectionProps,
         selectionStatus: "unknown",
         setPage: jest.fn(),

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -45,6 +45,8 @@ export type PagingPositionEnum = "bottom" | "top" | "both";
 
 export type ShowEmptyPlaceholderEnum = "none" | "custom";
 
+export type OnClickTriggerEnum = "single" | "double";
+
 export interface FilterListType {
     filter: ListAttributeValue<string | Big | boolean | Date>;
 }
@@ -94,6 +96,7 @@ export interface DatagridContainerProps {
     showEmptyPlaceholder: ShowEmptyPlaceholderEnum;
     emptyPlaceholder?: ReactNode;
     rowClass?: ListExpressionValue<string>;
+    onClickTrigger: OnClickTriggerEnum;
     onClick?: ListActionValue;
     onSelectionChange?: ActionValue;
     columnsSortable: boolean;
@@ -131,6 +134,7 @@ export interface DatagridPreviewProps {
     showEmptyPlaceholder: ShowEmptyPlaceholderEnum;
     emptyPlaceholder: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     rowClass: string;
+    onClickTrigger: OnClickTriggerEnum;
     onClick: {} | null;
     onSelectionChange: {} | null;
     columnsSortable: boolean;


### PR DESCRIPTION
Data Grid 1 has a double-click option. This PR adds the double-click option to the DataGrid 2. This will allow developers to replace old data grids with matching functionality.

The double click will be even more effective when the DG2 can emit events for the data view Data source Type "Listen to widget."

An option to consider is to add an extra action for "onClickDouble.". Though this might conflict with the single action, both actions might delay the click action.
