### PR TITLE
feat(richt-text-web): Improved content templates

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   Enabled customization of CKEditor 4 content template plugin.
+
 ## [2.2.3] - 2023-10-27
 
 ### Fixed

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
@@ -39,11 +39,36 @@ export function getProperties(
     if (values.preset !== "custom") {
         hidePropertiesIn(defaultProperties, values, toolbarGroups.concat(["toolbarConfig", "advancedConfig"]));
     }
+    if (values.preset === "basic" || values.preset === "standard") {
+        hidePropertiesIn(defaultProperties, values, [
+            "templates",
+            "templateDatasource",
+            "templateTitleAttribute",
+            "templateDescriptionAttribute",
+            "templateHtmlAttribute"
+        ]);
+    }
     if (values.toolbarConfig === "basic") {
-        hidePropertiesIn(defaultProperties, values, ["advancedConfig"]);
+        hidePropertiesIn(defaultProperties, values, [
+            "advancedConfig",
+            "templates",
+            "templateDatasource",
+            "templateTitleAttribute",
+            "templateDescriptionAttribute",
+            "templateHtmlAttribute"
+        ]);
     }
     if (values.toolbarConfig === "advanced") {
         hidePropertiesIn(defaultProperties, values, toolbarGroups);
+        if (values.advancedConfig.filter(e => e.ctItemType === "Templates").length < 1) {
+            hidePropertiesIn(defaultProperties, values, [
+                "templates",
+                "templateDatasource",
+                "templateTitleAttribute",
+                "templateDescriptionAttribute",
+                "templateHtmlAttribute"
+            ]);
+        }
     }
     if (values.advancedContentFilter === "auto") {
         hidePropertiesIn(defaultProperties, values, ["allowedContent", "disallowedContent"]);

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
@@ -36,33 +36,48 @@ export function getProperties(
     defaultProperties: Properties,
     platform: "web" | "desktop"
 ): Properties {
-    if (values.preset !== "custom") {
+    if (values.preset === "custom") {
+        if (values.toolbarConfig === "basic") {
+            hidePropertiesIn(defaultProperties, values, [
+                "advancedConfig",
+                "templates",
+                "templateDatasource",
+                "templateTitleAttribute",
+                "templateDescriptionAttribute",
+                "templateHtmlAttribute"
+            ]);
+        }
+        if (values.toolbarConfig === "advanced") {
+            hidePropertiesIn(defaultProperties, values, toolbarGroups);
+            if (values.advancedConfig.filter(e => e.ctItemType === "Templates").length < 1) {
+                hidePropertiesIn(defaultProperties, values, [
+                    "templates",
+                    "templateDatasource",
+                    "templateTitleAttribute",
+                    "templateDescriptionAttribute",
+                    "templateHtmlAttribute"
+                ]);
+            } else if (values.templates === "default") {
+                hidePropertiesIn(defaultProperties, values, [
+                    "templateDatasource",
+                    "templateTitleAttribute",
+                    "templateDescriptionAttribute",
+                    "templateHtmlAttribute"
+                ]);
+            }
+        }
+    } else {
         hidePropertiesIn(defaultProperties, values, toolbarGroups.concat(["toolbarConfig", "advancedConfig"]));
-    }
-    if (values.preset === "basic" || values.preset === "standard") {
-        hidePropertiesIn(defaultProperties, values, [
-            "templates",
-            "templateDatasource",
-            "templateTitleAttribute",
-            "templateDescriptionAttribute",
-            "templateHtmlAttribute"
-        ]);
-    }
-    if (values.toolbarConfig === "basic") {
-        hidePropertiesIn(defaultProperties, values, [
-            "advancedConfig",
-            "templates",
-            "templateDatasource",
-            "templateTitleAttribute",
-            "templateDescriptionAttribute",
-            "templateHtmlAttribute"
-        ]);
-    }
-    if (values.toolbarConfig === "advanced") {
-        hidePropertiesIn(defaultProperties, values, toolbarGroups);
-        if (values.advancedConfig.filter(e => e.ctItemType === "Templates").length < 1) {
+        if (values.preset === "basic" || values.preset === "standard") {
             hidePropertiesIn(defaultProperties, values, [
                 "templates",
+                "templateDatasource",
+                "templateTitleAttribute",
+                "templateDescriptionAttribute",
+                "templateHtmlAttribute"
+            ]);
+        } else if (values.templates === "default") {
+            hidePropertiesIn(defaultProperties, values, [
                 "templateDatasource",
                 "templateTitleAttribute",
                 "templateDescriptionAttribute",

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.xml
@@ -90,7 +90,7 @@
                 </property>
             </propertyGroup>
         </propertyGroup>
-        <propertyGroup caption="Custom toolbar">
+        <propertyGroup caption="Toolbar">
             <propertyGroup caption="Custom toolbar">
                 <property key="toolbarConfig" type="enumeration" defaultValue="basic">
                     <caption>Toolbar group</caption>
@@ -241,6 +241,37 @@
                             <description>Identifies in which toolbar this button appears. Make sure to give this a short and descriptive identifier. Items with the same Toolbar ID will be grouped</description>
                         </property>
                     </properties>
+                </property>
+            </propertyGroup>
+            <propertyGroup caption="Content templates">
+                <property key="templates" type="string" defaultValue="default">
+                    <caption>Template name</caption>
+                    <description>Name of the template to be used. Default is 'default'.</description>
+                </property>
+                <property key="templateDatasource" type="datasource" isList="true">
+                    <caption>Template source</caption>
+                    <description>The datasource providing a list of actual content templates for the rich text editor.</description>
+                </property>
+                <property key="templateTitleAttribute" type="attribute" required="true" dataSource="templateDatasource">
+                    <caption>Title attribute</caption>
+                    <description>The name of the title attribute of the current content template.</description>
+                    <attributeTypes>
+                        <attributeType name="String" />
+                    </attributeTypes>
+                </property>
+                <property key="templateDescriptionAttribute" type="attribute" required="true" dataSource="templateDatasource">
+                    <caption>Description attribute</caption>
+                    <description>The name of the description attribute of the current content template.</description>
+                    <attributeTypes>
+                        <attributeType name="String" />
+                    </attributeTypes>
+                </property>
+                <property key="templateHtmlAttribute" type="attribute" required="true" dataSource="templateDatasource">
+                    <caption>HTML attribute</caption>
+                    <description>The name of the HTML attribute of the current content template.</description>
+                    <attributeTypes>
+                        <attributeType name="String" />
+                    </attributeTypes>
                 </property>
             </propertyGroup>
         </propertyGroup>

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -1,10 +1,17 @@
 import { debounce } from "@mendix/widget-plugin-platform/utils/debounce";
-import { CKEditorEventPayload, CKEditorHookProps, CKEditorInstance } from "ckeditor4-react";
+import {
+    CKEditorEventPayload,
+    CKEditorHookProps,
+    CKEditorInstance,
+    CKEditorNamespace,
+    CKEditorEventAction
+} from "ckeditor4-react";
 import { Component, createElement } from "react";
 import { RichTextContainerProps } from "../../typings/RichTextProps";
 import { getCKEditorConfig } from "../utils/ckeditorConfigs";
 import { MainEditor } from "./MainEditor";
 import DOMPurify from "dompurify";
+import { ValueStatus } from "mendix";
 
 const FILE_SIZE_LIMIT = 1048576; // Binary bytes for 1MB
 
@@ -26,6 +33,18 @@ interface CKEditorEvent {
     stop(): void;
 }
 
+class ContentTemplate {
+    title: string;
+    description: string;
+    html: string;
+
+    constructor(title: string, description: string, html: string) {
+        this.title = title;
+        this.description = description;
+        this.html = html;
+    }
+}
+
 export class Editor extends Component<EditorProps> {
     widgetProps: RichTextContainerProps;
     editor: CKEditorInstance | null;
@@ -33,6 +52,7 @@ export class Editor extends Component<EditorProps> {
     editorKey: number;
     editorScript = "widgets/ckeditor/ckeditor.js";
     element: HTMLElement;
+    namespace: CKEditorNamespace;
     lastSentValue: string | undefined;
     applyChangesDebounce: () => void;
     setDataDebounce: (data: string | undefined) => void;
@@ -45,7 +65,7 @@ export class Editor extends Component<EditorProps> {
         this.widgetProps = { ...this.props.widgetProps };
         this.element = this.props.element;
         this.editorKey = this.getNewKey();
-        this.editorHookProps = this.getNewEditorHookProps();
+        this.editorHookProps = this.getNewEditorHookProps(true);
         this.onChange = this.onChange.bind(this);
         this.applyChangesDebounce = debounce(this.applyChangesImmediately.bind(this), 500)[0];
         this.setDataDebounce = debounce(data => this.editor?.setData(data, () => this.addListeners()), 50)[0];
@@ -55,30 +75,38 @@ export class Editor extends Component<EditorProps> {
         this.hasFocus = false;
     }
 
-    setNewRenderProps(): void {
+    setNewRenderProps(updatePlugins: boolean): void {
         this.widgetProps = { ...this.props.widgetProps };
-        this.element = this.props.element;
+        if (updatePlugins) {
+            this.element = this.props.element;
+        }
         this.editorKey = this.getNewKey();
-        this.editorHookProps = this.getNewEditorHookProps();
+        this.editorHookProps = this.getNewEditorHookProps(updatePlugins || true);
     }
 
     getRenderProps(): [number, EditorHookProps] {
         if (this.shouldRebuildEditor()) {
-            this.setNewRenderProps();
+            this.setNewRenderProps(true);
+        } else if (this.shouldUpdateEditor()) {
+            this.setNewRenderProps(false);
         }
 
         return [this.editorKey, this.editorHookProps];
     }
 
     shouldRebuildEditor(): boolean {
+        if (this.element !== this.props.element) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    shouldUpdateEditor(): boolean {
         const keys = Object.keys(this.widgetProps) as Array<keyof RichTextContainerProps>;
 
         const prevProps = this.widgetProps;
         const nextProps = this.props.widgetProps;
-
-        if (this.element !== this.props.element) {
-            return true;
-        }
 
         return keys.some(key => {
             // We skip stringAttribute as it always changes. And we
@@ -107,22 +135,30 @@ export class Editor extends Component<EditorProps> {
         return new URL(this.editorScript, window.mx.remoteUrl).toString();
     }
 
-    getNewEditorHookProps(): EditorHookProps {
+    getNewEditorHookProps(updatePlugins: boolean): EditorHookProps {
         const onInstanceReady = this.onInstanceReady.bind(this);
+        const onPluginsLoaded = this.onPluginsLoaded.bind(this);
         const onDestroy = this.onDestroy.bind(this);
-        const config = getCKEditorConfig(this.widgetProps);
+        const config = getCKEditorConfig(this.widgetProps, updatePlugins);
 
         return {
-            element: this.element,
+            element: this.props.element,
             editorUrl: this.getEditorUrl(),
             type: this.widgetProps.editorType,
+            dispatchEvent: ({ type, payload }) => {
+                if (type === CKEditorEventAction.namespaceLoaded) {
+                    this.namespace = payload;
+                }
+            },
             // Here we ignore hook API and instead use
             // editor instance to subscribe to events.
-            subscribeTo: [],
             config: Object.assign(config, {
                 on: {
                     instanceReady(this: CKEditorInstance) {
                         onInstanceReady(this);
+                    },
+                    pluginsLoaded(this: CKEditorInstance) {
+                        onPluginsLoaded(this);
                     },
                     destroy: onDestroy
                 }
@@ -135,6 +171,38 @@ export class Editor extends Component<EditorProps> {
         this.updateEditorState({
             data: this.widgetProps.stringAttribute.value
         });
+    }
+
+    onPluginsLoaded(editor: CKEditorInstance): void {
+        this.editor = editor;
+        const datasource = this.widgetProps.templateDatasource;
+        const CKEDITOR: CKEditorNamespace = this.namespace;
+        if (datasource === undefined) {
+            console.warn("Templates datasource not set for editor " + this.widgetProps.name);
+        } else if (datasource.status === ValueStatus.Available) {
+            console.log("Configuring content templates");
+            const contentTemplates: ContentTemplate[] = [];
+            const mxObjects = datasource.items;
+            if (mxObjects) {
+                mxObjects.forEach(mxObject => {
+                    console.info(
+                        "Adding template: " + this.widgetProps.templateTitleAttribute.get(mxObject).value || "<title>"
+                    );
+                    const contentTemplate: ContentTemplate = new ContentTemplate(
+                        this.widgetProps.templateTitleAttribute.get(mxObject).value || "<title>",
+                        this.widgetProps.templateDescriptionAttribute.get(mxObject).value || "<description>",
+                        this.widgetProps.templateHtmlAttribute.get(mxObject).value || "[html]"
+                    );
+                    contentTemplates.push(contentTemplate);
+                });
+            }
+            console.log("Registering templates");
+            CKEDITOR.addTemplates(this.widgetProps.templates, {
+                imagesPath: window.location.origin + "/img/",
+                templates: contentTemplates
+            });
+            console.info("Content templates for " + this.widgetProps.templates + " registered successfully.");
+        }
     }
 
     onDestroy(): void {
@@ -187,7 +255,7 @@ export class Editor extends Component<EditorProps> {
         }
     }
 
-    applyChangesImmediately() {
+    applyChangesImmediately(): void {
         // put last seen content to the attribute if it exists
         if (this.lastSentValue !== undefined) {
             this.widgetProps.stringAttribute.setValue(this.lastSentValue);
@@ -264,7 +332,7 @@ export class Editor extends Component<EditorProps> {
         this.lastSentValue = undefined;
     }
 
-    componentDidMount() {
+    componentDidMount(): void {
         this.cancelRAF = animationLoop(() => {
             if (this.element && this.element.parentElement) {
                 const newHasFocus = this.element.parentElement.contains(document.activeElement);
@@ -279,7 +347,7 @@ export class Editor extends Component<EditorProps> {
         });
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         this.cancelRAF?.();
     }
 

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -65,7 +65,7 @@ export class Editor extends Component<EditorProps> {
         this.widgetProps = { ...this.props.widgetProps };
         this.element = this.props.element;
         this.editorKey = this.getNewKey();
-        this.editorHookProps = this.getNewEditorHookProps(/*true*/);
+        this.editorHookProps = this.getNewEditorHookProps();
         this.onChange = this.onChange.bind(this);
         this.applyChangesDebounce = debounce(this.applyChangesImmediately.bind(this), 500)[0];
         this.setDataDebounce = debounce(data => this.editor?.setData(data, () => this.addListeners()), 50)[0];
@@ -95,24 +95,21 @@ export class Editor extends Component<EditorProps> {
         } else {
             const keys = Object.keys(this.widgetProps) as Array<keyof RichTextContainerProps>;
 
-            const prevProps = this.widgetProps;
-            const nextProps = this.props.widgetProps;
-
             return keys.some(key => {
                 // We skip stringAttribute as it always changes. And we
                 // handle updates in componentDidUpdate method.
                 if (key === "stringAttribute") {
                     return false;
                 }
-
                 if (key === "onChange") {
                     return false;
                 }
-
                 if (key === "onKeyPress") {
                     return false;
                 }
 
+                const prevProps = this.widgetProps;
+                const nextProps = this.props.widgetProps;
                 return prevProps[key] !== nextProps[key];
             });
         }

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -83,11 +83,13 @@ export class Editor extends Component<EditorProps> {
     }
 
     getRenderProps(): [number, EditorHookProps] {
-        this.setNewRenderProps();
+        if (this.shouldRebuildEditor()) {
+            this.setNewRenderProps();
+        }
         return [this.editorKey, this.editorHookProps];
     }
 
-    shouldUpdateEditor(): boolean {
+    shouldRebuildEditor(): boolean {
         if (this.element !== this.props.element) {
             return true;
         } else {

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -20,7 +20,7 @@ interface EditorProps {
     widgetProps: RichTextContainerProps;
 }
 
-type EditorHookProps = CKEditorHookProps<never>;
+type EditorHookProps = CKEditorHookProps<"beforeLoad">;
 
 interface CKEditorEvent {
     data: any;
@@ -140,6 +140,7 @@ export class Editor extends Component<EditorProps> {
             },
             // Here we ignore hook API and instead use
             // editor instance to subscribe to events.
+            subscribeTo: ["beforeLoad"],
             config: Object.assign(config, {
                 on: {
                     instanceReady(this: CKEditorInstance) {
@@ -163,7 +164,7 @@ export class Editor extends Component<EditorProps> {
 
     onPluginsLoaded(editor: CKEditorInstance): void {
         this.editor = editor;
-        if (this.widgetProps.templates !== "default") {
+        if (this.widgetProps.templates && this.widgetProps.templates !== "default") {
             const datasource = this.widgetProps.templateDatasource;
             if (datasource === undefined) {
                 console.warn("Templates datasource not set for editor " + this.widgetProps.name);

--- a/packages/pluggableWidgets/rich-text-web/src/components/MainEditor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/MainEditor.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { useCKEditor, CKEditorHookProps } from "ckeditor4-react";
 
 export interface MainEditorProps {
-    config: CKEditorHookProps<never>;
+    config: CKEditorHookProps<"beforeLoad">;
 }
 
 // Main idea of this component is to make sure it's never rerenders.

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
@@ -6,7 +6,7 @@ import { getPreset, defineEnterMode, getToolbarGroupByName, defineAdvancedGroups
 import { mount, ReactWrapper } from "enzyme";
 import renderer from "react-test-renderer";
 import { getDimensions } from "@mendix/widget-plugin-platform/utils/get-dimensions";
-import { EditableValueBuilder } from "@mendix/widget-plugin-test-utils";
+import { EditableValueBuilder, ListValueBuilder, ListAttributeValueBuilder } from "@mendix/widget-plugin-test-utils";
 import { TOOLBAR_GROUP, ToolbarGroup } from "../../utils/ckeditorPresets";
 import { AdvancedConfigType, RichTextContainerProps } from "../../../typings/RichTextProps";
 
@@ -46,6 +46,11 @@ const defaultRichTextProps: RichTextContainerProps = {
     codeHighlight: false,
     allowedContent: "",
     disallowedContent: "",
+    templates: "default",
+    templateDatasource: ListValueBuilder().simple(),
+    templateTitleAttribute: new ListAttributeValueBuilder<string>().build(),
+    templateDescriptionAttribute: new ListAttributeValueBuilder<string>().build(),
+    templateHtmlAttribute: new ListAttributeValueBuilder<string>().build(),
     id: "1.Dev.Test_ListenTo.richText1_x_1"
 };
 

--- a/packages/pluggableWidgets/rich-text-web/src/ui/RichText.scss
+++ b/packages/pluggableWidgets/rich-text-web/src/ui/RichText.scss
@@ -10,6 +10,7 @@
 @use "~ckeditor4/plugins/emoji/skins/default.css" as emoji;
 @use "~ckeditor4/plugins/preview/styles/screen.css";
 @use "~ckeditor4/plugins/copyformatting/styles/copyformatting.css";
+@use "~ckeditor4/plugins/templates/dialogs/templates.css";
 
 .widget-rich-text {
     &.editor-text {

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
@@ -50,14 +50,14 @@ export function defineEnterMode(type: string): number {
     }
 }
 
-export function getPreset(type: PresetEnum): CKEditorConfig {
+export function getPreset(type: PresetEnum, templates = "default", updatePlugins = false): CKEditorConfig {
     switch (type) {
         case "standard":
             return createPreset("standard");
         case "basic":
             return createPreset("basic");
         case "full":
-            return createPreset("full");
+            return createPreset("full", templates, updatePlugins);
         default:
             return createPreset("basic");
     }
@@ -112,20 +112,20 @@ export function defineAdvancedGroups(widgetProps: RichTextContainerProps): Toolb
     return toolbarArray;
 }
 
-export function getToolbarConfig(widgetProps: RichTextContainerProps): CKEditorConfig {
-    const { preset, toolbarConfig } = widgetProps;
+export function getToolbarConfig(widgetProps: RichTextContainerProps, updatePlugins: boolean): CKEditorConfig {
+    const { preset, toolbarConfig, templates } = widgetProps;
 
     if (preset !== "custom") {
-        return getPreset(preset);
+        return getPreset(preset, templates, updatePlugins);
     }
 
     const isBasic = toolbarConfig === "basic";
     const groupItems = isBasic ? defineBasicGroups(widgetProps) : defineAdvancedGroups(widgetProps);
 
-    return createCustomToolbar(groupItems, isBasic);
+    return createCustomToolbar(groupItems, isBasic, templates, updatePlugins);
 }
 
-export function getCKEditorConfig(widgetProps: RichTextContainerProps): CKEditorConfig {
+export function getCKEditorConfig(widgetProps: RichTextContainerProps, updatePlugins: boolean): CKEditorConfig {
     const {
         codeHighlight,
         advancedContentFilter,
@@ -161,7 +161,7 @@ export function getCKEditorConfig(widgetProps: RichTextContainerProps): CKEditor
         disableNativeSpellChecker: !spellChecker,
         readOnly: stringAttribute.readOnly,
         removeButtons: "",
-        ...getToolbarConfig(widgetProps)
+        ...getToolbarConfig(widgetProps, updatePlugins)
     };
 
     const plugins: PluginName[] = ["openlink", "indent", "indentlist"];
@@ -170,8 +170,10 @@ export function getCKEditorConfig(widgetProps: RichTextContainerProps): CKEditor
         plugins.push("codesnippet");
     }
 
-    for (const plugin of plugins) {
-        addPlugin(plugin, config);
+    if (updatePlugins) {
+        for (const plugin of plugins) {
+            addPlugin(plugin, config);
+        }
     }
 
     if (advancedContentFilter === "custom") {

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorConfigs.ts
@@ -50,14 +50,14 @@ export function defineEnterMode(type: string): number {
     }
 }
 
-export function getPreset(type: PresetEnum, templates = "default", updatePlugins = false): CKEditorConfig {
+export function getPreset(type: PresetEnum, templates = "default"): CKEditorConfig {
     switch (type) {
         case "standard":
             return createPreset("standard");
         case "basic":
             return createPreset("basic");
         case "full":
-            return createPreset("full", templates, updatePlugins);
+            return createPreset("full", templates);
         default:
             return createPreset("basic");
     }
@@ -112,20 +112,20 @@ export function defineAdvancedGroups(widgetProps: RichTextContainerProps): Toolb
     return toolbarArray;
 }
 
-export function getToolbarConfig(widgetProps: RichTextContainerProps, updatePlugins: boolean): CKEditorConfig {
+export function getToolbarConfig(widgetProps: RichTextContainerProps): CKEditorConfig {
     const { preset, toolbarConfig, templates } = widgetProps;
 
     if (preset !== "custom") {
-        return getPreset(preset, templates, updatePlugins);
+        return getPreset(preset, templates);
     }
 
     const isBasic = toolbarConfig === "basic";
     const groupItems = isBasic ? defineBasicGroups(widgetProps) : defineAdvancedGroups(widgetProps);
 
-    return createCustomToolbar(groupItems, isBasic, templates, updatePlugins);
+    return createCustomToolbar(groupItems, isBasic, templates);
 }
 
-export function getCKEditorConfig(widgetProps: RichTextContainerProps, updatePlugins: boolean): CKEditorConfig {
+export function getCKEditorConfig(widgetProps: RichTextContainerProps): CKEditorConfig {
     const {
         codeHighlight,
         advancedContentFilter,
@@ -161,7 +161,7 @@ export function getCKEditorConfig(widgetProps: RichTextContainerProps, updatePlu
         disableNativeSpellChecker: !spellChecker,
         readOnly: stringAttribute.readOnly,
         removeButtons: "",
-        ...getToolbarConfig(widgetProps, updatePlugins)
+        ...getToolbarConfig(widgetProps)
     };
 
     const plugins: PluginName[] = ["openlink", "indent", "indentlist"];
@@ -170,10 +170,8 @@ export function getCKEditorConfig(widgetProps: RichTextContainerProps, updatePlu
         plugins.push("codesnippet");
     }
 
-    if (updatePlugins) {
-        for (const plugin of plugins) {
-            addPlugin(plugin, config);
-        }
+    for (const plugin of plugins) {
+        addPlugin(plugin, config);
     }
 
     if (advancedContentFilter === "custom") {

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
@@ -84,7 +84,11 @@ const TOOLBAR_ITEMS: ToolbarItems[] = [
     { name: "about", items: ["About"] }
 ];
 
-function createPreset(type: "basic" | "standard" | "full"): CKEditorConfig {
+function createPreset(
+    type: "basic" | "standard" | "full",
+    templates = "default",
+    updatePlugins = false
+): CKEditorConfig {
     const config: CKEditorConfig = {};
     let toolbarGroup: Array<ToolbarGroup | string> = [];
     switch (type) {
@@ -108,8 +112,11 @@ function createPreset(type: "basic" | "standard" | "full"): CKEditorConfig {
             config.toolbarGroups = toolbarGroup;
             config.removeButtons = "";
             /* TODO temporary removed exportpdf*/
-            config.extraPlugins =
-                "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks";
+            if (updatePlugins) {
+                config.extraPlugins =
+                    "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks";
+            }
+            config.templates = templates;
             break;
         default:
             config.toolbarGroups = [...TOOLBAR_GROUP];
@@ -117,7 +124,12 @@ function createPreset(type: "basic" | "standard" | "full"): CKEditorConfig {
     return config;
 }
 
-function createCustomToolbar(groups: Array<string | ToolbarItems>, withGroupNames = true): CKEditorConfig {
+function createCustomToolbar(
+    groups: Array<string | ToolbarItems>,
+    withGroupNames = true,
+    templates = "default",
+    updatePlugins = false
+): CKEditorConfig {
     if (withGroupNames) {
         return {
             toolbar: groups
@@ -127,11 +139,19 @@ function createCustomToolbar(groups: Array<string | ToolbarItems>, withGroupName
                 .filter(item => item)
         };
     } else {
-        return {
-            extraPlugins:
-                "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks,smiley",
-            toolbar: groups
-        };
+        if (updatePlugins) {
+            return {
+                extraPlugins:
+                    "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks,smiley",
+                toolbar: groups,
+                templates
+            };
+        } else {
+            return {
+                toolbar: groups,
+                templates
+            };
+        }
     }
 }
 

--- a/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/ckeditorPresets.ts
@@ -84,11 +84,7 @@ const TOOLBAR_ITEMS: ToolbarItems[] = [
     { name: "about", items: ["About"] }
 ];
 
-function createPreset(
-    type: "basic" | "standard" | "full",
-    templates = "default",
-    updatePlugins = false
-): CKEditorConfig {
+function createPreset(type: "basic" | "standard" | "full", templates = "default"): CKEditorConfig {
     const config: CKEditorConfig = {};
     let toolbarGroup: Array<ToolbarGroup | string> = [];
     switch (type) {
@@ -112,10 +108,8 @@ function createPreset(
             config.toolbarGroups = toolbarGroup;
             config.removeButtons = "";
             /* TODO temporary removed exportpdf*/
-            if (updatePlugins) {
-                config.extraPlugins =
-                    "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks";
-            }
+            config.extraPlugins =
+                "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks";
             config.templates = templates;
             break;
         default:
@@ -127,8 +121,7 @@ function createPreset(
 function createCustomToolbar(
     groups: Array<string | ToolbarItems>,
     withGroupNames = true,
-    templates = "default",
-    updatePlugins = false
+    templates = "default"
 ): CKEditorConfig {
     if (withGroupNames) {
         return {
@@ -139,19 +132,12 @@ function createCustomToolbar(
                 .filter(item => item)
         };
     } else {
-        if (updatePlugins) {
-            return {
-                extraPlugins:
-                    "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks,smiley",
-                toolbar: groups,
-                templates
-            };
-        } else {
-            return {
-                toolbar: groups,
-                templates
-            };
-        }
+        return {
+            extraPlugins:
+                "save,templates,newpage,print,forms,find,selectall,div,divarea,justify,bidi,language,font,colorbutton,showblocks,smiley",
+            toolbar: groups,
+            templates
+        };
     }
 }
 

--- a/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
+++ b/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
@@ -3,7 +3,7 @@
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix Widgets Framework Team
  */
-import { ActionValue, EditableValue } from "mendix";
+import { ActionValue, EditableValue, ListValue, ListAttributeValue } from "mendix";
 
 export type EditorTypeEnum = "classic" | "inline";
 
@@ -65,6 +65,11 @@ export interface RichTextContainerProps {
     insertGroup: boolean;
     othersGroup: boolean;
     advancedConfig: AdvancedConfigType[];
+    templates: string;
+    templateDatasource: ListValue;
+    templateTitleAttribute: ListAttributeValue<string>;
+    templateDescriptionAttribute: ListAttributeValue<string>;
+    templateHtmlAttribute: ListAttributeValue<string>;
     onKeyPress?: ActionValue;
     onChange?: ActionValue;
     enterMode: EnterModeEnum;
@@ -104,6 +109,11 @@ export interface RichTextPreviewProps {
     insertGroup: boolean;
     othersGroup: boolean;
     advancedConfig: AdvancedConfigPreviewType[];
+    templates: string;
+    templateDatasource: {} | { caption: string } | { type: string } | null;
+    templateTitleAttribute: string;
+    templateDescriptionAttribute: string;
+    templateHtmlAttribute: string;
     onKeyPress: {} | null;
     onChange: {} | null;
     enterMode: EnterModeEnum;


### PR DESCRIPTION
<!--
IMPORTANT: Please read and follow instructions below on how to
open and submit your pull request.

REQUIRED STEPS:
1. Specify correct pull request type.
2. Write meaningful description.
3. Run `pnpm lint` and `pnpm test` in packages you changed and make sure they have no errors.
4. Add new tests (if needed) to cover new functionality.
5. Read checklist below.

CHECKLIST:
- Do you have a JIRA story for your pull request?
    - If yes, please format the PR title to match the `[XX-000]: description` pattern.
    - If no, please write your PR title using conventional commit rules.
- Does your change require a new version of the widget/module?
    - If yes, run `pnpm -w changelog` or update the `CHANGELOG.md` and bump the version manually.
    - If no, ignore.
- Do you have related PRs in other Mendix repositories?
    - If yes, please link all related pull requests in the description.
    - If no, ignore.
- Does your change touch XML, or is it a new feature or behavior?
    - If yes, if necessary, please create a PR with updates in the documentation (https://github.com/mendix/docs).
    - If no, ignore.
 - Is your change a bug fix or a new feature?
      - If yes, please add a description (last section in the template) of what should be tested and what steps are needed to test it.
     - If no, ignore.
-->

<!--
What type of changes does your PR introduce?
Uncomment relevant sections below by removing `<!--` at the beginning of the line.
-->

### Pull request type

<!-- No code changes (changes to documentation, CI, metadata, etc.)
<!---->

<!-- Dependency changes (any modification to dependencies in `package.json`)
<!---->

<!-- Refactoring (e.g. file rename, variable rename, etc.)
<!---->

<!-- Bug fix (non-breaking change which fixes an issue)
<!---->

New feature (non-breaking change which adds functionality)

<!-- Breaking change (fix or feature that would cause existing functionality to change)
<!---->

<!-- Test related change (New E2E test, test automation, etc.)
<!---->

---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description

This PR replaces an older open PR, as I had to reorganize my forked repository in order to deal with multiple open PRs. All former feedback has been incorporated to the best of my abilities. Furthermore, the number of changes could be reduced to achieve the same goal. 

Before the change, the rich-text-widget includes the CKEditor4 content templates plugin with its default settings, if either the "full" toolbar is chosen, or the "Templates" button is configured in an advanced custom toolbar. However, the default settings offer very limited value, as they would be useful in only very few use cases:

![image](https://github.com/mendix/web-widgets/assets/112866741/26c16e00-77c0-4503-b909-e8ea05978a84)

So the logical choice would be to either remove the content template plugin from the rich text widget entirely or make the content templates configurable in the Mendix application. Obviously, this pull request aims for the second choice, as we have multiple use cases for the feature in our project.

When the changes are applied, the default behavior of the widget does not change, only the widgets need to be updated once.
Even if an existing app uses the content template plugin for some reason, the default configuration is applied and nothing would change.

Changing the property "Template name" to anything other than "default", allows the developer to provide custom content templates from the app. Therefore, the developer needs to configure a data source to provide the templates and select title, descriptions and html attributes. Custom images are not yet supported due to reviewer concerns.

![image](https://github.com/mendix/web-widgets/assets/112866741/bc4039fc-9355-4ed8-a7ca-485aab730e32)

Having configured the content templates, the content templates menu can be filled based on data from the domain model. The user can then add or replaced HTML blocks in the document part handled by the rich text widget:

![image](https://github.com/mendix/web-widgets/assets/112866741/68a47457-156c-4c5f-9f7e-529eb8ad9790)

A demo application is available to showcase this feature. Any reviewer can be invited to the project if so desired.

<!--
### What should be covered while testing?
-->
