### PR TITLE
[WC-2637]: Fix: pagination in Data Grid 2 causing extra call in auto refresh

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed refreshed interval timer being duplicated on pagination click.
+
 ## [2.22.0] - 2024-09-13
 
 ### Changed

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -39,11 +39,17 @@ const Container = observer((props: Props): ReactElement => {
     const [exportProgress, abortExport] = useDataExport(props, props.columnsStore, props.progressStore);
 
     useEffect(() => {
+        let timer: ReturnType<typeof setTimeout>;
         if (props.refreshInterval > 0) {
-            setTimeout(() => {
+            timer = setTimeout(() => {
                 props.datasource.reload();
             }, props.refreshInterval * 1000);
         }
+        return () => {
+            if (timer) {
+                clearTimeout(timer);
+            }
+        };
     }, [props.datasource, props.refreshInterval]);
 
     const setPage = useCallback(


### PR DESCRIPTION


### Pull request type


 Bug fix (non-breaking change which fixes an issue)


<!-- New feature (non-breaking change which adds functionality)
<!---->

<!-- Breaking change (fix or feature that would cause existing functionality to change)
<!---->

<!-- Test related change (New E2E test, test automation, etc.)
<!---->

---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description
timer never cleared.
it keeps on creating new instance on datasource update.
this PR fix it.