### PR TITLE
[WC-2442] fix sorting for custom content

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with sorting by columns that display dymanic text or custom content.
+
 ## [2.16.0] - 2024-04-09
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/column/ColumnStore.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/column/ColumnStore.tsx
@@ -234,7 +234,9 @@ export class ColumnStore implements GridColumn {
 
     applySettings(conf: ColumnPersonalizationSettings): void {
         this.size = conf.size;
-        this.isHidden = conf.hidden;
+        if (this.canHide) {
+            this.isHidden = conf.hidden;
+        }
         this.orderWeight = conf.orderWeight * 10;
     }
 }

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/column/ColumnStore.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/column/ColumnStore.tsx
@@ -83,20 +83,9 @@ export class ColumnStore implements GridColumn {
         this._columnClass = props.columnClass;
         this._tooltip = props.tooltip;
 
-        switch (this.baseInfo.showContentAs) {
-            case "attribute": {
-                this._attribute = props.attribute;
-                break;
-            }
-            case "customContent": {
-                this._content = props.content;
-                break;
-            }
-            case "dynamicText": {
-                this._dynamicText = props.dynamicText;
-                break;
-            }
-        }
+        this._attribute = props.attribute;
+        this._content = props.content;
+        this._dynamicText = props.dynamicText;
     }
 
     // old props

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.16.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.16.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Pull request type


Bug fix (non-breaking change which fixes an issue)

### Description

Because of the logic of tracking underlying properties we lost track of the underlying attribute, this resulted in broken sorting for non-attribute columns even if attributes for those columns were selected.