### PR TITLE
[WC-2562] Fix rendering issue when visibility expression is has loading state

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We have resolved an issue where the Data Grid would not render in certain cases when a visibility expression was configured on some of its columns.
+
 ## [2.21.0] - 2024-07-08
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -179,15 +179,18 @@ const Container = observer((props: Props): ReactElement => {
     );
 });
 
+const ContainerWithLoading = observer((props: Props) => {
+    if (!props.rootStore.isLoaded) {
+        return null;
+    }
+    return <Container {...props} />;
+});
+
 export default function Datagrid(props: DatagridContainerProps): ReactElement | null {
     const rootStore = useRootStore(props);
 
-    if (!rootStore.isLoaded) {
-        return null;
-    }
-
     return (
-        <Container
+        <ContainerWithLoading
             {...props}
             rootStore={rootStore}
             columnsStore={rootStore.columnsStore}

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.21.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.21.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>


### PR DESCRIPTION

### Pull request type

Bug fix (non-breaking change which fixes an issue)

### Description

We missed an observable on the root level of the component, this made it never re-render when state changed from not loaded to loaded.