### PR TITLE
[WC-2458] Fix default value in filter widgets

### DIFF
--- a/packages/pluggableWidgets/datagrid-number-filter-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We resolved an issue where the default value was not working in certain cases.
+
 ## [2.5.0] - 2024-03-27
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-number-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-number-filter-web",
   "widgetName": "DatagridNumberFilter",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.tsx
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.tsx
@@ -3,7 +3,7 @@ import { DatagridNumberFilterContainerProps, DefaultFilterEnum } from "../typing
 import { FilterComponent } from "./components/FilterComponent";
 import { generateUUID } from "@mendix/widget-plugin-platform/framework/generate-uuid";
 import { Alert } from "@mendix/widget-plugin-component-kit/Alert";
-import { FilterType, getFilterDispatcher } from "@mendix/widget-plugin-filtering";
+import { FilterType, getFilterDispatcher, useDefaultValue } from "@mendix/widget-plugin-filtering";
 import { Big } from "big.js";
 
 import {
@@ -23,7 +23,7 @@ import { translateFilters } from "./utils/filters";
 
 export default function DatagridNumberFilter(props: DatagridNumberFilterContainerProps): ReactElement {
     const id = useRef(`NumberFilter${generateUUID()}`);
-    const { current: defaultValue } = useRef(props.defaultValue?.value);
+    const defaultValue = useDefaultValue(props.defaultValue);
 
     const FilterContext = getFilterDispatcher();
     const alertMessage = (
@@ -77,7 +77,7 @@ export default function DatagridNumberFilter(props: DatagridNumberFilterContaine
                     return <Alert bootstrapStyle="danger">{errorMessage}</Alert>;
                 }
 
-                if (props.defaultValue?.status === "loading") {
+                if (defaultValue === null) {
                     return null;
                 }
 

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="DatagridNumberFilter" version="2.5.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="DatagridNumberFilter" version="2.5.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="DatagridNumberFilter.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/datagrid-text-filter-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We resolved an issue where the default value was not working in certain cases.
+
 ## [2.5.0] - 2024-03-27
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-text-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-text-filter-web",
   "widgetName": "DatagridTextFilter",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.tsx
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.tsx
@@ -4,7 +4,7 @@ import { DatagridTextFilterContainerProps, DefaultFilterEnum } from "../typings/
 import { FilterComponent } from "./components/FilterComponent";
 import { Alert } from "@mendix/widget-plugin-component-kit/Alert";
 import { generateUUID } from "@mendix/widget-plugin-platform/framework/generate-uuid";
-import { FilterType, getFilterDispatcher } from "@mendix/widget-plugin-filtering";
+import { FilterType, getFilterDispatcher, useDefaultValue } from "@mendix/widget-plugin-filtering";
 
 import {
     attribute,
@@ -26,7 +26,7 @@ import { translateFilters } from "./utils/filters";
 
 export default function DatagridTextFilter(props: DatagridTextFilterContainerProps): ReactElement {
     const id = useRef(`TextFilter${generateUUID()}`);
-    const { current: defaultValue } = useRef(props.defaultValue?.value);
+    const defaultValue = useDefaultValue(props.defaultValue);
 
     const FilterContext = getFilterDispatcher();
     const alertMessage = (
@@ -80,7 +80,7 @@ export default function DatagridTextFilter(props: DatagridTextFilterContainerPro
                     return <Alert bootstrapStyle="danger">{errorMessage}</Alert>;
                 }
 
-                if (props.defaultValue?.status === "loading") {
+                if (defaultValue === null) {
                     return null;
                 }
 

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="DatagridTextFilter" version="2.5.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="DatagridTextFilter" version="2.5.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="DatagridTextFilter.xml" />
         </widgetFiles>

--- a/packages/shared/widget-plugin-filtering/src/main.ts
+++ b/packages/shared/widget-plugin-filtering/src/main.ts
@@ -3,3 +3,4 @@ export { error, value } from "./result-meta.js";
 export type { Result, Success, Error } from "./result-meta.js";
 export { readInitFilterValues, unwrapAndExpression } from "./read-init-props.js";
 export type { InitialFilterValue, BinaryExpression } from "./read-init-props.js";
+export { useDefaultValue } from "./useDefaultValue";

--- a/packages/shared/widget-plugin-filtering/src/useDefaultValue.ts
+++ b/packages/shared/widget-plugin-filtering/src/useDefaultValue.ts
@@ -1,0 +1,12 @@
+import { DynamicValue } from "mendix";
+import { useRef } from "react";
+
+export function useDefaultValue<T>(defaultValueProp?: DynamicValue<T>): T | undefined | null {
+    const defaultValueRef = useRef<T | undefined | null>(null);
+
+    if (defaultValueProp?.status !== "loading" && defaultValueRef.current === null) {
+        defaultValueRef.current = defaultValueProp?.value;
+    }
+
+    return defaultValueRef.current;
+}


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

### Description

While reading the default value the widget got cached `undefined` while it was still in loading state, hence the default value was missing. This was there for some time, but looks like the re-write of the datagrid widget exposed this bug. Now it should be fixed.