### PR TITLE
feat(google-tag-web): send (authenticated) user ID

### DIFF
--- a/packages/pluggableWidgets/google-tag-web/src/GoogleTag.editorConfig.ts
+++ b/packages/pluggableWidgets/google-tag-web/src/GoogleTag.editorConfig.ts
@@ -20,7 +20,7 @@ export function getProperties(values: GoogleTagPreviewProps, defaultProperties: 
                 break;
             }
             case "event": {
-                hidePropertiesIn(defaultProperties, values, ["targetId"]);
+                hidePropertiesIn(defaultProperties, values, ["targetId", "sendUserID"]);
                 handleValueTypes(values, defaultProperties);
                 break;
             }

--- a/packages/pluggableWidgets/google-tag-web/src/GoogleTag.tsx
+++ b/packages/pluggableWidgets/google-tag-web/src/GoogleTag.tsx
@@ -30,15 +30,14 @@ function GoogleTagBasicPageView(props: GoogleTagContainerProps): ReactElement | 
             return;
         }
 
+        const configProps = new Map<string, string | boolean>([["send_page_view", false]]);
+
+        if (props.sendUserID && window.mx.session.getUserId() !== undefined) {
+            configProps.set("user_id", window.mx.session.getUserId());
+        }
+
         // execute config if not yet executed
-        executeCommand(
-            "config",
-            "",
-            {
-                send_page_view: false
-            },
-            props.targetId.value
-        );
+        executeCommand("config", "", Object.fromEntries(configProps), props.targetId.value);
 
         // execute event page_view
         executeCommand(

--- a/packages/pluggableWidgets/google-tag-web/src/GoogleTag.xml
+++ b/packages/pluggableWidgets/google-tag-web/src/GoogleTag.xml
@@ -59,6 +59,10 @@
                     </propertyGroup>
                 </properties>
             </property>
+            <property key="sendUserID" type="boolean" required="true" defaultValue="false">
+                <caption>Share user ID</caption>
+                <description>Expose the authenticated User ID to uniquely identify individual users in Google Analytics.</description>
+            </property>
             <!-- / Common config options -->
 
             <!-- Advanced config options -->

--- a/packages/pluggableWidgets/google-tag-web/typings/GoogleTagProps.d.ts
+++ b/packages/pluggableWidgets/google-tag-web/typings/GoogleTagProps.d.ts
@@ -36,6 +36,7 @@ export interface GoogleTagContainerProps {
     widgetMode: WidgetModeEnum;
     targetId?: DynamicValue<string>;
     parameters: ParametersType[];
+    sendUserID: boolean;
     command: CommandEnum;
     eventName: string;
     trackPageChanges: boolean;
@@ -53,6 +54,7 @@ export interface GoogleTagPreviewProps {
     widgetMode: WidgetModeEnum;
     targetId: string;
     parameters: ParametersPreviewType[];
+    sendUserID: boolean;
     command: CommandEnum;
     eventName: string;
     trackPageChanges: boolean;

--- a/packages/pluggableWidgets/google-tag-web/typings/global.d.ts
+++ b/packages/pluggableWidgets/google-tag-web/typings/global.d.ts
@@ -9,7 +9,8 @@ declare global {
             };
             session: {
                 getSessionObjectId(): string,
-                getConfig() : { locale: { code: string } }
+                getConfig() : { locale: { code: string } },
+                getUserId(): string
             }
         };
         dojo: {


### PR DESCRIPTION
### Pull request type

New feature (non-breaking change which adds functionality)

### Description

This change introduce a new functionality allowing to optionally share the authenticated user ID with Google Analytics.

Sharing this information allow Google Analytics to identify individual users across different sessions and devices.

This is achieved by modifying the `config` command to add the new `user_id` parameter.

For more details on the feature, please have a look at https://developers.google.com/analytics/devguides/collection/ga4/user-id?client_type=gtag .