### PR TITLE
[WC-2256] DG2 pagination when necessary

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We added pagination visibility configuration named "Show paging buttons" property. User can choose to always show pagination button or automatically hide based on number of data displayed. Thanks to @Andries-Smit for the help on this feature.
+
 ## [2.11.0] - 2023-12-06
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -74,10 +74,8 @@ export function getProperties(
         }
     });
     if (values.pagination !== "buttons") {
+        hidePropertyIn(defaultProperties, values, "showPagingButtons");
         hidePropertyIn(defaultProperties, values, "pagingPosition");
-    }
-    if (values.pagination === "none") {
-        hidePropertyIn(defaultProperties, values, "pageSize");
     }
     if (values.showEmptyPlaceholder === "none") {
         hidePropertyIn(defaultProperties, values, "emptyPlaceholder");

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -76,6 +76,9 @@ export function getProperties(
     if (values.pagination !== "buttons") {
         hidePropertyIn(defaultProperties, values, "pagingPosition");
     }
+    if (values.pagination === "none") {
+        hidePropertyIn(defaultProperties, values, "pageSize");
+    }
     if (values.showEmptyPlaceholder === "none") {
         hidePropertyIn(defaultProperties, values, "emptyPlaceholder");
     }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -212,7 +212,12 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
             onExportCancel={abort}
             page={currentPage}
             pageSize={props.pageSize}
-            paging={props.pagination === "buttons"}
+            paging={
+                props.pagination === "buttons" &&
+                (props.showPagingButtons === "always" ||
+                    (props.showPagingButtons === "whenNecessary" &&
+                        (props.datasource.totalCount ? props.datasource.totalCount > props.datasource.limit : false)))
+            }
             pagingPosition={props.pagingPosition}
             rowClass={useCallback((value: any) => props.rowClass?.get(value)?.value ?? "", [props.rowClass])}
             setPage={setPage}

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -20,6 +20,7 @@ import { UpdateDataSourceFn, useDG2ExportApi } from "./features/export";
 import { Column } from "./helpers/Column";
 import "./ui/Datagrid.scss";
 import { useColumnsState } from "./features/use-columns-state";
+import { useShowPagination } from "./utils/useShowPagination";
 
 export default function Datagrid(props: DatagridContainerProps): ReactElement {
     const id = useRef(`DataGrid${generateUUID()}`);
@@ -212,12 +213,12 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
             onExportCancel={abort}
             page={currentPage}
             pageSize={props.pageSize}
-            paging={
-                props.pagination === "buttons" &&
-                (props.showPagingButtons === "always" ||
-                    (props.showPagingButtons === "whenNecessary" &&
-                        (props.datasource.totalCount ? props.datasource.totalCount > props.datasource.limit : false)))
-            }
+            paging={useShowPagination({
+                pagination: props.pagination,
+                showPagingButtons: props.showPagingButtons,
+                totalCount: props.datasource.totalCount,
+                limit: props.datasource.limit
+            })}
             pagingPosition={props.pagingPosition}
             rowClass={useCallback((value: any) => props.rowClass?.get(value)?.value ?? "", [props.rowClass])}
             setPage={setPage}

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -178,17 +178,18 @@
                 </property>
             </propertyGroup>
             <propertyGroup caption="Rows">
-                <property key="pageSize" type="integer" defaultValue="20">
-                    <caption>Page size</caption>
-                    <description />
-                </property>
                 <property key="pagination" type="enumeration" defaultValue="buttons">
                     <caption>Pagination</caption>
                     <description />
                     <enumerationValues>
                         <enumerationValue key="buttons">Paging buttons</enumerationValue>
                         <enumerationValue key="virtualScrolling">Virtual scrolling</enumerationValue>
+                        <enumerationValue key="none">None</enumerationValue>
                     </enumerationValues>
+                </property>
+                <property key="pageSize" type="integer" defaultValue="20">
+                    <caption>Page size</caption>
+                    <description />
                 </property>
                 <property key="pagingPosition" type="enumeration" defaultValue="bottom">
                     <caption>Position of paging buttons</caption>

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -178,18 +178,17 @@
                 </property>
             </propertyGroup>
             <propertyGroup caption="Rows">
+                <property key="pageSize" type="integer" defaultValue="20">
+                    <caption>Page size</caption>
+                    <description />
+                </property>
                 <property key="pagination" type="enumeration" defaultValue="buttons">
                     <caption>Pagination</caption>
                     <description />
                     <enumerationValues>
                         <enumerationValue key="buttons">Paging buttons</enumerationValue>
                         <enumerationValue key="virtualScrolling">Virtual scrolling</enumerationValue>
-                        <enumerationValue key="none">None</enumerationValue>
                     </enumerationValues>
-                </property>
-                <property key="pageSize" type="integer" defaultValue="20">
-                    <caption>Page size</caption>
-                    <description />
                 </property>
                 <property key="pagingPosition" type="enumeration" defaultValue="bottom">
                     <caption>Position of paging buttons</caption>
@@ -198,6 +197,14 @@
                         <enumerationValue key="bottom">Below grid</enumerationValue>
                         <enumerationValue key="top">Above grid</enumerationValue>
                         <enumerationValue key="both">Both</enumerationValue>
+                    </enumerationValues>
+                </property>
+                <property key="showPagingButtons" type="enumeration" defaultValue="always">
+                    <caption>Show paging buttons</caption>
+                    <description />
+                    <enumerationValues>
+                        <enumerationValue key="always">Always</enumerationValue>
+                        <enumerationValue key="whenNecessary">When necessary</enumerationValue>
                     </enumerationValues>
                 </property>
                 <property key="showEmptyPlaceholder" type="enumeration" defaultValue="none">

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -204,7 +204,7 @@
                     <description />
                     <enumerationValues>
                         <enumerationValue key="always">Always</enumerationValue>
-                        <enumerationValue key="whenNecessary">When necessary</enumerationValue>
+                        <enumerationValue key="auto">Auto</enumerationValue>
                     </enumerationValues>
                 </property>
                 <property key="showEmptyPlaceholder" type="enumeration" defaultValue="none">

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.11.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.12.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/datagrid-web/src/utils/useShowPagination.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/useShowPagination.ts
@@ -1,0 +1,20 @@
+import { useMemo } from "react";
+import { PaginationEnum, ShowPagingButtonsEnum } from "../../typings/DatagridProps";
+
+interface ShowPaginationProps {
+    pagination: PaginationEnum;
+    showPagingButtons: ShowPagingButtonsEnum;
+    totalCount?: number;
+    limit: number;
+}
+
+export const useShowPagination = (props: ShowPaginationProps): boolean => {
+    const { pagination, showPagingButtons, totalCount, limit } = props;
+    return useMemo(() => {
+        return (
+            pagination === "buttons" &&
+            (showPagingButtons === "always" ||
+                (showPagingButtons === "whenNecessary" && (totalCount ? totalCount > limit : false)))
+        );
+    }, [pagination, showPagingButtons, totalCount, limit]);
+};

--- a/packages/pluggableWidgets/datagrid-web/src/utils/useShowPagination.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/useShowPagination.ts
@@ -14,7 +14,7 @@ export const useShowPagination = (props: ShowPaginationProps): boolean => {
         return (
             pagination === "buttons" &&
             (showPagingButtons === "always" ||
-                (showPagingButtons === "whenNecessary" && (totalCount ? totalCount > limit : false)))
+                (showPagingButtons === "auto" && (totalCount ? totalCount > limit : false)))
         );
     }, [pagination, showPagingButtons, totalCount, limit]);
 };

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -44,7 +44,7 @@ export type PaginationEnum = "buttons" | "virtualScrolling";
 
 export type PagingPositionEnum = "bottom" | "top" | "both";
 
-export type ShowPagingButtonsEnum = "always" | "whenNecessary";
+export type ShowPagingButtonsEnum = "always" | "auto";
 
 export type ShowEmptyPlaceholderEnum = "none" | "custom";
 

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -40,9 +40,11 @@ export interface ColumnsType {
     wrapText: boolean;
 }
 
-export type PaginationEnum = "buttons" | "virtualScrolling" | "none";
+export type PaginationEnum = "buttons" | "virtualScrolling";
 
 export type PagingPositionEnum = "bottom" | "top" | "both";
+
+export type ShowPagingButtonsEnum = "always" | "whenNecessary";
 
 export type ShowEmptyPlaceholderEnum = "none" | "custom";
 
@@ -90,9 +92,10 @@ export interface DatagridContainerProps {
     showSelectAllToggle: boolean;
     columns: ColumnsType[];
     columnsFilterable: boolean;
-    pagination: PaginationEnum;
     pageSize: number;
+    pagination: PaginationEnum;
     pagingPosition: PagingPositionEnum;
+    showPagingButtons: ShowPagingButtonsEnum;
     showEmptyPlaceholder: ShowEmptyPlaceholderEnum;
     emptyPlaceholder?: ReactNode;
     rowClass?: ListExpressionValue<string>;
@@ -128,9 +131,10 @@ export interface DatagridPreviewProps {
     showSelectAllToggle: boolean;
     columns: ColumnsPreviewType[];
     columnsFilterable: boolean;
-    pagination: PaginationEnum;
     pageSize: number | null;
+    pagination: PaginationEnum;
     pagingPosition: PagingPositionEnum;
+    showPagingButtons: ShowPagingButtonsEnum;
     showEmptyPlaceholder: ShowEmptyPlaceholderEnum;
     emptyPlaceholder: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     rowClass: string;

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -40,7 +40,7 @@ export interface ColumnsType {
     wrapText: boolean;
 }
 
-export type PaginationEnum = "buttons" | "virtualScrolling";
+export type PaginationEnum = "buttons" | "virtualScrolling" | "none";
 
 export type PagingPositionEnum = "bottom" | "top" | "both";
 
@@ -90,8 +90,8 @@ export interface DatagridContainerProps {
     showSelectAllToggle: boolean;
     columns: ColumnsType[];
     columnsFilterable: boolean;
-    pageSize: number;
     pagination: PaginationEnum;
+    pageSize: number;
     pagingPosition: PagingPositionEnum;
     showEmptyPlaceholder: ShowEmptyPlaceholderEnum;
     emptyPlaceholder?: ReactNode;
@@ -128,8 +128,8 @@ export interface DatagridPreviewProps {
     showSelectAllToggle: boolean;
     columns: ColumnsPreviewType[];
     columnsFilterable: boolean;
-    pageSize: number | null;
     pagination: PaginationEnum;
+    pageSize: number | null;
     pagingPosition: PagingPositionEnum;
     showEmptyPlaceholder: ShowEmptyPlaceholderEnum;
     emptyPlaceholder: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };


### PR DESCRIPTION
Data grid 1 has an option "Show paging bar": "No" The Data Grid 2, will always show pagination buttons. This PR will add an extra property for "Showing paging buttons: When necessary"

As a developer/user we do not always need pagination, some use cases will only have a limited number of items, and the paging buttons only confuses the end users, and taking valuable space on the screen.

This is a non breaking change, by adding an extra property with little code change.
The "Showing paging buttons" property is only visible when the  "Pagination" option set to "Button".

![image](https://github.com/mendix/web-widgets/assets/6724749/4a3a7cb5-9098-4ddf-91c4-be93d528abcc)



![image](https://github.com/mendix/web-widgets/assets/1436036/fb02cc0d-3a2e-4fc8-8057-b6aab5ce6e9c)
