### PR TITLE
[WC-2460] Remove useless warnings

### DIFF
--- a/automation/utils/bin/rui-changelog-helper.ts
+++ b/automation/utils/bin/rui-changelog-helper.ts
@@ -59,6 +59,7 @@ async function getChangelogSections(): Promise<LogSection[]> {
 async function selectNextVersion(currentVersion: string): Promise<string | undefined> {
     const { bump } = await prompt<{ bump: boolean }>({
         type: "confirm",
+        initial: true,
         name: "bump",
         message: "Would you like to bump the package version?"
     });
@@ -93,6 +94,7 @@ async function main(): Promise<void> {
 
     const { save } = await prompt<{ save: boolean }>({
         type: "confirm",
+        initial: true,
         name: "save",
         message: "Save changes?"
     });

--- a/automation/utils/package.json
+++ b/automation/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/automation-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Set of helpers for release processes",
   "private": true,
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",

--- a/automation/utils/src/bump-version.ts
+++ b/automation/utils/src/bump-version.ts
@@ -53,12 +53,29 @@ export async function writeVersion(pkg: PackageListing, version: string): Promis
     }
 }
 
-export async function selectBumpVersionType(): Promise<BumpVersionType> {
+export async function selectBumpVersionType(currentVersion: string): Promise<BumpVersionType> {
     const { bumpType } = await prompt<{ bumpType: string }>({
         type: "autocomplete",
         name: "bumpType",
         message: "Want to bump?",
-        choices: ["major", "minor", "patch", "set manually"]
+        choices: [
+            {
+                name: `patch [${currentVersion} -> ${getNewVersion("patch", currentVersion)}]`,
+                value: "patch"
+            },
+            {
+                name: `minor [${currentVersion} -> ${getNewVersion("minor", currentVersion)}]`,
+                value: "minor"
+            },
+            {
+                name: `major [${currentVersion} -> ${getNewVersion("major", currentVersion)}]`,
+                value: "major"
+            },
+            {
+                name: "Set manually",
+                value: "set manually"
+            }
+        ]
     });
 
     if (bumpType === "set manually") {
@@ -75,7 +92,7 @@ export async function selectBumpVersionType(): Promise<BumpVersionType> {
 }
 
 export async function getNextVersion(currentVersion: string): Promise<string> {
-    const bumpVersionType = await selectBumpVersionType();
+    const bumpVersionType = await selectBumpVersionType(currentVersion);
     const nextVersion = getNewVersion(bumpVersionType, currentVersion);
     console.log(chalk.green(`Version change: ${currentVersion} => ${nextVersion}`));
     return nextVersion;

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   A new property that controls custom content events.
 
+### Removed
+
+-   We removed the sorting console warnings that were being triggered incorrectly.
+
 ## [2.17.0] - 2024-04-17
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/ColumnGroupStore.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/ColumnGroupStore.ts
@@ -80,8 +80,7 @@ export class ColumnGroupStore implements IColumnGroupStore, IColumnParentStore {
         });
 
         if (this.visibleColumns.length < 1) {
-            // if all columns are hidden after the update - reset hidden state HERE
-            console.warn("All columns are hidden, resetting hidden state");
+            // if all columns are hidden after the update - reset hidden state for all columns
             this._allColumns.forEach(c => {
                 c.isHidden = false;
             });

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/ColumnsSortingStore.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/ColumnsSortingStore.ts
@@ -61,7 +61,6 @@ export function sortInstructionsToSortRules(
             const [attrId, dir] = si;
             const cId = allColumns.find(c => c.attrId === attrId)?.columnId;
             if (!cId) {
-                console.warn(`Can't parse sorting instruction. Unknown attribute id: '${attrId}'`);
                 return undefined;
             }
 
@@ -83,7 +82,6 @@ export function sortRulesToSortInstructions(
             const [cId, dir] = rule;
             const attrId = allColumns.find(c => c.columnId === cId)?.attrId;
             if (!attrId) {
-                console.warn(`Can't apply sorting for column ${cId}. The column either doesn't exist or not sortable.`);
                 return undefined;
             }
             return [attrId, dir];


### PR DESCRIPTION
As we discovered those warnings trigger in a completely valid use case, so it is better to remove them.