### PR TITLE
[WC-2686]: show correct custom content on single selection

### DIFF
--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue when selecting custom content on a single selection combobox. The selected item should show the custom content value.
+
 ## [2.1.1] - 2024-11-15
 
 ### Fixed

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -64,10 +64,10 @@ export function SingleSelection({
                         tabIndex={tabIndex}
                         {...getInputProps(
                             {
+                                "aria-required": ariaRequired,
                                 disabled: selector.readOnly,
                                 readOnly: selector.options.filterType === "none",
-                                ref: inputRef,
-                                "aria-required": ariaRequired
+                                ref: inputRef
                             },
                             { suppressRefError: true }
                         )}

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -136,6 +136,19 @@ $cb-skeleton-dark: #d2d2d2;
                 background-color: transparent;
             }
         }
+
+        .widget-combobox-input {
+            opacity: 0;
+        }
+
+        &-active {
+            .widget-combobox-input {
+                opacity: 1;
+            }
+            .widget-combobox-placeholder-custom {
+                opacity: 0;
+            }
+        }
     }
 
     &-input {
@@ -237,6 +250,14 @@ $cb-skeleton-dark: #d2d2d2;
         flex-grow: 1;
         flex-direction: column;
 
+        .widget-combobox-placeholder-custom {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+        }
+
         .widget-combobox-input {
             &:not(:focus),
             &:placeholder-shown {
@@ -246,9 +267,9 @@ $cb-skeleton-dark: #d2d2d2;
                 right: 0;
                 bottom: 0;
             }
-            &:focus:not(:placeholder-shown) + .widget-combobox-placeholder-custom {
-                display: none;
-            }
+            // &:focus:not(:placeholder-shown) + .widget-combobox-placeholder-custom {
+            //     opacity: 0;
+            // }
         }
     }
 


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

When selecting custom content on a single selection combobox, the selected item should show the custom content value.