### PR TITLE
[WC-2511] accordion unsync content display with state

### DIFF
--- a/packages/pluggableWidgets/accordion-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/accordion-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed the issue where in nested mode, the display collapsed/uncollapsed content can be not in sync with the accordion state.
+
 ## [2.3.1] - 2023-09-27
 
 ### Fixed

--- a/packages/pluggableWidgets/accordion-web/package.json
+++ b/packages/pluggableWidgets/accordion-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/accordion-web",
   "widgetName": "Accordion",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A Mendix pluggable widget to display expandable list items.",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
@@ -48,7 +48,7 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
     useEffect(() => {
         const resizeObserver = new ResizeObserver(entries => {
             for (const entry of entries) {
-                if (entry.contentBoxSize && !props.collapsed && contentWrapperRef.current && contentRef.current) {
+                if (entry.contentBoxSize && !renderCollapsed && contentWrapperRef.current && contentRef.current) {
                     contentWrapperRef.current.style.height = `${contentRef.current.getBoundingClientRect().height}px`;
                 }
             }
@@ -59,7 +59,7 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
         return () => {
             resizeObserver.disconnect();
         };
-    }, [props.collapsed]);
+    }, [renderCollapsed]);
 
     const completeTransitioning = useCallback((): void => {
         if (contentWrapperRef.current && rootRef.current && animatingContent.current) {

--- a/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
@@ -1,7 +1,8 @@
-import { createElement, KeyboardEvent, ReactElement, ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
-import "../ui/accordion-main.scss";
+import { createElement, KeyboardEvent, ReactElement, ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { LoadContentEnum } from "typings/AccordionProps";
+import { useDebouncedResizeObserver, CallResizeObserver } from "../utils/resizeObserver";
+import "../ui/accordion-main.scss";
 
 /* eslint-disable no-unused-vars */
 export const enum Target {
@@ -44,22 +45,7 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
     const renderContent = useRef(loadContent === "always");
 
     renderContent.current ||= !renderCollapsed;
-
-    useEffect(() => {
-        const resizeObserver = new ResizeObserver(entries => {
-            for (const entry of entries) {
-                if (entry.contentBoxSize && !renderCollapsed && contentWrapperRef.current && contentRef.current) {
-                    contentWrapperRef.current.style.height = `${contentRef.current.getBoundingClientRect().height}px`;
-                }
-            }
-        });
-        if (contentRef.current) {
-            resizeObserver.observe(contentRef.current);
-        }
-        return () => {
-            resizeObserver.disconnect();
-        };
-    }, [renderCollapsed]);
+    useDebouncedResizeObserver(CallResizeObserver, { renderCollapsed, contentWrapperRef, contentRef });
 
     const completeTransitioning = useCallback((): void => {
         if (contentWrapperRef.current && rootRef.current && animatingContent.current) {

--- a/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
@@ -45,6 +45,28 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
 
     renderContent.current ||= !renderCollapsed;
 
+    useEffect(() => {
+        const resizeObserver = new ResizeObserver(entries => {
+            for (const entry of entries) {
+                if (entry.contentBoxSize) {
+                    if (!props.collapsed) {
+                        if (contentWrapperRef.current && contentRef.current) {
+                            contentWrapperRef.current.style.height = `${
+                                contentRef.current.getBoundingClientRect().height
+                            }px`;
+                        }
+                    }
+                }
+            }
+        });
+        if (contentRef.current) {
+            resizeObserver.observe(contentRef.current);
+        }
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, [props.collapsed]);
+
     const completeTransitioning = useCallback((): void => {
         if (contentWrapperRef.current && rootRef.current && animatingContent.current) {
             if (!renderCollapsed) {

--- a/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
@@ -95,8 +95,17 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
             }
         } else if (props.collapsed !== renderCollapsed && (!animateContent || !props.visible)) {
             setRenderCollapsed(props.collapsed);
+        } else if (props.collapsed === renderCollapsed) {
+            // if state and props looses their sync due to "complete transition" not being triggered
+            // make sure it is sync back in.
+            if (
+                (renderCollapsed && rootRef.current?.classList.contains("widget-accordion-group-expanding")) ||
+                (!renderCollapsed && rootRef.current?.classList.contains("widget-accordion-group-collapsing"))
+            ) {
+                completeTransitioning();
+            }
         }
-    }, [props.collapsed, props.visible, renderCollapsed, animateContent]);
+    }, [props.collapsed, props.visible, renderCollapsed, animateContent, completeTransitioning]);
 
     useEffect(() => {
         if (renderCollapsed !== previousRenderCollapsed.current) {

--- a/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
@@ -48,14 +48,8 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
     useEffect(() => {
         const resizeObserver = new ResizeObserver(entries => {
             for (const entry of entries) {
-                if (entry.contentBoxSize) {
-                    if (!props.collapsed) {
-                        if (contentWrapperRef.current && contentRef.current) {
-                            contentWrapperRef.current.style.height = `${
-                                contentRef.current.getBoundingClientRect().height
-                            }px`;
-                        }
-                    }
+                if (entry.contentBoxSize && !props.collapsed && contentWrapperRef.current && contentRef.current) {
+                    contentWrapperRef.current.style.height = `${contentRef.current.getBoundingClientRect().height}px`;
                 }
             }
         });

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/Accordion.spec.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/Accordion.spec.tsx
@@ -2,9 +2,14 @@ import { createElement } from "react";
 import { mount, ReactWrapper, shallow } from "enzyme";
 import { Accordion, AccordionProps } from "../Accordion";
 
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn()
+}));
+
 describe("Accordion", () => {
     let defaultProps: AccordionProps;
-
     function getProps(collapsible: boolean, singleExpandedGroup?: boolean): AccordionProps {
         return {
             id: "id",

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/AccordionGroup.spec.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/AccordionGroup.spec.tsx
@@ -2,6 +2,12 @@ import { createElement } from "react";
 import { mount, shallow, ShallowWrapper } from "enzyme";
 import { AccordionGroup, AccordionGroupProps, Target } from "../AccordionGroup";
 
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn()
+}));
+
 describe("AccordionGroup", () => {
     let defaultAccordionGroupProps: AccordionGroupProps;
 

--- a/packages/pluggableWidgets/accordion-web/src/package.xml
+++ b/packages/pluggableWidgets/accordion-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Accordion" version="2.3.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Accordion" version="2.3.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Accordion.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/accordion-web/src/utils/resizeObserver.ts
+++ b/packages/pluggableWidgets/accordion-web/src/utils/resizeObserver.ts
@@ -1,0 +1,36 @@
+import { debounce } from "@mendix/widget-plugin-platform/utils/debounce";
+import { RefObject, useEffect, useMemo } from "react";
+import "../ui/accordion-main.scss";
+
+type ResizeObserverProps = {
+    renderCollapsed: boolean;
+    contentWrapperRef: RefObject<HTMLDivElement>;
+    contentRef: RefObject<HTMLDivElement>;
+};
+
+export function CallResizeObserver(entries: ResizeObserverEntry[], props: ResizeObserverProps): void {
+    const { renderCollapsed, contentWrapperRef, contentRef } = props;
+    for (const entry of entries) {
+        if (entry.contentBoxSize && !renderCollapsed && contentWrapperRef.current && contentRef.current) {
+            contentWrapperRef.current.style.height = `${contentRef.current.getBoundingClientRect().height}px`;
+        }
+    }
+}
+
+export function useDebouncedResizeObserver(callback: typeof CallResizeObserver, props: ResizeObserverProps): void {
+    const { contentRef } = props;
+    const [callResizeObserverDebounce] = useMemo(
+        () => debounce((entries: ResizeObserverEntry[]) => callback(entries, props), 32),
+        [callback, props]
+    );
+
+    useEffect(() => {
+        const observer = new ResizeObserver(callResizeObserverDebounce);
+        if (contentRef.current) {
+            observer.observe(contentRef.current);
+        }
+        return () => {
+            observer.disconnect();
+        };
+    }, [callResizeObserverDebounce, props, contentRef]);
+}


### PR DESCRIPTION
<!--
What type of changes does your PR introduce?
Uncomment relevant sections below by removing `<!--` at the beginning of the line.
-->

### Pull request type

Bug Fix
---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description

child content tries to expand, and calculate the content height while parent is not finished expanding. 
thus, child content is still not fully visible, which cause their bounding rectangle calculation incorrect.

fixing this by adding resize observer to the content.

### What should be covered while testing?

Anything related to accordion content's resizing. make sure the resize observer doesn't try to expand content while content should be collapsing
