### PR TITLE
[WC-2480] add missing events from RTE v2

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/rich-text-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We add on change and on key press events to make upgrade consistent from previous version.
+
 ## [3.2.0] - 2024-05-21
 
 ### Added

--- a/packages/pluggableWidgets/rich-text-web/package.json
+++ b/packages/pluggableWidgets/rich-text-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/rich-text-web",
   "widgetName": "RichText",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Rich inline or toolbar text editing",
   "copyright": "© Mendix Technology BV 2024. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
@@ -73,6 +73,10 @@ export function getProperties(values: RichTextPreviewProps, defaultProperties: P
     if (!values.enableStatusBar) {
         hidePropertyIn(defaultProperties, values, "resize");
     }
+
+    if (!values.onChange) {
+        hidePropertyIn(defaultProperties, values, "onChangeType");
+    }
     return defaultProperties;
 }
 

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
@@ -51,8 +51,8 @@ export default function RichText(props: RichTextContainerProps): JSX.Element {
                 style={wrapperStyle}
                 {...wrapperAttributes}
             >
-                {stringAttribute.status === "loading" ? (
-                    <div></div>
+                {stringAttribute.status === "loading" || stringAttribute.status !== "available" ? (
+                    <div className="mx-progress"></div>
                 ) : (
                     <BundledEditor
                         {...props}

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.xml
@@ -136,13 +136,31 @@
         </propertyGroup>
         <propertyGroup caption="Events">
             <propertyGroup caption="Events">
+                <property key="onChange" type="action">
+                    <caption>On change</caption>
+                    <description />
+                </property>
                 <property key="onFocus" type="action">
-                    <caption>On focus</caption>
+                    <caption>On enter</caption>
                     <description />
                 </property>
                 <property key="onBlur" type="action">
-                    <caption>On blur</caption>
+                    <caption>On leave</caption>
                     <description />
+                </property>
+                <property key="onKeyPress" type="action">
+                    <caption>On key press</caption>
+                    <description />
+                </property>
+            </propertyGroup>
+            <propertyGroup caption="On change behavior">
+                <property key="onChangeType" type="enumeration" defaultValue="onLeave">
+                    <caption>Editor resize</caption>
+                    <description />
+                    <enumerationValues>
+                        <enumerationValue key="onLeave">When user leaves input field</enumerationValue>
+                        <enumerationValue key="onDataChange">While user is entering data</enumerationValue>
+                    </enumerationValues>
                 </property>
             </propertyGroup>
         </propertyGroup>

--- a/packages/pluggableWidgets/rich-text-web/src/__tests__/RichText.spec.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/__tests__/RichText.spec.tsx
@@ -76,7 +76,8 @@ describe("Rich Text", () => {
             readOnlyStyle: "text",
             advancedMenubarConfig: [],
             contextmenutype: "native",
-            tabIndex: 0
+            tabIndex: 0,
+            onChangeType: "onLeave"
         };
     });
 

--- a/packages/pluggableWidgets/rich-text-web/src/__tests__/__snapshots__/RichText.spec.tsx.snap
+++ b/packages/pluggableWidgets/rich-text-web/src/__tests__/__snapshots__/RichText.spec.tsx.snap
@@ -7,7 +7,9 @@ exports[`Rich Text renders richtext widget 1`] = `
     id="RichText1"
     style="width: 100%; min-height: 75px;"
   >
-    <div />
+    <div
+      class="mx-progress"
+    />
   </div>
 </div>
 `;

--- a/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/Editor.tsx
@@ -55,7 +55,7 @@ export default function BundledEditor(props: BundledEditorProps): ReactElement {
         if (stringAttribute?.status === "available" && editorState === "ready") {
             setEditorValue(stringAttribute.value ?? "");
         }
-    }, [stringAttribute, editorState]);
+    }, [stringAttribute.value, stringAttribute.status, editorState]);
 
     const onEditorChange = useCallback(
         (value: string, _editor: TinyMCEEditor) => {
@@ -114,7 +114,7 @@ export default function BundledEditor(props: BundledEditorProps): ReactElement {
         // react page needs "mx-progress" a couple of milisecond to be rendered
         // use the next tick to trigger tinymce.init for consistent result
         // especially if we have multiple editor in single page
-        return <div></div>;
+        return <div className="mx-progress"></div>;
     }
 
     return (

--- a/packages/pluggableWidgets/rich-text-web/src/package.xml
+++ b/packages/pluggableWidgets/rich-text-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="RichText" version="3.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="RichText" version="3.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="RichText.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
+++ b/packages/pluggableWidgets/rich-text-web/typings/RichTextProps.d.ts
@@ -23,6 +23,8 @@ export type HeightUnitEnum = "percentageOfWidth" | "pixels" | "percentageOfParen
 
 export type ResizeEnum = "false" | "true" | "both";
 
+export type OnChangeTypeEnum = "onLeave" | "onDataChange";
+
 export type ToolbarConfigEnum = "basic" | "advanced";
 
 export type CtItemTypeEnum = "separator" | "aligncenter" | "alignjustify" | "alignleft" | "alignnone" | "alignright" | "blockquote" | "backcolor" | "blocks" | "bold" | "copy" | "cut" | "fontfamily" | "fontsize" | "forecolor" | "hr" | "indent" | "italic" | "lineheight" | "newdocument" | "outdent" | "paste" | "pastetext" | "print" | "redo" | "remove" | "removeformat" | "selectall" | "strikethrough" | "subscript" | "superscript" | "underline" | "undo" | "visualaid" | "accordion" | "code" | "anchor" | "charmap" | "codesample" | "ltr" | "rtl" | "emoticons" | "fullscreen" | "help" | "image" | "insertdatetime" | "link" | "openlink" | "unlink" | "bullist" | "numlist" | "media" | "pagebreak" | "preview" | "searchreplace" | "table" | "tabledelete" | "tableinsertdialog" | "visualblocks" | "visualchars" | "wordcount";
@@ -66,8 +68,11 @@ export interface RichTextContainerProps {
     height: number;
     minHeight: number;
     resize: ResizeEnum;
+    onChange?: ActionValue;
     onFocus?: ActionValue;
     onBlur?: ActionValue;
+    onKeyPress?: ActionValue;
+    onChangeType: OnChangeTypeEnum;
     extended_valid_elements?: DynamicValue<string>;
     spellCheck: boolean;
     highlight_on_focus: boolean;
@@ -124,8 +129,11 @@ export interface RichTextPreviewProps {
     height: number | null;
     minHeight: number | null;
     resize: ResizeEnum;
+    onChange: {} | null;
     onFocus: {} | null;
     onBlur: {} | null;
+    onKeyPress: {} | null;
+    onChangeType: OnChangeTypeEnum;
     extended_valid_elements: string;
     spellCheck: boolean;
     highlight_on_focus: boolean;


### PR DESCRIPTION


### Pull request type

<!-- No code changes (changes to documentation, CI, metadata, etc.)
<!---->

<!-- Dependency changes (any modification to dependencies in `package.json`)
<!---->

<!-- Refactoring (e.g. file rename, variable rename, etc.)
<!---->

<!-- Bug fix (non-breaking change which fixes an issue)
<!---->

 New feature (non-breaking change which adds functionality)


<!-- Breaking change (fix or feature that would cause existing functionality to change)
<!---->

<!-- Test related change (New E2E test, test automation, etc.)
<!---->

---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description

return back onChange and onKeyPress event that is available on v2.

for consistency, add onChangeType : onLeave or onDataChange

the difference between onchange with onleave changetype is that there is a validation for value change, which makes event triggers only if value change.
as for current on-blur event, it will always trigger regardless of the data.