### PR TITLE
[WC-2500] Don't automatically focus the input on default filter type change

### DIFF
--- a/packages/pluggableWidgets/datagrid-number-filter-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with the filter unexpectedly focusing when combined with conditional visibility.
+
 ## [2.6.0] - 2024-06-19
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-number-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-number-filter-web",
   "widgetName": "DatagridNumberFilter",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="DatagridNumberFilter" version="2.6.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="DatagridNumberFilter" version="2.6.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="DatagridNumberFilter.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/datagrid-text-filter-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with the filter unexpectedly focusing when combined with conditional visibility.
+
 ## [2.6.0] - 2024-06-19
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-text-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mendix/datagrid-text-filter-web",
   "widgetName": "DatagridTextFilter",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2023. All rights reserved.",
   "private": true,

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="DatagridTextFilter" version="2.6.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="DatagridTextFilter" version="2.6.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="DatagridTextFilter.xml" />
         </widgetFiles>

--- a/packages/shared/widget-plugin-filter-selector/src/FilterSelector.tsx
+++ b/packages/shared/widget-plugin-filter-selector/src/FilterSelector.tsx
@@ -6,7 +6,7 @@ interface FilterSelectorProps<T extends string> {
     ariaLabel?: string;
     id?: string;
     defaultFilter: T;
-    onChange: (value: T) => void;
+    onChange: (value: T, isFromUserInteraction: boolean) => void;
     options: Array<{ value: T; label: string }>;
 }
 
@@ -23,7 +23,7 @@ export function FilterSelector<T extends string>(props: FilterSelectorProps<T>):
     const onClick = useCallback(
         (value: T) => {
             setValue(value);
-            onChange(value);
+            onChange(value, true);
             setShow(false);
         },
         [onChange]
@@ -31,7 +31,7 @@ export function FilterSelector<T extends string>(props: FilterSelectorProps<T>):
 
     useEffect(() => {
         setValue(defaultFilter);
-        onChange(defaultFilter);
+        onChange(defaultFilter, false);
     }, [defaultFilter, onChange]);
 
     const filterSelectors = (

--- a/packages/shared/widget-plugin-filter-selector/src/__tests__/FilterSelector.spec.tsx
+++ b/packages/shared/widget-plugin-filter-selector/src/__tests__/FilterSelector.spec.tsx
@@ -70,7 +70,12 @@ describe("Filter selector", () => {
         const onChange = jest.fn();
         render(<FilterSelector defaultFilter="contains" onChange={onChange} id="test" options={options} />);
 
+        // default filter set on mount
+        expect(onChange).toBeCalledWith("contains", false);
+
         const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+        // clicking on filter first time
         await user.click(screen.getByRole("button"));
         jest.runOnlyPendingTimers();
 
@@ -78,10 +83,10 @@ describe("Filter selector", () => {
         expect(item0).toBeDefined();
         await user.click(item0!);
         jest.runOnlyPendingTimers();
+        // on user interaction filter set
+        expect(onChange).toBeCalledWith("contains", true);
 
-        expect(onChange).toBeCalled();
-        expect(onChange).toBeCalledWith("contains");
-
+        // clicking on filter second time
         await user.click(screen.getByRole("button"));
         jest.runOnlyPendingTimers();
 
@@ -89,8 +94,8 @@ describe("Filter selector", () => {
         expect(item1).toBeDefined();
         await user.click(item1!);
         jest.runOnlyPendingTimers();
-
-        expect(onChange).toBeCalledWith("startsWith");
+        // on user interaction filter set
+        expect(onChange).toBeCalledWith("startsWith", true);
     });
 
     describe("focus", () => {
@@ -145,6 +150,9 @@ describe("Filter selector", () => {
 
             expect(document.body).toHaveFocus();
 
+            // default filter set on mount
+            expect(onChange).toHaveBeenCalledWith("contains", false);
+
             const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
             await user.click(screen.getByRole("button"));
             jest.runOnlyPendingTimers();
@@ -158,7 +166,8 @@ describe("Filter selector", () => {
 
             jest.runOnlyPendingTimers();
 
-            expect(onChange).toHaveBeenCalledWith("contains");
+            // on user interaction filter set
+            expect(onChange).toHaveBeenCalledWith("contains", true);
         });
 
         it("changes focused element back to the button when pressing escape in any element", async () => {

--- a/packages/shared/widget-plugin-filtering/src/controls/input/typings.ts
+++ b/packages/shared/widget-plugin-filtering/src/controls/input/typings.ts
@@ -15,7 +15,7 @@ export interface BaseProps {
 export type FilterList<T> = Array<{ value: T; label: string }>;
 
 export interface InputProps<TFilterEnum> {
-    onFilterChange: (type: TFilterEnum) => void;
+    onFilterChange: (type: TFilterEnum, isFromUserInteraction: boolean) => void;
     defaultFilter: TFilterEnum;
     filters: FilterList<TFilterEnum>;
 

--- a/packages/shared/widget-plugin-filtering/src/controls/input/useInputProps.ts
+++ b/packages/shared/widget-plugin-filtering/src/controls/input/useInputProps.ts
@@ -51,9 +51,11 @@ export function useInputProps<TValue, TFilterEnum>(
         inputRef,
         inputValue: state.inputValue,
         inputDisabled: inputDisabled(state.filterFn),
-        onFilterChange: useCallback(fn => {
+        onFilterChange: useCallback((fn, isFromUserInteraction) => {
             setFilterFn(fn);
-            inputRef.current?.focus();
+            if (isFromUserInteraction) {
+                inputRef.current?.focus();
+            }
         }, []),
         onInputChange: useCallback(event => setInputValue(event.target.value), [])
     };


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---


### Description

When filter is being showed a default filter type is applied via onChange, even though the interaction didn't come from the user. The underlying logic trues to focus the input while it is not needed. This change introduces a flag to let the underlying logic know if the interaction came from the user.