### PR TITLE
[WC-2320] fix: dropdown closing when click on scrollbar

### DIFF
--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed dropdown options directly closing when clicking on scrollbar if placed in popup dialog
+
 ## [1.1.2] - 2024-01-19
 
 ### Fixed

--- a/packages/pluggableWidgets/combobox-web/package.json
+++ b/packages/pluggableWidgets/combobox-web/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@mendix/combobox-web",
   "widgetName": "Combobox",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Configurable Combo box widget with suggestions and autocomplete.",
-  "copyright": "© Mendix Technology BV 2022. All rights reserved.",
+  "copyright": "© Mendix Technology BV 2024. All rights reserved.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
   "marketplace": {
     "minimumMXVersion": "9.24.0",
     "appNumber": 219304,
-    "appName": "Combobox"
+    "appName": "Combo box"
   },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",

--- a/packages/pluggableWidgets/combobox-web/src/components/ComboboxMenuWrapper.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/ComboboxMenuWrapper.tsx
@@ -64,7 +64,8 @@ export function ComboboxMenuWrapper(props: ComboboxMenuWrapperProps): ReactEleme
                 })}
                 {...getMenuProps?.(
                     {
-                        onClick: onOptionClick
+                        onClick: onOptionClick,
+                        onMouseDown: PreventMenuCloseEventHandler
                     },
                     { suppressRefError: true }
                 )}

--- a/packages/pluggableWidgets/combobox-web/src/package.xml
+++ b/packages/pluggableWidgets/combobox-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Combobox" version="1.1.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Combobox" version="1.1.3" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Combobox.xml" />
         </widgetFiles>


### PR DESCRIPTION
on clicking scrollbar in dropdown menu,
the "related target" is incorrect.
thus, this event is detected as "onBlur" and close the dropdown directly.

prevent the onblur event being called by handling onMouseDown in the menu itself.