### PR TITLE
[WC-2400] Improve columns swap behavior

### DIFF
--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -44,6 +44,44 @@ $grid-selected-row-background: $brand-light;
         padding: $spacing-medium;
         top: 0;
         min-width: 0;
+        position: relative;
+
+        &.dragging {
+            opacity: 0.5;
+            &.dragging-over-self {
+                opacity: 0.8;
+            }
+        }
+
+        &.drop-after:after,
+        &.drop-before:after {
+            content: "";
+            position: absolute;
+            top: 0;
+            height: 100%;
+            width: $dragging-effect-size;
+            background-color: $dragging-color-effect;
+
+            z-index: 1;
+        }
+
+        &.drop-before {
+            &:after {
+                left: 0;
+            }
+            &:not(:first-child):after {
+                transform: translateX(-50%);
+            }
+        }
+
+        &.drop-after {
+            &:after {
+                right: 0;
+            }
+            &:not(:last-child):after {
+                transform: translateX(50%);
+            }
+        }
 
         /* Clickable column header (Sortable) */
         .clickable {
@@ -76,13 +114,6 @@ $grid-selected-row-background: $brand-light;
             flex-grow: 1;
             align-self: stretch;
             min-width: 0;
-            padding-left: $dragging-effect-size;
-            margin-left: -$dragging-effect-size;
-            /* Styles while dragging another column */
-            &.dragging {
-                border-left: $dragging-effect-size solid $dragging-color-effect;
-                padding-left: 0;
-            }
 
             &:not(:has(.filter)) {
                 .column-header {

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   We have enhanced the swap behavior of the columns, making it more intuitive and user-friendly. This improvement also includes a slight adjustment to the classnames applied to the elements being swapped, providing better control over their styling.
+
 ## [2.16.1] - 2024-04-16
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -157,7 +157,7 @@ const Container = observer((props: Props): ReactElement => {
                         </FilterContext.Provider>
                     );
                 },
-                [FilterContext, columnsStore.availableColumns, rootStore.headerFiltersStore, filtersChannelName]
+                [FilterContext, columnsStore.columnFilters, rootStore.headerFiltersStore, filtersChannelName]
             )}
             headerTitle={props.filterSectionTitle?.value}
             headerContent={

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -200,7 +200,7 @@ const Container = observer((props: Props): ReactElement => {
             visibleColumns={columnsStore.visibleColumns}
             availableColumns={columnsStore.availableColumns}
             columnsCreateSizeSnapshot={() => columnsStore.createSizeSnapshot()}
-            columnsSwap={(a, b) => columnsStore.swapColumns(a, b)}
+            columnsSwap={(moved, [target, placement]) => columnsStore.swapColumns(moved, [target, placement])}
             selectActionHelper={selectActionHelper}
             cellEventsController={cellEventsController}
             checkboxEventsController={checkboxEventsController}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -72,7 +72,7 @@ export interface WidgetProps<C extends GridColumn, T extends ObjectItem = Object
     visibleColumns: GridColumn[];
     availableColumns: GridColumn[];
 
-    columnsSwap: (a: ColumnId, b: ColumnId) => void;
+    columnsSwap: (source: ColumnId, target: [ColumnId, "after" | "before"]) => void;
     columnsCreateSizeSnapshot: () => void;
 }
 
@@ -112,8 +112,8 @@ export const Widget = observer(<C extends GridColumn>(props: WidgetProps<C>): Re
     } = props;
 
     const isInfinite = !paging;
-    const [isDragging, setIsDragging] = useState(false);
-    const [dragOver, setDragOver] = useState<ColumnId | undefined>(undefined);
+    const [isDragging, setIsDragging] = useState<[ColumnId | undefined, ColumnId, ColumnId | undefined] | undefined>();
+    const [dragOver, setDragOver] = useState<[ColumnId, "before" | "after"] | undefined>(undefined);
     const showHeader = !!headerContent;
     const showTopBar = paging && (pagingPosition === "top" || pagingPosition === "both");
 
@@ -180,7 +180,7 @@ export const Widget = observer(<C extends GridColumn>(props: WidgetProps<C>): Re
                                             gridId={props.id}
                                             column={column}
                                             draggable={columnsDraggable}
-                                            dragOver={dragOver}
+                                            dropTarget={dragOver}
                                             filterable={columnsFilterable}
                                             filterWidget={filterRendererProp(renderFilterWrapper, column.columnIndex)}
                                             hidable={columnsHidable}
@@ -194,7 +194,7 @@ export const Widget = observer(<C extends GridColumn>(props: WidgetProps<C>): Re
                                                 />
                                             }
                                             swapColumns={props.columnsSwap}
-                                            setDragOver={setDragOver}
+                                            setDropTarget={setDragOver}
                                             setIsDragging={setIsDragging}
                                             sortable={columnsSortable}
                                         />

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
@@ -127,7 +127,7 @@ function mockHeaderProps(): HeaderProps {
             toggleSort: () => undefined
         } as GridColumn,
         draggable: false,
-        dragOver: undefined,
+        dropTarget: undefined,
         filterable: false,
         filterWidget: undefined,
         hidable: false,
@@ -135,7 +135,7 @@ function mockHeaderProps(): HeaderProps {
         resizer: <ColumnResizer setColumnWidth={jest.fn()} />,
         sortable: false,
         swapColumns: jest.fn(),
-        setDragOver: jest.fn(),
+        setDropTarget: jest.fn(),
         setIsDragging: jest.fn()
     };
 }

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -3,13 +3,13 @@
 exports[`Header renders the structure correctly 1`] = `
 <div
   class="th"
+  data-column-id="dg1-column0"
   role="columnheader"
   style="cursor:unset"
   title="Test"
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     id="dg1-columndg1-column0"
   >
     <div
@@ -27,13 +27,13 @@ exports[`Header renders the structure correctly 1`] = `
 exports[`Header renders the structure correctly when draggable 1`] = `
 <div
   class="th"
+  data-column-id="dg1-column0"
   role="columnheader"
   style="cursor:unset"
   title="Test"
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     draggable="true"
     id="dg1-columndg1-column0"
   >
@@ -52,13 +52,13 @@ exports[`Header renders the structure correctly when draggable 1`] = `
 exports[`Header renders the structure correctly when filterable with custom classes 1`] = `
 <div
   class="th"
+  data-column-id="dg1-column0"
   role="columnheader"
   style="cursor:unset"
   title="Test"
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     id="dg1-columndg1-column0"
   >
     <div
@@ -76,13 +76,13 @@ exports[`Header renders the structure correctly when filterable with custom clas
 exports[`Header renders the structure correctly when filterable with custom filter 1`] = `
 <div
   class="th"
+  data-column-id="dg1-column0"
   role="columnheader"
   style="cursor:unset"
   title="Test"
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     id="dg1-columndg1-column0"
   >
     <div
@@ -108,13 +108,13 @@ exports[`Header renders the structure correctly when filterable with custom filt
 exports[`Header renders the structure correctly when filterable with no custom filter 1`] = `
 <div
   class="th"
+  data-column-id="dg1-column0"
   role="columnheader"
   style="cursor:unset"
   title="Test"
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     id="dg1-columndg1-column0"
   >
     <div
@@ -132,13 +132,13 @@ exports[`Header renders the structure correctly when filterable with no custom f
 exports[`Header renders the structure correctly when is hidden and preview 1`] = `
 <div
   class="th hidden-column-preview"
+  data-column-id="dg1-column0"
   role="columnheader"
   style="cursor:unset"
   title="Test"
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     id="dg1-columndg1-column0"
   >
     <div
@@ -156,13 +156,13 @@ exports[`Header renders the structure correctly when is hidden and preview 1`] =
 exports[`Header renders the structure correctly when resizable 1`] = `
 <div
   class="th"
+  data-column-id="dg1-column0"
   role="columnheader"
   style="cursor:unset"
   title="Test"
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     id="dg1-columndg1-column0"
   >
     <div
@@ -189,12 +189,12 @@ exports[`Header renders the structure correctly when sortable 1`] = `
 <div
   aria-sort="none"
   class="th"
+  data-column-id="dg1-column0"
   role="columnheader"
   title="Test"
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     id="dg1-columndg1-column0"
   >
     <div
@@ -229,13 +229,13 @@ exports[`Header renders the structure correctly when sortable 1`] = `
 exports[`Header renders the structure correctly when value is empty 1`] = `
 <div
   class="th"
+  data-column-id="dg1-column0"
   role="columnheader"
   style="cursor:unset"
   title=""
 >
   <div
     class="column-container"
-    data-column-id="dg1-column0"
     id="dg1-columndg1-column0"
   >
     <div

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Table.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Table.spec.tsx.snap
@@ -26,13 +26,13 @@ exports[`Table renders the structure correctly 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -98,13 +98,13 @@ exports[`Table renders the structure correctly for preview when no header is pro
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title=""
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -170,13 +170,13 @@ exports[`Table renders the structure correctly with column alignments 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -191,13 +191,13 @@ exports[`Table renders the structure correctly with column alignments 1`] = `
           </div>
           <div
             class="th"
+            data-column-id="1"
             role="columnheader"
             style="cursor:unset"
             title="Test 2"
           >
             <div
               class="column-container"
-              data-column-id="1"
               id="dg1-column1"
             >
               <div
@@ -275,13 +275,13 @@ exports[`Table renders the structure correctly with custom filtering 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -351,13 +351,13 @@ exports[`Table renders the structure correctly with dragging 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -423,13 +423,13 @@ exports[`Table renders the structure correctly with dynamic row class 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -495,13 +495,13 @@ exports[`Table renders the structure correctly with empty placeholder 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -567,13 +567,13 @@ exports[`Table renders the structure correctly with filtering 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -653,13 +653,13 @@ exports[`Table renders the structure correctly with header filters and a11y 1`] 
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -728,13 +728,13 @@ exports[`Table renders the structure correctly with header wrapper 1`] = `
           >
             <div
               class="th"
+              data-column-id="0"
               role="columnheader"
               style="cursor:unset"
               title="Test"
             >
               <div
                 class="column-container"
-                data-column-id="0"
                 id="dg1-column0"
               >
                 <div
@@ -801,13 +801,13 @@ exports[`Table renders the structure correctly with hiding 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -914,13 +914,13 @@ exports[`Table renders the structure correctly with paging 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -1076,13 +1076,13 @@ exports[`Table renders the structure correctly with resizing 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -1148,13 +1148,13 @@ exports[`Table renders the structure correctly with sorting 1`] = `
         >
           <div
             class="th"
+            data-column-id="0"
             role="columnheader"
             style="cursor:unset"
             title="Test"
           >
             <div
               class="column-container"
-              data-column-id="0"
               id="dg1-column0"
             >
               <div
@@ -1226,13 +1226,13 @@ exports[`Table with selection method checkbox render an extra column and add cla
             />
             <div
               class="th"
+              data-column-id="0"
               role="columnheader"
               style="cursor: unset;"
               title="Test"
             >
               <div
                 class="column-container"
-                data-column-id="0"
                 id="dg1-column0"
               >
                 <div
@@ -1467,13 +1467,13 @@ exports[`Table with selection method rowClick add class to each selected cell 1`
           >
             <div
               class="th"
+              data-column-id="0"
               role="columnheader"
               style="cursor: unset;"
               title="Test"
             >
               <div
                 class="column-container"
-                data-column-id="0"
                 id="dg1-column0"
               >
                 <div

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/ColumnGroupStore.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/ColumnGroupStore.ts
@@ -23,7 +23,7 @@ export interface IColumnGroupStore {
 
     columnFilters: ColumnFilterStore[];
 
-    swapColumns(columnIdA: ColumnId, columnIdB: ColumnId): void;
+    swapColumns(source: ColumnId, target: [ColumnId, "after" | "before"]): void;
     createSizeSnapshot(): void;
 }
 
@@ -88,11 +88,15 @@ export class ColumnGroupStore implements IColumnGroupStore, IColumnParentStore {
         }
     }
 
-    swapColumns(columnIdA: ColumnId, columnIdB: ColumnId): void {
-        const columnA = this._allColumnsById.get(columnIdA)!;
-        const columnB = this._allColumnsById.get(columnIdB)!;
+    swapColumns(source: ColumnId, [target, placement]: [ColumnId, "after" | "before"]): void {
+        const columnSource = this._allColumnsById.get(source)!;
+        const columnTarget = this._allColumnsById.get(target)!;
+        columnSource.orderWeight = columnTarget.orderWeight + (placement === "after" ? 1 : -1);
 
-        [columnA.orderWeight, columnB.orderWeight] = [columnB.orderWeight, columnA.orderWeight];
+        // normalize columns
+        this._allColumnsOrdered.forEach((column, idx) => {
+            column.orderWeight = idx * 10;
+        });
     }
 
     createSizeSnapshot(): void {

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/useRootStore.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/useRootStore.ts
@@ -1,20 +1,23 @@
 import { DatagridContainerProps } from "../../../typings/DatagridProps";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { RootGridStore } from "./RootGridStore";
 import { autorun, IReactionDisposer } from "mobx";
 import { and } from "mendix/filters/builders";
 
-export function useRootStore(props: DatagridContainerProps) {
+export function useRootStore(props: DatagridContainerProps): RootGridStore {
     const [rootStore] = useState(() => {
         return new RootGridStore(props);
     });
+
+    const datasourceRef = useRef(props.datasource);
+    datasourceRef.current = props.datasource;
 
     useEffect(() => {
         const disposers: IReactionDisposer[] = [];
         // apply sorting
         disposers.push(
             autorun(() => {
-                props.datasource.setSortOrder(rootStore.sortInstructions);
+                datasourceRef.current.setSortOrder(rootStore.sortInstructions);
             })
         );
 
@@ -29,9 +32,9 @@ export function useRootStore(props: DatagridContainerProps) {
                 }
 
                 if (filters.length > 0) {
-                    props.datasource.setFilter(filters.length > 1 ? and(...filters) : filters[0]);
+                    datasourceRef.current.setFilter(filters.length > 1 ? and(...filters) : filters[0]);
                 } else {
-                    props.datasource.setFilter(undefined);
+                    datasourceRef.current.setFilter(undefined);
                 }
             })
         );
@@ -40,7 +43,7 @@ export function useRootStore(props: DatagridContainerProps) {
             disposers.forEach(d => d());
             rootStore.dispose();
         };
-    }, []);
+    }, [rootStore]);
 
     useEffect(() => {
         rootStore.updateProps(props);


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

### Description

Make the swap behavior more intuitive. The change involves moving `.dragging` class up the tree from `column-container` to the `.th` level to allow better styling control over the whole cell.

Also included non-functional changes to take care of leftovers from the previous story.