### PR TITLE
[WC-2381] fix: input text does not work in the combobox footer area

### DIFF
--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 -   We fixed sorting on combobox, now the sorting follows the default when the combobox opens, and follow a sorted ranking when any input is given.
+-   We fixed focusable element not able to have focus if being placed on custom footer.
 
 ## [1.2.0] - 2024-02-27
 

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__snapshots__/MultiSelection.spec.tsx.snap
@@ -82,6 +82,7 @@ exports[`Combo box (Association) renders combobox widget 1`] = `
     >
       <div
         class="widget-combobox-menu-header widget-combobox-item"
+        tabindex="0"
       >
         <span
           class="widget-combobox-menu-header-select-all-button widget-combobox-icon-container"
@@ -193,6 +194,7 @@ exports[`Combo box (Association) toggles combobox menu on: input CLICK(focus) / 
     >
       <div
         class="widget-combobox-menu-header widget-combobox-item"
+        tabindex="0"
       >
         <span
           class="widget-combobox-menu-header-select-all-button widget-combobox-icon-container"
@@ -304,6 +306,7 @@ exports[`Combo box (Association) toggles combobox menu on: input TOGGLE BUTTON 1
     >
       <div
         class="widget-combobox-menu-header widget-combobox-item"
+        tabindex="0"
       >
         <span
           class="widget-combobox-menu-header-select-all-button widget-combobox-icon-container"

--- a/packages/pluggableWidgets/combobox-web/src/components/ComboboxMenuWrapper.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/ComboboxMenuWrapper.tsx
@@ -16,8 +16,6 @@ interface ComboboxMenuWrapperProps extends PropsWithChildren, Partial<UseCombobo
 }
 
 function PreventMenuCloseEventHandler(e: React.MouseEvent): void {
-    (e.target as HTMLElement)?.focus();
-    e.preventDefault();
     e.stopPropagation();
 }
 
@@ -55,6 +53,7 @@ export function ComboboxMenuWrapper(props: ComboboxMenuWrapperProps): ReactEleme
                 <div
                     className="widget-combobox-menu-header widget-combobox-item"
                     onMouseDown={PreventMenuCloseEventHandler}
+                    tabIndex={0}
                 >
                     {menuHeaderContent}
                 </div>
@@ -74,7 +73,7 @@ export function ComboboxMenuWrapper(props: ComboboxMenuWrapperProps): ReactEleme
                 {isOpen ? isEmpty ? <NoOptionsPlaceholder>{noOptionsText}</NoOptionsPlaceholder> : children : null}
             </ul>
             {menuFooterContent && (
-                <div className="widget-combobox-menu-footer" onMouseDown={PreventMenuCloseEventHandler}>
+                <div tabIndex={0} className="widget-combobox-menu-footer" onMouseDown={PreventMenuCloseEventHandler}>
                     {menuFooterContent}
                 </div>
             )}

--- a/packages/pluggableWidgets/combobox-web/src/components/ComboboxMenuWrapper.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/ComboboxMenuWrapper.tsx
@@ -16,6 +16,7 @@ interface ComboboxMenuWrapperProps extends PropsWithChildren, Partial<UseCombobo
 }
 
 function PreventMenuCloseEventHandler(e: React.MouseEvent): void {
+    (e.target as HTMLElement)?.focus();
     e.preventDefault();
     e.stopPropagation();
 }

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/SelectAllButton.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/SelectAllButton.tsx
@@ -23,7 +23,11 @@ export function SelectAllButton({ id, ariaLabel, value, onChange }: SelectAllBut
                 <ThreeStateCheckBox value={value} id={id} onChange={onChange} />
             </span>
             {ariaLabel ? (
-                <CaptionContent onClick={onChange} htmlFor={id}>
+                // empty onclick function is being set to allow label clicking
+                // the actual event occurs on checkbox input inside ThreeStateCheckBox
+                // if being set to onChange, the event will be triggered twice
+                // if undefined, label click will not be triggered.
+                <CaptionContent onClick={() => {}} htmlFor={id}>
                     {ariaLabel}
                 </CaptionContent>
             ) : undefined}


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

To prevent menu closing directly on clicking, we previously added event propagate stopper in menu footer click event.
But apparently, this is also stopping element getting focus.
thus, this PR adding focus to each element target clicked on footer click event.

note for testing: please also validate with multi-selection and select all button.