### PR TITLE
[WC-1619]: Combobox lazy load option

### DIFF
--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We added lazy loading feature. By default it is turned off. When turned on, the items will be loaded in batches when scrolling.
+
 ### Breaking
 
 -   The Combo box now uses Atlas variables for its styling. This may change how the widget looks depending on the custom variables.

--- a/packages/pluggableWidgets/combobox-web/package.json
+++ b/packages/pluggableWidgets/combobox-web/package.json
@@ -50,6 +50,7 @@
     "@mendix/prettier-config-web-widgets": "workspace:*",
     "@mendix/run-e2e": "workspace:^*",
     "@mendix/widget-plugin-component-kit": "workspace:*",
+    "@mendix/widget-plugin-grid": "workspace:*",
     "@mendix/widget-plugin-hooks": "workspace:*",
     "@mendix/widget-plugin-platform": "workspace:*",
     "@mendix/widget-plugin-test-utils": "workspace:*",

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorConfig.ts
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorConfig.ts
@@ -39,7 +39,8 @@ export function getProperties(values: ComboboxPreviewProps, defaultProperties: P
                 "selectedItemsStyle",
                 "selectionMethod",
                 "selectAllButton",
-                "selectAllButtonCaption"
+                "selectAllButtonCaption",
+                "lazyLoading"
             ]);
             if (values.optionsSourceType === "boolean") {
                 hidePropertiesIn(defaultProperties, values, ["clearable"]);
@@ -127,7 +128,8 @@ export function getProperties(values: ComboboxPreviewProps, defaultProperties: P
             "optionsSourceDatabaseCustomContentType",
             "optionsSourceDatabaseDataSource",
             "optionsSourceDatabaseValueAttribute",
-            "optionsSourceDatabaseDefaultValue"
+            "optionsSourceDatabaseDefaultValue",
+            "lazyLoading"
         ]);
     }
 

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -3,14 +3,14 @@ import { ReactElement, createElement, useMemo } from "react";
 import { ComboboxPreviewProps } from "../typings/ComboboxProps";
 import { SingleSelection } from "./components/SingleSelection/SingleSelection";
 
-import { SingleSelector } from "./helpers/types";
+import { SingleSelector, SelectionBaseProps } from "./helpers/types";
 import "./ui/Combobox.scss";
 import { AssociationPreviewSelector } from "./helpers/Association/Preview/AssociationPreviewSelector";
 import { StaticPreviewSelector } from "./helpers/Static/Preview/StaticPreviewSelector";
 
 export const preview = (props: ComboboxPreviewProps): ReactElement => {
     const id = generateUUID().toString();
-    const commonProps = {
+    const commonProps: Omit<SelectionBaseProps<null>, "selector"> = {
         tabIndex: 1,
         inputId: id,
         labelId: `${id}-label`,
@@ -28,7 +28,7 @@ export const preview = (props: ComboboxPreviewProps): ReactElement => {
                 a11yNoOption: props.noOptionsText
             }
         },
-        showFooter: props.showFooter,
+        lazyLoading: props.lazyLoading ?? false,
         menuFooterContent: props.showFooter ? (
             <props.menuFooterContent.renderer caption="Place footer widget here">
                 <div />

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorPreview.tsx
@@ -28,7 +28,6 @@ export const preview = (props: ComboboxPreviewProps): ReactElement => {
                 a11yNoOption: props.noOptionsText
             }
         },
-        lazyLoading: props.lazyLoading ?? false,
         menuFooterContent: props.showFooter ? (
             <props.menuFooterContent.renderer caption="Place footer widget here">
                 <div />

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
@@ -37,8 +37,7 @@ export default function Combobox(props: ComboboxContainerProps): ReactElement {
                 a11yNoOption: props.noOptionsText?.value ?? ""
             }
         },
-        menuFooterContent: props.showFooter ? props.menuFooterContent : undefined,
-        lazyLoading: props.lazyLoading ?? false
+        menuFooterContent: props.showFooter ? props.menuFooterContent : undefined
     };
 
     return (

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.tsx
@@ -1,12 +1,15 @@
 import { createElement, ReactElement } from "react";
-import { useActionEvents } from "./hooks/useActionEvents";
-import { ComboboxContainerProps } from "../typings/ComboboxProps";
-import { SingleSelection } from "./components/SingleSelection/SingleSelection";
-import { MultiSelection } from "./components/MultiSelection/MultiSelection";
 
-import "./ui/Combobox.scss";
+import { ComboboxContainerProps } from "../typings/ComboboxProps";
+
+import { SelectionBaseProps } from "./helpers/types";
+import { useActionEvents } from "./hooks/useActionEvents";
 import { useGetSelector } from "./hooks/useGetSelector";
 import { Placeholder } from "./components/Placeholder";
+import { MultiSelection } from "./components/MultiSelection/MultiSelection";
+import { SingleSelection } from "./components/SingleSelection/SingleSelection";
+
+import "./ui/Combobox.scss";
 
 export default function Combobox(props: ComboboxContainerProps): ReactElement {
     const selector = useGetSelector(props);
@@ -15,7 +18,7 @@ export default function Combobox(props: ComboboxContainerProps): ReactElement {
         onLeaveEvent: props.onLeaveEvent,
         selector
     });
-    const commonProps = {
+    const commonProps: Omit<SelectionBaseProps<null>, "selector"> = {
         tabIndex: props.tabIndex!,
         inputId: props.id,
         labelId: `${props.id}-label`,
@@ -34,7 +37,8 @@ export default function Combobox(props: ComboboxContainerProps): ReactElement {
                 a11yNoOption: props.noOptionsText?.value ?? ""
             }
         },
-        menuFooterContent: props.showFooter ? props.menuFooterContent : undefined
+        menuFooterContent: props.showFooter ? props.menuFooterContent : undefined,
+        lazyLoading: props.lazyLoading ?? false
     };
 
     return (

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -364,5 +364,13 @@
                 </property>
             </propertyGroup>
         </propertyGroup>
+        <propertyGroup caption="Advanced">
+            <propertyGroup caption="Performance">
+                <property key="lazyLoading" type="boolean" defaultValue="false">
+                    <caption>Lazy loading</caption>
+                    <description />
+                </property>
+            </propertyGroup>
+        </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -6,6 +6,7 @@ import {
     ReferenceSetValueBuilder,
     listExp
 } from "@mendix/widget-plugin-test-utils";
+import "./__mocks__/intersectionObserverMock";
 import "@testing-library/jest-dom";
 import { fireEvent, render, RenderResult, waitFor } from "@testing-library/react";
 import { ObjectItem, DynamicValue } from "mendix";
@@ -45,6 +46,7 @@ describe("Combo box (Association)", () => {
             filterType: "contains",
             selectedItemsStyle: "text",
             readOnlyStyle: "bordered",
+            lazyLoading: false,
             noOptionsText: dynamicValue("no options found"),
             clearButtonAriaLabel: dynamicValue("Clear selection"),
             removeValueAriaLabel: dynamicValue("Remove value"),

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -6,6 +6,7 @@ import {
     ListValueBuilder,
     ReferenceValueBuilder
 } from "@mendix/widget-plugin-test-utils";
+import "./__mocks__/intersectionObserverMock";
 import "@testing-library/jest-dom";
 import { fireEvent, render, RenderResult, act, waitFor } from "@testing-library/react";
 import { ObjectItem, DynamicValue } from "mendix";
@@ -49,6 +50,7 @@ describe("Combo box (Association)", () => {
             filterType: "contains",
             selectedItemsStyle: "text",
             readOnlyStyle: "bordered",
+            lazyLoading: false,
             clearButtonAriaLabel: dynamicValue("Clear selection"),
             removeValueAriaLabel: dynamicValue("Remove value"),
             selectAllButtonCaption: dynamicValue("Select All"),

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/StaticSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/StaticSelection.spec.tsx
@@ -6,6 +6,7 @@ import {
     ListValueBuilder,
     ReferenceValueBuilder
 } from "@mendix/widget-plugin-test-utils";
+import "./__mocks__/intersectionObserverMock";
 import "@testing-library/jest-dom";
 import { fireEvent, render, RenderResult, act, waitFor } from "@testing-library/react";
 import { ObjectItem, DynamicValue } from "mendix";
@@ -44,6 +45,7 @@ describe("Combo box (Static values)", () => {
             filterType: "contains",
             selectedItemsStyle: "text",
             readOnlyStyle: "bordered",
+            lazyLoading: false,
             clearButtonAriaLabel: dynamicValue("Clear selection"),
             removeValueAriaLabel: dynamicValue("Remove value"),
             selectAllButtonCaption: dynamicValue("Select All"),

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__mocks__/intersectionObserverMock.ts
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__mocks__/intersectionObserverMock.ts
@@ -1,0 +1,24 @@
+// Mock the IntersectionObserver, see https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+export class IntersectionObserver {
+    root = null;
+    rootMargin = "";
+    thresholds = [];
+
+    disconnect() {
+        return null;
+    }
+
+    observe() {
+        return null;
+    }
+
+    takeRecords() {
+        return [];
+    }
+
+    unobserve() {
+        return null;
+    }
+}
+window.IntersectionObserver = IntersectionObserver;
+global.IntersectionObserver = IntersectionObserver;

--- a/packages/pluggableWidgets/combobox-web/src/components/ComboboxMenuWrapper.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/ComboboxMenuWrapper.tsx
@@ -1,10 +1,14 @@
 import classNames from "classnames";
 import { UseComboboxPropGetters } from "downshift/typings";
-import { PropsWithChildren, ReactElement, ReactNode, createElement, MouseEvent } from "react";
+import { createElement, MouseEvent, PropsWithChildren, ReactElement, ReactNode } from "react";
+import { InfiniteBodyProps, useInfiniteControl } from "@mendix/widget-plugin-grid/components/InfiniteBody";
 import { useMenuStyle } from "../hooks/useMenuStyle";
 import { NoOptionsPlaceholder } from "./Placeholder";
 
-interface ComboboxMenuWrapperProps extends PropsWithChildren, Partial<UseComboboxPropGetters<string>> {
+interface ComboboxMenuWrapperProps
+    extends PropsWithChildren,
+        Partial<UseComboboxPropGetters<string>>,
+        Pick<InfiniteBodyProps, "hasMoreItems" | "isInfinite" | "setPage"> {
     isOpen: boolean;
     isEmpty: boolean;
     noOptionsText?: string;
@@ -35,10 +39,13 @@ export function ComboboxMenuWrapper(props: ComboboxMenuWrapperProps): ReactEleme
         menuHeaderContent,
         menuFooterContent,
         highlightedIndex,
-        onOptionClick
+        onOptionClick,
+        hasMoreItems,
+        isInfinite,
+        setPage
     } = props;
-
     const [ref, style] = useMenuStyle<HTMLDivElement>(isOpen);
+    const [trackScrolling] = useInfiniteControl({ hasMoreItems, isInfinite, setPage });
 
     return (
         <div
@@ -65,12 +72,14 @@ export function ComboboxMenuWrapper(props: ComboboxMenuWrapperProps): ReactEleme
             )}
             <ul
                 className={classNames("widget-combobox-menu-list", {
-                    "widget-combobox-menu-highlighted": (highlightedIndex ?? -1) >= 0
+                    "widget-combobox-menu-highlighted": (highlightedIndex ?? -1) >= 0,
+                    "infinite-loading": isInfinite
                 })}
                 {...getMenuProps?.(
                     {
                         onClick: onOptionClick,
-                        onMouseDown: ForcePreventMenuCloseEventHandler
+                        onMouseDown: ForcePreventMenuCloseEventHandler,
+                        onScroll: isInfinite ? trackScrolling : undefined
                     },
                     { suppressRefError: true }
                 )}

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
@@ -1,5 +1,5 @@
 import { UseComboboxPropGetters } from "downshift/typings";
-import { ReactElement, ReactNode, createElement, MouseEvent } from "react";
+import { createElement, MouseEvent, ReactElement, ReactNode, useCallback } from "react";
 import { Checkbox } from "../../assets/icons";
 import { MultiSelector } from "../../helpers/types";
 import { ComboboxMenuWrapper } from "../ComboboxMenuWrapper";
@@ -31,6 +31,12 @@ export function MultiSelectionMenu({
     menuFooterContent,
     onOptionClick
 }: MultiSelectionMenuProps): ReactElement {
+    const setPage = useCallback(() => {
+        if (selector.options.loadMore) {
+            selector.options.loadMore();
+        }
+    }, [selector.options]);
+
     return (
         <ComboboxMenuWrapper
             isOpen={isOpen}
@@ -41,6 +47,9 @@ export function MultiSelectionMenu({
             menuHeaderContent={menuHeaderContent}
             menuFooterContent={menuFooterContent}
             onOptionClick={onOptionClick}
+            hasMoreItems={selector.options.hasMore ?? false}
+            isInfinite={selector.lazyLoading ?? false}
+            setPage={setPage}
         >
             {isOpen &&
                 selectableItems.map((item, index) => {

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
@@ -1,5 +1,5 @@
 import { UseComboboxPropGetters } from "downshift/typings";
-import { createElement, ReactElement, ReactNode } from "react";
+import { createElement, ReactElement, ReactNode, useCallback } from "react";
 import { SingleSelector } from "../../helpers/types";
 import { ComboboxMenuWrapper } from "../ComboboxMenuWrapper";
 import { ComboboxOptionWrapper } from "../ComboboxOptionWrapper";
@@ -25,6 +25,11 @@ export function SingleSelectionMenu({
     menuFooterContent
 }: ComboboxMenuProps): ReactElement {
     const items = selector.options.getAll();
+    const setPage = useCallback(() => {
+        if (selector.options.loadMore) {
+            selector.options.loadMore();
+        }
+    }, [selector.options]);
 
     return (
         <ComboboxMenuWrapper
@@ -34,6 +39,9 @@ export function SingleSelectionMenu({
             noOptionsText={noOptionsText}
             menuFooterContent={menuFooterContent}
             alwaysOpen={alwaysOpen}
+            hasMoreItems={selector.options.hasMore ?? false}
+            isInfinite={selector.lazyLoading ?? false}
+            setPage={setPage}
         >
             {isOpen &&
                 items.map((item, index) => (

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationOptionsProvider.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/AssociationOptionsProvider.ts
@@ -1,7 +1,8 @@
-import { CaptionsProvider, Status, SortOrder } from "../types";
 import { ListValue, ObjectItem, ReferenceSetValue, ReferenceValue } from "mendix";
 import { FilterTypeEnum } from "../../../typings/ComboboxProps";
 import { BaseOptionsProvider } from "../BaseOptionsProvider";
+import { CaptionsProvider, Status, SortOrder } from "../types";
+import { DEFAULT_LIMIT_SIZE } from "../utils";
 
 interface Props {
     attr: ReferenceValue | ReferenceSetValue;
@@ -34,7 +35,7 @@ export class AssociationOptionsProvider extends BaseOptionsProvider<ObjectItem, 
 
     loadMore(): void {
         if (this.ds && this.hasMore) {
-            this.ds.setLimit(this.ds.limit + 30);
+            this.ds.setLimit(this.ds.limit + DEFAULT_LIMIT_SIZE);
         }
     }
 

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/utils.ts
@@ -23,7 +23,8 @@ type ExtractionReturnValue = [
     FilterTypeEnum,
     ActionValue | undefined,
     ListWidgetValue | undefined,
-    OptionsSourceAssociationCustomContentTypeEnum
+    OptionsSourceAssociationCustomContentTypeEnum,
+    boolean
 ];
 
 export function extractAssociationProps(props: ComboboxContainerProps): ExtractionReturnValue {
@@ -59,6 +60,7 @@ export function extractAssociationProps(props: ComboboxContainerProps): Extracti
     const clearable = props.clearable;
     const customContent = props.optionsSourceAssociationCustomContent;
     const customContentType = props.optionsSourceAssociationCustomContentType;
+    const lazyLoading = props.lazyLoading ?? false;
 
     return [
         attr,
@@ -69,6 +71,7 @@ export function extractAssociationProps(props: ComboboxContainerProps): Extracti
         filterType,
         onChangeEvent,
         customContent,
-        customContentType
+        customContentType,
+        lazyLoading
     ];
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Database/DatabaseOptionsProvider.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Database/DatabaseOptionsProvider.ts
@@ -1,7 +1,8 @@
-import { CaptionsProvider, Status, SortOrder } from "../types";
 import { ListValue, ObjectItem } from "mendix";
 import { FilterTypeEnum } from "../../../typings/ComboboxProps";
 import { BaseOptionsProvider } from "../BaseOptionsProvider";
+import { CaptionsProvider, Status, SortOrder } from "../types";
+import { DEFAULT_LIMIT_SIZE } from "../utils";
 
 interface Props {
     ds: ListValue;
@@ -33,7 +34,7 @@ export class DatabaseOptionsProvider extends BaseOptionsProvider<ObjectItem, Pro
 
     loadMore(): void {
         if (this.ds && this.hasMore) {
-            this.ds.setLimit(this.ds.limit + 30);
+            this.ds.setLimit(this.ds.limit + DEFAULT_LIMIT_SIZE);
         }
     }
 

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Database/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Database/utils.ts
@@ -25,7 +25,8 @@ type ExtractionReturnValue = [
     ListWidgetValue | undefined,
     OptionsSourceAssociationCustomContentTypeEnum,
     ListAttributeValue<string | Big>,
-    DynamicValue<string | Big>
+    DynamicValue<string | Big>,
+    boolean
 ];
 
 export function extractDatabaseProps(props: ComboboxContainerProps): ExtractionReturnValue {
@@ -50,6 +51,7 @@ export function extractDatabaseProps(props: ComboboxContainerProps): ExtractionR
     const customContent = props.optionsSourceAssociationCustomContent;
     const customContentType = props.optionsSourceAssociationCustomContentType;
     const valueAttribute = props.optionsSourceDatabaseValueAttribute;
+    const lazyLoading = props.lazyLoading ?? false;
 
     if (attr.value instanceof Big && valueAttribute?.type !== "Integer" && valueAttribute?.type !== "Enum") {
         throw new Error(`Atrribute is type of Integer while Value has type ${valueAttribute?.type}`);
@@ -73,6 +75,7 @@ export function extractDatabaseProps(props: ComboboxContainerProps): ExtractionR
         customContent,
         customContentType,
         valueAttribute,
-        emptyValue
+        emptyValue,
+        lazyLoading
     ];
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
@@ -53,6 +53,7 @@ interface SelectorBase<T, V> {
     selectorType?: "context" | "database" | "static";
     type: T;
     readOnly: boolean;
+    lazyLoading?: boolean;
     validation?: string;
 
     // options related
@@ -90,7 +91,6 @@ export interface SelectionBaseProps<Selector> {
     selector: Selector;
     menuFooterContent?: ReactNode;
     tabIndex: number;
-    lazyLoading: boolean;
     a11yConfig: {
         ariaLabels: {
             clearSelection: string;

--- a/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
@@ -90,6 +90,7 @@ export interface SelectionBaseProps<Selector> {
     selector: Selector;
     menuFooterContent?: ReactNode;
     tabIndex: number;
+    lazyLoading: boolean;
     a11yConfig: {
         ariaLabels: {
             clearSelection: string;

--- a/packages/pluggableWidgets/combobox-web/src/helpers/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/utils.ts
@@ -4,6 +4,8 @@ import { MultiSelector } from "./types";
 import { PropsWithChildren, ReactElement, createElement } from "react";
 import { Big } from "big.js";
 
+export const DEFAULT_LIMIT_SIZE = 100;
+
 type ValueType = string | Big | boolean | Date | undefined;
 
 export function getSelectedCaptionsPlaceholder(selector: MultiSelector, selectedItems: string[]): string {

--- a/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
+++ b/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
@@ -88,6 +88,7 @@ export interface ComboboxContainerProps {
     a11ySelectedValue?: DynamicValue<string>;
     a11yOptionsAvailable?: DynamicValue<string>;
     a11yInstructions?: DynamicValue<string>;
+    lazyLoading: boolean;
 }
 
 export interface ComboboxPreviewProps {
@@ -135,4 +136,5 @@ export interface ComboboxPreviewProps {
     a11ySelectedValue: string;
     a11yOptionsAvailable: string;
     a11yInstructions: string;
+    lazyLoading: boolean;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -914,6 +914,9 @@ importers:
       '@mendix/widget-plugin-component-kit':
         specifier: workspace:*
         version: link:../../shared/widget-plugin-component-kit
+      '@mendix/widget-plugin-grid':
+        specifier: workspace:*
+        version: link:../../shared/widget-plugin-grid
       '@mendix/widget-plugin-hooks':
         specifier: workspace:*
         version: link:../../shared/widget-plugin-hooks


### PR DESCRIPTION
### Pull request type

New feature (non-breaking change which adds functionality)

---

### Description

Add new property `lazyLoading` for association and database source, with default value set to false.
When set to true, only a set of data is loaded in the beginning, and the rest will be loaded when scrolling to the bottom.

There are no visual changes, all visual changes will be implemented in another PR.