### PR TITLE
feat(rich-text-web): configurable styles drop down based on style …

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We added the posibility to customize the styles menu and use a selection of styles from the app's theme.
+
 ## [2.2.3] - 2023-10-27
 
 ### Fixed

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
@@ -56,6 +56,9 @@ export function getProperties(
     } else {
         hidePropertyIn(defaultProperties, values, "advancedMode");
     }
+    if (values.styleSetName === undefined) {
+        hidePropertiesIn(defaultProperties, values, ["stylesConfig", "validSelectors", "skipSelectors"]);
+    }
     return defaultProperties;
 }
 

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.xml
@@ -301,6 +301,41 @@
                     <description />
                 </property>
             </propertyGroup>
+            <propertyGroup caption="Custom Style Set">
+                <property key="styleSetName" type="string" required="false">
+                    <caption>Name</caption>
+                    <description />
+                </property>
+                <property key="validSelectors" type="string" required="false">
+                    <caption>Valid Selectors</caption>
+                    <description>Define a regular expression for elements and classes from the app's stylesheets, that should be shown in the styles combo box.</description>
+                </property>
+                <property key="skipSelectors" type="string" required="false">
+                    <caption>Skip Selectors</caption>
+                    <description>Define a regular expression for elements and classes from the app's stylesheets, that should not be shown in the styles combo box.</description>
+                </property>
+                <property key="stylesConfig" type="object" isList="true" required="false">
+                    <caption>Styles</caption>
+                    <description />
+                    <properties>
+                        <property key="styleName" type="string" required="true">
+                            <caption>Name</caption>
+                            <category>item</category>
+                            <description>Name of the Style as shown in the dropdown box</description>
+                        </property>
+                        <property key="styleElement" type="string" required="true">
+                            <caption>Element</caption>
+                            <category>item</category>
+                            <description>HTML Element that the style is applied to</description>
+                        </property>
+                        <property key="styleClass" type="string" required="false">
+                            <caption>Class</caption>
+                            <category>item</category>
+                            <description>Style Class of the element as definied in one of the project's stylesheets</description>
+                        </property>
+                    </properties>
+                </property>
+            </propertyGroup>
         </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
@@ -46,6 +46,10 @@ const defaultRichTextProps: RichTextContainerProps = {
     codeHighlight: false,
     allowedContent: "",
     disallowedContent: "",
+    styleSetName: "",
+    validSelectors: "",
+    skipSelectors: "",
+    stylesConfig: [],
     id: "1.Dev.Test_ListenTo.richText1_x_1"
 };
 

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
@@ -7,10 +7,11 @@ import {
     ToolbarGroup,
     ToolbarItems,
     GroupType,
-    createCustomToolbar
+    createCustomToolbar,
+    Style
 } from "./ckeditorPresets";
 
-export type PluginName = "codesnippet" | "openlink" | "indent" | "indentlist";
+export type PluginName = "stylesheetparser" | "codesnippet" | "openlink" | "indent" | "indentlist";
 
 const PLUGIN_CONFIGS = {
     openlink: {
@@ -27,6 +28,13 @@ const PLUGIN_CONFIGS = {
         name: "CodeSnippet",
         config: {
             codeSnippet_theme: "idea"
+        }
+    },
+    stylesheetparser: {
+        extraPlugins: "stylesheetparser",
+        name: "StylesheetParser",
+        config: {
+            contentsCss: "theme.compiled.css"
         }
     },
     indent: null,
@@ -112,6 +120,26 @@ export function defineAdvancedGroups(widgetProps: RichTextContainerProps): Toolb
     return toolbarArray;
 }
 
+export function defineStyleSet(widgetProps: RichTextContainerProps): Style[] | string {
+    const { stylesConfig: items } = widgetProps;
+    const styleSet: Style[] = [];
+    if (items.length === 0) {
+        return "default";
+    } else {
+        items.forEach(item => {
+            const styleAttributes = {
+                class: item.styleClass
+            };
+            styleSet.push({
+                name: item.styleName,
+                element: item.styleElement,
+                attributes: styleAttributes
+            });
+        });
+        return styleSet;
+    }
+}
+
 export function getToolbarConfig(widgetProps: RichTextContainerProps): CKEditorConfig {
     const { preset, toolbarConfig } = widgetProps;
 
@@ -139,7 +167,10 @@ export function getCKEditorConfig(widgetProps: RichTextContainerProps): CKEditor
         width,
         widthUnit,
         height,
-        heightUnit
+        heightUnit,
+        styleSetName,
+        validSelectors,
+        skipSelectors
     } = widgetProps;
 
     const dimensions = getDimensions({
@@ -161,6 +192,7 @@ export function getCKEditorConfig(widgetProps: RichTextContainerProps): CKEditor
         disableNativeSpellChecker: !spellChecker,
         readOnly: stringAttribute.readOnly,
         removeButtons: "",
+        stylesSet: defineStyleSet(widgetProps),
         ...getToolbarConfig(widgetProps)
     };
 
@@ -168,6 +200,16 @@ export function getCKEditorConfig(widgetProps: RichTextContainerProps): CKEditor
 
     if (codeHighlight) {
         plugins.push("codesnippet");
+    }
+
+    if (styleSetName) {
+        plugins.push("stylesheetparser");
+        if (validSelectors) {
+            config.stylesheetParser_validSelectors = new RegExp(validSelectors);
+        }
+        if (skipSelectors) {
+            config.stylesheetParser_skipSelectors = new RegExp(skipSelectors);
+        }
     }
 
     for (const plugin of plugins) {

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
@@ -10,6 +10,12 @@ export interface ToolbarItems {
     items: string[];
 }
 
+export interface Style {
+    name: string;
+    element: string;
+    attributes: object;
+}
+
 export type GroupType =
     | "documentGroup"
     | "formsGroup"

--- a/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
+++ b/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
@@ -30,9 +30,21 @@ export type ShiftEnterModeEnum = "paragraph" | "breakLines" | "blocks";
 
 export type AdvancedContentFilterEnum = "auto" | "custom";
 
+export interface StylesConfigType {
+    styleName: string;
+    styleElement: string;
+    styleClass: string;
+}
+
 export interface AdvancedConfigPreviewType {
     ctItemType: CtItemTypeEnum;
     ctItemToolbar: string;
+}
+
+export interface StylesConfigPreviewType {
+    styleName: string;
+    styleElement: string;
+    styleClass: string;
 }
 
 export interface RichTextContainerProps {
@@ -74,6 +86,10 @@ export interface RichTextContainerProps {
     advancedContentFilter: AdvancedContentFilterEnum;
     allowedContent: string;
     disallowedContent: string;
+    styleSetName: string;
+    validSelectors: string;
+    skipSelectors: string;
+    stylesConfig: StylesConfigType[];
 }
 
 export interface RichTextPreviewProps {
@@ -113,4 +129,8 @@ export interface RichTextPreviewProps {
     advancedContentFilter: AdvancedContentFilterEnum;
     allowedContent: string;
     disallowedContent: string;
+    styleSetName: string;
+    validSelectors: string;
+    skipSelectors: string;
+    stylesConfig: StylesConfigPreviewType[];
 }


### PR DESCRIPTION
…classes from app theme

<!--
IMPORTANT: Please read and follow instructions below on how to
open and submit your pull request.

REQUIRED STEPS:
1. Specify correct pull request type.
2. Write meaningful description.
3. Run `pnpm lint` and `pnpm test` in packages you changed and make sure they have no errors.
4. Add new tests (if needed) to cover new functionality.
5. Read checklist below.

CHECKLIST:
- Do you have a JIRA story for your pull request?
    - If yes, please format the PR title to match the `[XX-000]: description` pattern.
    - If no, please write your PR title using conventional commit rules.
- Does your change require a new version of the widget/module?
    - If yes, run `pnpm -w changelog` or update the `CHANGELOG.md` and bump the version manually.
    - If no, ignore.
- Do you have related PRs in other Mendix repositories?
    - If yes, please link all related pull requests in the description.
    - If no, ignore.
- Does your change touch XML, or is it a new feature or behavior?
    - If yes, if necessary, please create a PR with updates in the documentation (https://github.com/mendix/docs).
    - If no, ignore.
 - Is your change a bug fix or a new feature?
      - If yes, please add a description (last section in the template) of what should be tested and what steps are needed to test it.
     - If no, ignore.
-->

<!--
What type of changes does your PR introduce?
Uncomment relevant sections below by removing `<!--` at the beginning of the line.
-->

### Pull request type

<!-- No code changes (changes to documentation, CI, metadata, etc.)
<!---->

<!-- Dependency changes (any modification to dependencies in `package.json`)
<!---->

<!-- Refactoring (e.g. file rename, variable rename, etc.)
<!---->

<!-- Bug fix (non-breaking change which fixes an issue)
<!---->

New feature (non-breaking change which adds functionality)

<!-- Breaking change (fix or feature that would cause existing functionality to change)
<!---->

<!-- Test related change (New E2E test, test automation, etc.)
<!---->

---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description

The rich text widget has a styles menu that allows to style a selection or starting from the current cursor position. However, only very few choices are available, and the hardcoded styles might not fit the apps needs

![image](https://github.com/mendix/web-widgets/assets/112866741/5dfb7dd0-b488-4644-9d7a-980fddc9495a)


Besides the fonts in the menu look different than the fonts in the editor:

![image](https://github.com/mendix/web-widgets/assets/112866741/4ceda6d3-b521-43ad-ba6d-bd360220ae4e)


This feature leverages CKEditor4's capability to use custom styles, in case of a Mendix application the theme defined in App/Styling: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_howtos_styles.html

By default, nothing is changed, so existing apps should behave as before (updating widgets is required though). When the developer decides to use custom styles, he sets the "Styleset name" in the widget properties. 

The developer can then assign a subset of style classes from the App's theme to the rich text widget. 
![image](https://github.com/mendix/web-widgets/assets/112866741/14c73417-fb2c-4f52-ad53-380a75bda0da)


The styles menu can be explicitly designed so that proper styles are selectable depending on the context (text, table, selection, etc.). The "Valid Selectors" property defines available style classes from the theme. In the "Edit Styles" dialog, the available styles can be assigned to HTML tags, so that the "Styles" menu shows available options based on the current context.

![image](https://github.com/mendix/web-widgets/assets/112866741/991d9a35-ef12-407b-be5f-253d8a214427)

Styles in the menu look the same as in the editor, so there is a better WYSIWYG experience.

Menu:

![image](https://github.com/mendix/web-widgets/assets/112866741/072a5728-923c-4ed4-beaf-f26a98d404e4)

Editor:

![image](https://github.com/mendix/web-widgets/assets/112866741/d2717939-d36f-402e-8fe8-d4b8217f954c)

Result in HTML Element:

![image](https://github.com/mendix/web-widgets/assets/112866741/015777a0-0005-4ecf-952b-aae588974676)

Inspecting the resulting content stored in the entity shows that style information is stored in classes instead of style attributes and HTML, which is more in line with Mendix best practices:

![image](https://github.com/mendix/web-widgets/assets/112866741/4028e0e1-c7e2-41ce-ada4-0b69602f6cbe)

I have created a Mendix app including data snapshot to showcase the improved widget. If so desired, I can invite any reviewer as a team member to test the changes.

<!--
### What should be covered while testing?
-->
