### PR TITLE
[WC-2455]: Implement Combobox lazy load UI (spinner and skeleton loaders)

### DIFF
--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+-   We added Spinner and Skeleton loaders in addition to lazy loading feature. The default loader is spinner, and skeleton can also be selected. This improves UX when loading more content.
+
 -   We added lazy loading feature. By default it is turned off. When turned on, the items will be loaded in batches when scrolling.
 
 ### Breaking

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.editorConfig.ts
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.editorConfig.ts
@@ -149,6 +149,10 @@ export function getProperties(values: ComboboxPreviewProps, defaultProperties: P
         hidePropertiesIn(defaultProperties, values, ["selectedItemsStyle"]);
     }
 
+    if (values.lazyLoading === false) {
+        hidePropertiesIn(defaultProperties, values, ["loadingType"]);
+    }
+
     return defaultProperties;
 }
 

--- a/packages/pluggableWidgets/combobox-web/src/Combobox.xml
+++ b/packages/pluggableWidgets/combobox-web/src/Combobox.xml
@@ -370,6 +370,14 @@
                     <caption>Lazy loading</caption>
                     <description />
                 </property>
+                <property key="loadingType" type="enumeration" defaultValue="spinner" required="true">
+                    <caption>Loading type</caption>
+                    <description />
+                    <enumerationValues>
+                        <enumerationValue key="spinner">Spinner</enumerationValue>
+                        <enumerationValue key="skeleton">Skeleton</enumerationValue>
+                    </enumerationValues>
+                </property>
             </propertyGroup>
         </propertyGroup>
     </properties>

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -47,6 +47,7 @@ describe("Combo box (Association)", () => {
             selectedItemsStyle: "text",
             readOnlyStyle: "bordered",
             lazyLoading: false,
+            loadingType: "spinner",
             noOptionsText: dynamicValue("no options found"),
             clearButtonAriaLabel: dynamicValue("Clear selection"),
             removeValueAriaLabel: dynamicValue("Remove value"),

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/MultiSelection.spec.tsx
@@ -9,7 +9,7 @@ import {
 import "./__mocks__/intersectionObserverMock";
 import "@testing-library/jest-dom";
 import { fireEvent, render, RenderResult, waitFor } from "@testing-library/react";
-import { ObjectItem, DynamicValue } from "mendix";
+import { ObjectItem, DynamicValue, ListValue } from "mendix";
 import { createElement } from "react";
 import { ComboboxContainerProps } from "../../typings/ComboboxProps";
 import Combobox from "../Combobox";
@@ -159,5 +159,33 @@ describe("Combo box (Association)", () => {
         expect(defaultProps.attributeAssociation?.value).toHaveLength(1);
         fireEvent.click(selectAllButton);
         expect(defaultProps.attributeAssociation?.value).toHaveLength(4);
+    });
+
+    describe("with lazy loading", () => {
+        it("calls loadMore only when menu opens", async () => {
+            const setLimit = jest.fn();
+            const lazyLoadingProps = {
+                ...defaultProps,
+                lazyLoading: true,
+                optionsSourceAssociationDataSource: {
+                    ...defaultProps.optionsSourceAssociationDataSource,
+                    hasMoreItems: true,
+                    limit: 0,
+                    setLimit
+                } as ListValue
+            };
+            const component = render(<Combobox {...lazyLoadingProps} />);
+
+            expect(component.queryAllByRole("option")).toHaveLength(0);
+            expect(lazyLoadingProps.optionsSourceAssociationDataSource?.limit).toEqual(0);
+
+            const input = await getInput(component);
+            fireEvent.click(input);
+
+            await waitFor(() => {
+                expect(component.queryAllByRole("option")).toHaveLength(4);
+                expect(setLimit).toHaveBeenCalledWith(100);
+            });
+        });
     });
 });

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -51,6 +51,7 @@ describe("Combo box (Association)", () => {
             selectedItemsStyle: "text",
             readOnlyStyle: "bordered",
             lazyLoading: false,
+            loadingType: "spinner",
             clearButtonAriaLabel: dynamicValue("Clear selection"),
             removeValueAriaLabel: dynamicValue("Remove value"),
             selectAllButtonCaption: dynamicValue("Select All"),

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/SingleSelection.spec.tsx
@@ -9,7 +9,7 @@ import {
 import "./__mocks__/intersectionObserverMock";
 import "@testing-library/jest-dom";
 import { fireEvent, render, RenderResult, act, waitFor } from "@testing-library/react";
-import { ObjectItem, DynamicValue } from "mendix";
+import { ObjectItem, DynamicValue, ListValue } from "mendix";
 import { createElement } from "react";
 import { ComboboxContainerProps } from "../../typings/ComboboxProps";
 import Combobox from "../Combobox";
@@ -145,5 +145,33 @@ describe("Combo box (Association)", () => {
 
         expect(labelText?.innerHTML).toEqual(defaultProps.emptyOptionText?.value);
         expect(defaultProps.attributeAssociation?.value).toEqual(undefined);
+    });
+
+    describe("with lazy loading", () => {
+        it("calls loadMore only when menu opens", async () => {
+            const setLimit = jest.fn();
+            const lazyLoadingProps = {
+                ...defaultProps,
+                lazyLoading: true,
+                optionsSourceAssociationDataSource: {
+                    ...defaultProps.optionsSourceAssociationDataSource,
+                    hasMoreItems: true,
+                    limit: 0,
+                    setLimit
+                } as ListValue
+            };
+            const component = render(<Combobox {...lazyLoadingProps} />);
+
+            expect(component.queryAllByRole("option")).toHaveLength(0);
+            expect(lazyLoadingProps.optionsSourceAssociationDataSource?.limit).toEqual(0);
+
+            const input = await getInput(component);
+            fireEvent.click(input);
+
+            await waitFor(() => {
+                expect(component.queryAllByRole("option")).toHaveLength(4);
+                expect(setLimit).toHaveBeenCalledWith(100);
+            });
+        });
     });
 });

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/StaticSelection.spec.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/StaticSelection.spec.tsx
@@ -46,6 +46,7 @@ describe("Combo box (Static values)", () => {
             selectedItemsStyle: "text",
             readOnlyStyle: "bordered",
             lazyLoading: false,
+            loadingType: "spinner",
             clearButtonAriaLabel: dynamicValue("Clear selection"),
             removeValueAriaLabel: dynamicValue("Remove value"),
             selectAllButtonCaption: dynamicValue("Select All"),

--- a/packages/pluggableWidgets/combobox-web/src/components/Loader.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/Loader.tsx
@@ -1,7 +1,8 @@
-import { createElement, ReactElement } from "react";
+import { createElement, Fragment, ReactElement } from "react";
 import { LoadingTypeEnum } from "typings/ComboboxProps";
-import { SpinnerLoader } from "./SpinnerLoader";
+import { DEFAULT_LIMIT_SIZE } from "../helpers/utils";
 import { SkeletonLoader } from "./SkeletonLoader";
+import { SpinnerLoader } from "./SpinnerLoader";
 
 type LoaderProps = {
     isLoading: boolean;
@@ -13,11 +14,18 @@ type LoaderProps = {
 
 export function Loader(props: LoaderProps): ReactElement | null {
     const { isLoading, isOpen, lazyLoading, loadingType, withCheckbox } = props;
-    const Loader = loadingType === "skeleton" ? SkeletonLoader : SpinnerLoader;
 
     if (!isOpen || !lazyLoading || !isLoading) {
         return null;
     }
 
-    return <Loader withCheckbox={withCheckbox} />;
+    return loadingType === "skeleton" ? (
+        <Fragment>
+            {Array.from({ length: DEFAULT_LIMIT_SIZE }).map((_, i) => (
+                <SkeletonLoader withCheckbox={withCheckbox} key={i} />
+            ))}
+        </Fragment>
+    ) : (
+        <SpinnerLoader />
+    );
 }

--- a/packages/pluggableWidgets/combobox-web/src/components/Loader.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/Loader.tsx
@@ -1,0 +1,23 @@
+import { createElement, ReactElement } from "react";
+import { LoadingTypeEnum } from "typings/ComboboxProps";
+import { SpinnerLoader } from "./SpinnerLoader";
+import { SkeletonLoader } from "./SkeletonLoader";
+
+type LoaderProps = {
+    isLoading: boolean;
+    isOpen: boolean;
+    lazyLoading: boolean;
+    loadingType?: LoadingTypeEnum;
+    withCheckbox: boolean;
+};
+
+export function Loader(props: LoaderProps): ReactElement | null {
+    const { isLoading, isOpen, lazyLoading, loadingType, withCheckbox } = props;
+    const Loader = loadingType === "skeleton" ? SkeletonLoader : SpinnerLoader;
+
+    if (!isOpen || !lazyLoading || !isLoading) {
+        return null;
+    }
+
+    return <Loader withCheckbox={withCheckbox} />;
+}

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
@@ -1,5 +1,5 @@
 import { UseComboboxPropGetters } from "downshift/typings";
-import { createElement, MouseEvent, ReactElement, ReactNode, useCallback } from "react";
+import { createElement, MouseEvent, ReactElement, ReactNode } from "react";
 import { Checkbox } from "../../assets/icons";
 import { MultiSelector } from "../../helpers/types";
 import { ComboboxMenuWrapper } from "../ComboboxMenuWrapper";
@@ -31,25 +31,23 @@ export function MultiSelectionMenu({
     menuFooterContent,
     onOptionClick
 }: MultiSelectionMenuProps): ReactElement {
-    const setPage = useCallback(() => {
-        if (selector.options.loadMore) {
-            selector.options.loadMore();
-        }
-    }, [selector.options]);
-
     return (
         <ComboboxMenuWrapper
-            isOpen={isOpen}
-            isEmpty={selectableItems.length <= 0}
             getMenuProps={getMenuProps}
-            noOptionsText={noOptionsText}
-            highlightedIndex={highlightedIndex}
-            menuHeaderContent={menuHeaderContent}
-            menuFooterContent={menuFooterContent}
-            onOptionClick={onOptionClick}
             hasMoreItems={selector.options.hasMore ?? false}
+            highlightedIndex={highlightedIndex}
+            isEmpty={selectableItems.length <= 0}
             isInfinite={selector.lazyLoading ?? false}
-            setPage={setPage}
+            isOpen={isOpen}
+            loadingType={selector.loadingType}
+            menuFooterContent={menuFooterContent}
+            menuHeaderContent={menuHeaderContent}
+            noOptionsText={noOptionsText}
+            numberOfItems={selectableItems.length}
+            onOptionClick={onOptionClick}
+            setPage={() => {
+                if (selector.options.loadMore) selector.options.loadMore();
+            }}
         >
             {isOpen &&
                 selectableItems.map((item, index) => {

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
@@ -2,8 +2,10 @@ import { UseComboboxPropGetters } from "downshift/typings";
 import { createElement, MouseEvent, ReactElement, ReactNode } from "react";
 import { Checkbox } from "../../assets/icons";
 import { MultiSelector } from "../../helpers/types";
+import { useLazyLoading } from "../../hooks/useLazyLoading";
 import { ComboboxMenuWrapper } from "../ComboboxMenuWrapper";
 import { ComboboxOptionWrapper } from "../ComboboxOptionWrapper";
+import { Loader } from "../Loader";
 
 interface MultiSelectionMenuProps extends Partial<UseComboboxPropGetters<string>> {
     isOpen: boolean;
@@ -31,25 +33,40 @@ export function MultiSelectionMenu({
     menuFooterContent,
     onOptionClick
 }: MultiSelectionMenuProps): ReactElement {
+    const lazyLoading = selector.lazyLoading ?? false;
+    const { isLoading, onScroll } = useLazyLoading({
+        hasMoreItems: selector.options.hasMore ?? false,
+        isInfinite: lazyLoading,
+        isOpen,
+        loadMore: () => {
+            if (selector.options.loadMore) {
+                selector.options.loadMore();
+            }
+        },
+        numberOfItems: selectableItems.length
+    });
+
     return (
         <ComboboxMenuWrapper
             getMenuProps={getMenuProps}
-            hasMoreItems={selector.options.hasMore ?? false}
             highlightedIndex={highlightedIndex}
             isEmpty={selectableItems.length <= 0}
-            isInfinite={selector.lazyLoading ?? false}
             isOpen={isOpen}
-            loadingType={selector.loadingType}
+            lazyLoading={lazyLoading}
+            loader={
+                <Loader
+                    isLoading={isLoading}
+                    isOpen={isOpen}
+                    lazyLoading={lazyLoading}
+                    loadingType={selector.loadingType}
+                    withCheckbox={selector.selectionMethod === "checkbox"}
+                />
+            }
             menuFooterContent={menuFooterContent}
             menuHeaderContent={menuHeaderContent}
             noOptionsText={noOptionsText}
-            numberOfItems={selectableItems.length}
             onOptionClick={onOptionClick}
-            setPage={() => {
-                if (selector.options.loadMore) {
-                    selector.options.loadMore();
-                }
-            }}
+            onScroll={lazyLoading ? onScroll : undefined}
         >
             {isOpen &&
                 selectableItems.map((item, index) => {

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelectionMenu.tsx
@@ -46,7 +46,9 @@ export function MultiSelectionMenu({
             numberOfItems={selectableItems.length}
             onOptionClick={onOptionClick}
             setPage={() => {
-                if (selector.options.loadMore) selector.options.loadMore();
+                if (selector.options.loadMore) {
+                    selector.options.loadMore();
+                }
             }}
         >
             {isOpen &&

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
@@ -39,7 +39,9 @@ export function SingleSelectionMenu({
             noOptionsText={noOptionsText}
             numberOfItems={items.length}
             setPage={() => {
-                if (selector.options.loadMore) selector.options.loadMore();
+                if (selector.options.loadMore) {
+                    selector.options.loadMore();
+                }
             }}
         >
             {isOpen &&

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
@@ -1,8 +1,10 @@
 import { UseComboboxPropGetters } from "downshift/typings";
 import { createElement, ReactElement, ReactNode } from "react";
 import { SingleSelector } from "../../helpers/types";
+import { useLazyLoading } from "../../hooks/useLazyLoading";
 import { ComboboxMenuWrapper } from "../ComboboxMenuWrapper";
 import { ComboboxOptionWrapper } from "../ComboboxOptionWrapper";
+import { Loader } from "../Loader";
 
 interface ComboboxMenuProps extends Partial<UseComboboxPropGetters<string>> {
     isOpen: boolean;
@@ -25,24 +27,38 @@ export function SingleSelectionMenu({
     menuFooterContent
 }: ComboboxMenuProps): ReactElement {
     const items = selector.options.getAll();
+    const lazyLoading = selector.lazyLoading ?? false;
+    const { isLoading, onScroll } = useLazyLoading({
+        hasMoreItems: selector.options.hasMore ?? false,
+        isInfinite: lazyLoading,
+        isOpen,
+        loadMore: () => {
+            if (selector.options.loadMore) {
+                selector.options.loadMore();
+            }
+        },
+        numberOfItems: items.length
+    });
 
     return (
         <ComboboxMenuWrapper
             alwaysOpen={alwaysOpen}
             getMenuProps={getMenuProps}
-            hasMoreItems={selector.options.hasMore ?? false}
             isEmpty={items?.length <= 0}
-            isInfinite={selector.lazyLoading ?? false}
             isOpen={isOpen}
-            loadingType={selector.loadingType}
+            lazyLoading={lazyLoading}
+            loader={
+                <Loader
+                    isLoading={isLoading}
+                    isOpen={isOpen}
+                    lazyLoading={lazyLoading}
+                    loadingType={selector.loadingType}
+                    withCheckbox={false}
+                />
+            }
             menuFooterContent={menuFooterContent}
             noOptionsText={noOptionsText}
-            numberOfItems={items.length}
-            setPage={() => {
-                if (selector.options.loadMore) {
-                    selector.options.loadMore();
-                }
-            }}
+            onScroll={lazyLoading ? onScroll : undefined}
         >
             {isOpen &&
                 items.map((item, index) => (

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelectionMenu.tsx
@@ -1,5 +1,5 @@
 import { UseComboboxPropGetters } from "downshift/typings";
-import { createElement, ReactElement, ReactNode, useCallback } from "react";
+import { createElement, ReactElement, ReactNode } from "react";
 import { SingleSelector } from "../../helpers/types";
 import { ComboboxMenuWrapper } from "../ComboboxMenuWrapper";
 import { ComboboxOptionWrapper } from "../ComboboxOptionWrapper";
@@ -25,23 +25,22 @@ export function SingleSelectionMenu({
     menuFooterContent
 }: ComboboxMenuProps): ReactElement {
     const items = selector.options.getAll();
-    const setPage = useCallback(() => {
-        if (selector.options.loadMore) {
-            selector.options.loadMore();
-        }
-    }, [selector.options]);
 
     return (
         <ComboboxMenuWrapper
-            isOpen={isOpen}
-            isEmpty={items?.length <= 0}
-            getMenuProps={getMenuProps}
-            noOptionsText={noOptionsText}
-            menuFooterContent={menuFooterContent}
             alwaysOpen={alwaysOpen}
+            getMenuProps={getMenuProps}
             hasMoreItems={selector.options.hasMore ?? false}
+            isEmpty={items?.length <= 0}
             isInfinite={selector.lazyLoading ?? false}
-            setPage={setPage}
+            isOpen={isOpen}
+            loadingType={selector.loadingType}
+            menuFooterContent={menuFooterContent}
+            noOptionsText={noOptionsText}
+            numberOfItems={items.length}
+            setPage={() => {
+                if (selector.options.loadMore) selector.options.loadMore();
+            }}
         >
             {isOpen &&
                 items.map((item, index) => (

--- a/packages/pluggableWidgets/combobox-web/src/components/SkeletonLoader.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SkeletonLoader.tsx
@@ -1,0 +1,14 @@
+import { createElement, ReactElement } from "react";
+
+type SkeletonLoaderProps = {
+    withCheckbox?: boolean;
+};
+
+export function SkeletonLoader({ withCheckbox = false }: SkeletonLoaderProps): ReactElement {
+    return (
+        <div className="widget-combobox-skeleton">
+            {withCheckbox && <span className="widget-combobox-skeleton-loader widget-combobox-skeleton-loader-small" />}
+            <span className="widget-combobox-skeleton-loader" />
+        </div>
+    );
+}

--- a/packages/pluggableWidgets/combobox-web/src/components/SpinnerLoader.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SpinnerLoader.tsx
@@ -1,0 +1,18 @@
+import classNames from "classnames";
+import { createElement, ReactElement } from "react";
+
+type SpinnerLoaderProps = {
+    size?: "small" | "medium";
+};
+
+export function SpinnerLoader({ size = "medium" }: SpinnerLoaderProps): ReactElement {
+    return (
+        <div className="widget-combobox-spinner">
+            <div
+                className={classNames("widget-combobox-spinner-loader", {
+                    "widget-combobox-spinner-loader-small": size === "small"
+                })}
+            />
+        </div>
+    );
+}

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/BaseAssociationSelector.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/BaseAssociationSelector.ts
@@ -1,5 +1,9 @@
 import { ObjectItem, ReferenceValue, ReferenceSetValue, ActionValue, ValueStatus } from "mendix";
-import { ComboboxContainerProps, OptionsSourceAssociationCustomContentTypeEnum } from "../../../typings/ComboboxProps";
+import {
+    ComboboxContainerProps,
+    LoadingTypeEnum,
+    OptionsSourceAssociationCustomContentTypeEnum
+} from "../../../typings/ComboboxProps";
 import { Status } from "../types";
 import { AssociationOptionsProvider } from "./AssociationOptionsProvider";
 import { AssociationSimpleCaptionsProvider } from "./AssociationSimpleCaptionsProvider";
@@ -15,6 +19,7 @@ export class BaseAssociationSelector<T extends string | string[], R extends Refe
     caption: AssociationSimpleCaptionsProvider;
     readOnly = false;
     lazyLoading = false;
+    loadingType?: LoadingTypeEnum;
     customContentType: OptionsSourceAssociationCustomContentTypeEnum = "no";
     validation?: string = undefined;
     protected _attr: R | undefined;
@@ -38,7 +43,8 @@ export class BaseAssociationSelector<T extends string | string[], R extends Refe
             onChangeEvent,
             customContent,
             customContentType,
-            lazyLoading
+            lazyLoading,
+            loadingType
         ] = extractAssociationProps(props);
 
         const newLimit = this.newLimit(ds.limit, attr.readOnly, attr.status, lazyLoading);
@@ -82,6 +88,7 @@ export class BaseAssociationSelector<T extends string | string[], R extends Refe
         this.customContentType = customContentType;
         this.validation = attr.validation;
         this.lazyLoading = lazyLoading;
+        this.loadingType = loadingType;
     }
 
     setValue(_value: T | null): void {

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/BaseAssociationSelector.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/BaseAssociationSelector.ts
@@ -9,7 +9,6 @@ import { AssociationOptionsProvider } from "./AssociationOptionsProvider";
 import { AssociationSimpleCaptionsProvider } from "./AssociationSimpleCaptionsProvider";
 import { extractAssociationProps } from "./utils";
 import { executeAction } from "@mendix/widget-plugin-platform/framework/execute-action";
-import { DEFAULT_LIMIT_SIZE } from "../utils";
 
 export class BaseAssociationSelector<T extends string | string[], R extends ReferenceSetValue | ReferenceValue> {
     status: Status = "unavailable";
@@ -25,7 +24,7 @@ export class BaseAssociationSelector<T extends string | string[], R extends Refe
     protected _attr: R | undefined;
     private onChangeEvent?: ActionValue;
     private _valuesMap: Map<string, ObjectItem> = new Map();
-    private limit: number = DEFAULT_LIMIT_SIZE;
+    private limit: number = 0;
 
     constructor() {
         this.caption = new AssociationSimpleCaptionsProvider(this._valuesMap);

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Association/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Association/utils.ts
@@ -11,6 +11,7 @@ import {
 import {
     ComboboxContainerProps,
     FilterTypeEnum,
+    LoadingTypeEnum,
     OptionsSourceAssociationCustomContentTypeEnum
 } from "../../../typings/ComboboxProps";
 
@@ -24,7 +25,8 @@ type ExtractionReturnValue = [
     ActionValue | undefined,
     ListWidgetValue | undefined,
     OptionsSourceAssociationCustomContentTypeEnum,
-    boolean
+    boolean,
+    LoadingTypeEnum
 ];
 
 export function extractAssociationProps(props: ComboboxContainerProps): ExtractionReturnValue {
@@ -61,6 +63,7 @@ export function extractAssociationProps(props: ComboboxContainerProps): Extracti
     const customContent = props.optionsSourceAssociationCustomContent;
     const customContentType = props.optionsSourceAssociationCustomContentType;
     const lazyLoading = props.lazyLoading ?? false;
+    const loadingType = props.loadingType;
 
     return [
         attr,
@@ -72,6 +75,7 @@ export function extractAssociationProps(props: ComboboxContainerProps): Extracti
         onChangeEvent,
         customContent,
         customContentType,
-        lazyLoading
+        lazyLoading,
+        loadingType
     ];
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Database/DatabaseSingleSelector.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Database/DatabaseSingleSelector.ts
@@ -10,7 +10,7 @@ import { DatabaseCaptionsProvider } from "./DatabaseCaptionsProvider";
 import { extractDatabaseProps } from "./utils";
 import { executeAction } from "@mendix/widget-plugin-platform/framework/execute-action";
 import { DatabaseValuesProvider } from "./DatabaseValuesProvider";
-import { DEFAULT_LIMIT_SIZE, _valuesIsEqual } from "../utils";
+import { _valuesIsEqual } from "../utils";
 
 export class DatabaseSingleSelector<T extends string | Big, R extends EditableValue<T>> implements SingleSelector {
     type = "single" as const;
@@ -29,7 +29,7 @@ export class DatabaseSingleSelector<T extends string | Big, R extends EditableVa
     protected _attr: R | undefined;
     private onChangeEvent?: ActionValue;
     private _objectsMap: Map<string, ObjectItem> = new Map();
-    private limit: number = DEFAULT_LIMIT_SIZE;
+    private limit: number = 0;
 
     constructor() {
         this.caption = new DatabaseCaptionsProvider(this._objectsMap);

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Database/DatabaseSingleSelector.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Database/DatabaseSingleSelector.ts
@@ -1,5 +1,9 @@
 import { ObjectItem, ActionValue, EditableValue, ValueStatus } from "mendix";
-import { ComboboxContainerProps, OptionsSourceAssociationCustomContentTypeEnum } from "../../../typings/ComboboxProps";
+import {
+    ComboboxContainerProps,
+    LoadingTypeEnum,
+    OptionsSourceAssociationCustomContentTypeEnum
+} from "../../../typings/ComboboxProps";
 import { SingleSelector, Status } from "../types";
 import { DatabaseOptionsProvider } from "./DatabaseOptionsProvider";
 import { DatabaseCaptionsProvider } from "./DatabaseCaptionsProvider";
@@ -19,6 +23,7 @@ export class DatabaseSingleSelector<T extends string | Big, R extends EditableVa
     caption: DatabaseCaptionsProvider;
     readOnly = false;
     lazyLoading = false;
+    loadingType?: LoadingTypeEnum;
     customContentType: OptionsSourceAssociationCustomContentTypeEnum = "no";
     validation?: string = undefined;
     protected _attr: R | undefined;
@@ -45,7 +50,8 @@ export class DatabaseSingleSelector<T extends string | Big, R extends EditableVa
             customContentType,
             valueAttribute,
             emptyValue,
-            lazyLoading
+            lazyLoading,
+            loadingType
         ] = extractDatabaseProps(props);
 
         const newLimit = this.newLimit(ds.limit, attr.readOnly, attr.status, lazyLoading);
@@ -112,6 +118,7 @@ export class DatabaseSingleSelector<T extends string | Big, R extends EditableVa
         this.customContentType = customContentType;
         this.validation = attr.validation;
         this.lazyLoading = lazyLoading;
+        this.loadingType = loadingType;
     }
 
     setValue(objectId: string | null): void {

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Database/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Database/utils.ts
@@ -10,6 +10,7 @@ import {
 import {
     ComboboxContainerProps,
     FilterTypeEnum,
+    LoadingTypeEnum,
     OptionsSourceAssociationCustomContentTypeEnum
 } from "../../../typings/ComboboxProps";
 import Big from "big.js";
@@ -26,7 +27,8 @@ type ExtractionReturnValue = [
     OptionsSourceAssociationCustomContentTypeEnum,
     ListAttributeValue<string | Big>,
     DynamicValue<string | Big>,
-    boolean
+    boolean,
+    LoadingTypeEnum
 ];
 
 export function extractDatabaseProps(props: ComboboxContainerProps): ExtractionReturnValue {
@@ -52,6 +54,7 @@ export function extractDatabaseProps(props: ComboboxContainerProps): ExtractionR
     const customContentType = props.optionsSourceAssociationCustomContentType;
     const valueAttribute = props.optionsSourceDatabaseValueAttribute;
     const lazyLoading = props.lazyLoading ?? false;
+    const loadingType = props.loadingType;
 
     if (attr.value instanceof Big && valueAttribute?.type !== "Integer" && valueAttribute?.type !== "Enum") {
         throw new Error(`Atrribute is type of Integer while Value has type ${valueAttribute?.type}`);
@@ -76,6 +79,7 @@ export function extractDatabaseProps(props: ComboboxContainerProps): ExtractionR
         customContentType,
         valueAttribute,
         emptyValue,
-        lazyLoading
+        lazyLoading,
+        loadingType
     ];
 }

--- a/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/types.ts
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import {
     ComboboxContainerProps,
     FilterTypeEnum,
+    LoadingTypeEnum,
     OptionsSourceAssociationCustomContentTypeEnum,
     ReadOnlyStyleEnum,
     SelectedItemsStyleEnum,
@@ -54,6 +55,7 @@ interface SelectorBase<T, V> {
     type: T;
     readOnly: boolean;
     lazyLoading?: boolean;
+    loadingType?: LoadingTypeEnum;
     validation?: string;
 
     // options related

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useLazyLoading.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useLazyLoading.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from "react";
+import { InfiniteBodyProps, useInfiniteControl } from "@mendix/widget-plugin-grid/components/InfiniteBody";
+
+type UseLazyLoadingProps = Pick<InfiniteBodyProps, "hasMoreItems" | "isInfinite"> & {
+    isOpen: boolean;
+    loadMore?: () => void;
+    numberOfItems: number;
+};
+
+type UseLazyLoadingReturn = {
+    isLoading: boolean;
+    onScroll: (e: any) => void;
+};
+
+export function useLazyLoading(props: UseLazyLoadingProps): UseLazyLoadingReturn {
+    const { hasMoreItems, isInfinite, isOpen, loadMore, numberOfItems } = props;
+    const [isLoading, setIsLoading] = useState(false);
+    const [firstLoad, setFirstLoad] = useState(false);
+    const setPageCallback = useCallback(() => {
+        if (loadMore) {
+            setIsLoading(true);
+            loadMore();
+        }
+    }, [loadMore]);
+
+    const [trackScrolling] = useInfiniteControl({ hasMoreItems, isInfinite, setPage: setPageCallback });
+
+    useEffect(() => {
+        if (firstLoad === false && isInfinite === true && isOpen === true) {
+            setFirstLoad(true);
+            setPageCallback();
+        }
+    }, [firstLoad, isInfinite, isOpen]);
+
+    useEffect(() => {
+        setIsLoading(false);
+    }, [numberOfItems]);
+
+    return { isLoading, onScroll: trackScrolling };
+}

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -14,6 +14,8 @@ $cb-disabled-text-color: #6c7180;
 $cb-menu-outer-padding: 10px;
 $cb-spacing: 4px;
 $cb-menu-border-radius: 7px;
+$cb-skeleton-light: rgba(194, 194, 194, 0.2);
+$cb-skeleton-dark: #d2d2d2;
 
 .widget-combobox {
     flex-grow: 1;
@@ -324,5 +326,67 @@ $cb-menu-border-radius: 7px;
     &-icon-container {
         display: flex;
         padding-top: 1px;
+    }
+
+    &-skeleton,
+    &-spinner {
+        align-content: center;
+        align-items: center;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        padding: 6px var(--dropdown-outer-padding, $cb-menu-outer-padding);
+        overflow: hidden;
+    }
+
+    &-skeleton {
+        &-loader {
+            animation: skeleton-loading 1s linear infinite alternate;
+            background: linear-gradient(90deg, $cb-skeleton-light 0%, $cb-skeleton-dark 100%);
+            background-size: 300% 100%;
+            border-radius: 4px;
+            height: 16px;
+            width: 148px;
+
+            &-small {
+                margin-right: 8px;
+                width: 16px;
+            }
+        }
+    }
+
+    &-spinner {
+        justify-content: center;
+        width: 100%;
+
+        &-loader {
+            --widget-combobox-spinner-loader: conic-gradient(#0000 10%, #000), linear-gradient(#000 0 0) content-box;
+            animation: rotate 1s infinite linear;
+            aspect-ratio: 1;
+            background: var(--brand-primary, $cb-brand-primary);
+            border-radius: 50%;
+            mask: var(--widget-combobox-spinner-loader);
+            mask-composite: subtract;
+            padding: 3.5px;
+            height: 24px;
+            width: 24px;
+
+            &-small {
+                height: 16px;
+                width: 16px;
+            }
+        }
+    }
+}
+
+@keyframes skeleton-loading {
+    0% {
+        background-position: right;
+    }
+}
+
+@keyframes rotate {
+    to {
+        transform: rotate(1turn);
     }
 }

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -43,6 +43,19 @@ $cb-skeleton-dark: #d2d2d2;
                 margin-bottom: var(--dropdown-outer-padding, $cb-menu-outer-padding);
             }
         }
+        &-lazy-scroll {
+            background:
+                /* Shadow Cover TOP */ linear-gradient(white 30%, rgba(255, 255, 255, 0)) center
+                    top,
+                /* Shadow Cover BOTTOM */ linear-gradient(rgba(255, 255, 255, 0), white 70%) center bottom,
+                /* Shadow TOP */ linear-gradient(0deg, rgba(255, 255, 255, 0.6), rgba(197, 197, 197, 0.6)) center top,
+                /* Shadow BOTTOM */ linear-gradient(180deg, rgba(255, 255, 255, 0.6), rgba(197, 197, 197, 0.6)) center
+                    bottom;
+
+            background-repeat: no-repeat;
+            background-size: 100% 40px, 100% 40px, 100% 35px, 100% 35px;
+            background-attachment: local, local, scroll, scroll;
+        }
         &-hidden {
             display: none;
         }

--- a/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
+++ b/packages/pluggableWidgets/combobox-web/typings/ComboboxProps.d.ts
@@ -35,6 +35,8 @@ export type SelectedItemsStyleEnum = "text" | "boxes";
 
 export type ReadOnlyStyleEnum = "bordered" | "text";
 
+export type LoadingTypeEnum = "spinner" | "skeleton";
+
 export interface OptionsSourceStaticDataSourcePreviewType {
     staticDataSourceValue: string;
     staticDataSourceCustomContent: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
@@ -89,6 +91,7 @@ export interface ComboboxContainerProps {
     a11yOptionsAvailable?: DynamicValue<string>;
     a11yInstructions?: DynamicValue<string>;
     lazyLoading: boolean;
+    loadingType: LoadingTypeEnum;
 }
 
 export interface ComboboxPreviewProps {
@@ -137,4 +140,5 @@ export interface ComboboxPreviewProps {
     a11yOptionsAvailable: string;
     a11yInstructions: string;
     lazyLoading: boolean;
+    loadingType: LoadingTypeEnum;
 }


### PR DESCRIPTION
### Pull request type

New feature (non-breaking change which adds functionality)

---

### Description

Implement the UI for the lazy load on combobox with the option to select between spinner loader or skeleton loader.

Screenshots:
<img width="604" alt="Screenshot 2024-06-06 at 09 41 17" src="https://github.com/mendix/web-widgets/assets/7821031/932a295f-1be5-4d97-9527-c2f6dd53d383">
<img width="597" alt="Screenshot 2024-06-06 at 10 24 34" src="https://github.com/mendix/web-widgets/assets/7821031/269d7774-e663-4cd1-91b9-fd742ed7370c">
<img width="604" alt="Screenshot 2024-06-06 at 10 22 09" src="https://github.com/mendix/web-widgets/assets/7821031/68f93500-4f9e-4c4d-86d5-a015035639a8">
