### PR TITLE
fix: unexpected behaviour on ios safari

### DIFF
--- a/packages/modules/web-actions/CHANGELOG.md
+++ b/packages/modules/web-actions/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue in Take Picture action.
+
 ## [2.10.0] - 2024-01-29
 
 ### Changed

--- a/packages/modules/web-actions/package.json
+++ b/packages/modules/web-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/web-actions",
   "moduleName": "Web Actions",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "repository": {

--- a/packages/modules/web-actions/src/javascriptsource/webactions/actions/TakePicture.js
+++ b/packages/modules/web-actions/src/javascriptsource/webactions/actions/TakePicture.js
@@ -255,8 +255,9 @@ export async function TakePicture(picture, showConfirmationScreen, pictureQualit
         async function startCamera(facingMode) {
             var _a;
             try {
+                const cameraQuality = getCameraQuality();
                 stream = await navigator.mediaDevices.getUserMedia({
-                    video: Object.assign({ facingMode }, getCameraQuality())
+                    video: { facingMode: facingMode, width: cameraQuality.width, height: cameraQuality.height}
                 });
                 (_a = stream === null || stream === void 0 ? void 0 : stream.getTracks()) === null || _a === void 0
                     ? void 0


### PR DESCRIPTION

### Pull request type

 Bug fix (non-breaking change which fixes an issue)

---

### Description
A weird issue occurred on Safari iOS with the take picture action, this issue does not occur in the examples of the library we're using (https://webrtc.github.io/samples/)
This PR changes the configuration of the video to make it more explicit what we're setting there. So far this seems to work and gets rid of that black bar that covers half the screen.

### What should be covered while testing?
On iOS Safari browser, this should render the video without a black bar covering half the screen. 
