### PR TITLE
[WC-2669]: Dropdown-filter onChange fix

### DIFF
--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/RefFilterContainer.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/RefFilterContainer.tsx
@@ -24,11 +24,13 @@ function Container(props: RefFilterContainerProps): React.ReactElement {
             new RefFilterController({
                 store: props.filterStore,
                 multiselect: props.multiselect,
-                emptyCaption: props.emptyCaption
+                emptyCaption: props.emptyCaption,
+                onChange: props.onChange
             })
     );
 
     useEffect(() => controller.setup(), [controller]);
+    useEffect(() => controller.updateProps({ onChange: props.onChange }), [props.onChange]);
     const handleContentScroll = useOnScrollBottom(controller.handleScrollEnd, { triggerZoneHeight: 100 });
 
     return (

--- a/packages/shared/widget-plugin-filtering/src/controllers/RefFilterController.ts
+++ b/packages/shared/widget-plugin-filtering/src/controllers/RefFilterController.ts
@@ -1,3 +1,4 @@
+import { executeAction } from "@mendix/widget-plugin-platform/framework/execute-action";
 import { ActionValue } from "mendix";
 import { makeObservable, computed } from "mobx";
 import { OptionListFilterInterface, Option } from "../typings/OptionListFilterInterface";
@@ -25,6 +26,7 @@ export class RefFilterController {
             selected: false
         };
         this.onChange = params.onChange;
+        console.info("RefFilterController", params.onChange);
 
         makeObservable(this, {
             inputValue: computed
@@ -57,6 +59,10 @@ export class RefFilterController {
 
     setup(): void {}
 
+    updateProps(props: Pick<Params, "onChange">): void {
+        this.onChange = props.onChange;
+    }
+
     handleSelect = (value: string): void => {
         if (value === this.empty.value) {
             this.store.replace([]);
@@ -66,9 +72,7 @@ export class RefFilterController {
             this.store.replace([value]);
         }
 
-        if (this.onChange?.canExecute) {
-            this.onChange.execute();
-        }
+        executeAction(this.onChange);
     };
 
     handleTriggerClick = (): void => {

--- a/packages/shared/widget-plugin-filtering/src/controllers/StaticFilterController.ts
+++ b/packages/shared/widget-plugin-filtering/src/controllers/StaticFilterController.ts
@@ -1,3 +1,4 @@
+import { executeAction } from "@mendix/widget-plugin-platform/framework/execute-action";
 import { ActionValue, DynamicValue } from "mendix";
 import { makeObservable, computed, autorun, observable } from "mobx";
 import { OptionListFilterInterface, Option } from "../typings/OptionListFilterInterface";
@@ -88,8 +89,6 @@ export class StaticFilterController {
             this.store.replace([value]);
         }
 
-        if (this.onChange?.canExecute) {
-            this.onChange.execute();
-        }
+        executeAction(this.onChange);
     };
 }


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

`onChange` prop is not updating on RefFilterController, on first iteraction it is not executable, so this PR adds an useEffect to update the `onChange` prop, so it will become executable.