### PR TITLE
[WC-2340] Allow sanitization config in html-element

### DIFF
--- a/packages/pluggableWidgets/html-element-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/html-element-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   It is now possible to pass configuration to the underlying HTML sanitization library. This makes it possible to extend default configuration that might be too restrictive for certain advanced use cases.
+
 ## [1.1.1] - 2023-09-27
 
 ### Fixed

--- a/packages/pluggableWidgets/html-element-web/package.json
+++ b/packages/pluggableWidgets/html-element-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/html-element-web",
   "widgetName": "HTMLElement",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Displays custom HTML",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/html-element-web/src/HTMLElement.editorConfig.ts
+++ b/packages/pluggableWidgets/html-element-web/src/HTMLElement.editorConfig.ts
@@ -113,6 +113,16 @@ export function getProperties(values: HTMLElementPreviewProps, defaultProperties
     return defaultProperties;
 }
 
+export function checkJson(json: string): string | undefined {
+    try {
+        JSON.parse(json);
+    } catch (e) {
+        if (e instanceof Error) {
+            return e.message;
+        }
+    }
+}
+
 export function check(values: HTMLElementPreviewProps): Problem[] {
     const errors: Problem[] = [];
 
@@ -164,6 +174,17 @@ export function check(values: HTMLElementPreviewProps): Problem[] {
         }
         existingEventNames.add(attr.eventName);
     });
+
+    if (values.sanitizationConfigFull) {
+        const jsonParseError = checkJson(values.sanitizationConfigFull);
+        if (jsonParseError) {
+            errors.push({
+                severity: "error",
+                property: `sanitizationConfigFull`,
+                message: `Incorrect JSON value: ${jsonParseError}`
+            });
+        }
+    }
 
     return errors;
 }

--- a/packages/pluggableWidgets/html-element-web/src/HTMLElement.tsx
+++ b/packages/pluggableWidgets/html-element-web/src/HTMLElement.tsx
@@ -31,6 +31,7 @@ export function HTMLElement(props: HTMLElementContainerProps): ReactElement | nu
                         ...prepareEvents(createEventResolver(item), props.events)
                     }}
                     unsafeHTML={prepareHtml(props, item)}
+                    sanitizationConfig={props.sanitizationConfigFull}
                 >
                     {prepareChildren(props, item)}
                 </HTMLTag>

--- a/packages/pluggableWidgets/html-element-web/src/HTMLElement.xml
+++ b/packages/pluggableWidgets/html-element-web/src/HTMLElement.xml
@@ -318,5 +318,13 @@
                 </properties>
             </property>
         </propertyGroup>
+        <propertyGroup caption="Advanced">
+            <propertyGroup caption="HTML Sanitization">
+                <property key="sanitizationConfigFull" type="string" required="false" multiline="true">
+                    <caption>Sanitization configuration</caption>
+                    <description>Configuration for HTML sanitization in JSON format. Leave blank for default.</description>
+                </property>
+            </propertyGroup>
+        </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/html-element-web/src/components/HTMLTag.tsx
+++ b/packages/pluggableWidgets/html-element-web/src/components/HTMLTag.tsx
@@ -6,10 +6,11 @@ interface HTMLTagProps {
     unsafeHTML?: string;
     children: ReactNode;
     attributes: HTMLAttributes<Element> & { [dataAttribute: `data-${string}`]: string };
+    sanitizationConfig?: string;
 }
 
 export function HTMLTag(props: HTMLTagProps): ReactElement {
-    const sanitize = useSanitize();
+    const sanitize = useSanitize(props.sanitizationConfig);
     const Tag = props.tagName;
     const { unsafeHTML } = props;
     if (unsafeHTML !== undefined) {

--- a/packages/pluggableWidgets/html-element-web/src/package.xml
+++ b/packages/pluggableWidgets/html-element-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="HTMLElement" version="1.1.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="HTMLElement" version="1.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="HTMLElement.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/html-element-web/typings/HTMLElementProps.d.ts
+++ b/packages/pluggableWidgets/html-element-web/typings/HTMLElementProps.d.ts
@@ -64,6 +64,7 @@ export interface HTMLElementContainerProps {
     tagContentRepeatContainer?: ListWidgetValue;
     attributes: AttributesType[];
     events: EventsType[];
+    sanitizationConfigFull: string;
 }
 
 export interface HTMLElementPreviewProps {
@@ -86,4 +87,5 @@ export interface HTMLElementPreviewProps {
     tagContentRepeatContainer: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     attributes: AttributesPreviewType[];
     events: EventsPreviewType[];
+    sanitizationConfigFull: string;
 }


### PR DESCRIPTION
### Pull request type

New feature (non-breaking change which adds functionality)

### Description

Add **Advanced** tab in the config. Add **Configuration for HTML sanitization** property. This allows specifying additional config as per: https://github.com/cure53/DOMPurify#control-our-allow-lists-and-block-lists