### PR TITLE
[WC-2698] Save new personalized side on resize end

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We have introduced the loading state in Datagrid 2, so that the loading state is displayed on every pagination, filter search, or loading.
 
+### Changed
+
+-   We improved resizing behaviour of the widget. It is now saving personalization settings only at the end of the resizing.
+
 ## [2.26.1] - 2024-10-31
 
 ### Changed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mendix/datagrid-web",
     "widgetName": "Datagrid",
-    "version": "2.26.1",
+    "version": "2.26.2",
     "description": "",
     "copyright": "© Mendix Technology BV 2023. All rights reserved.",
     "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -92,7 +92,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             visibleColumns={columns}
             availableColumns={[]}
             columnsSwap={noop}
-            columnsCreateSizeSnapshot={noop}
+            setIsResizing={noop}
             data={data}
             emptyPlaceholderRenderer={useCallback(
                 (renderWrapper: (children: ReactNode) => ReactElement) => (

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -148,7 +148,7 @@ const Container = observer((props: Props): ReactElement => {
             selectRowLabel={props.selectRowLabel?.value}
             visibleColumns={columnsStore.visibleColumns}
             availableColumns={columnsStore.availableColumns}
-            columnsCreateSizeSnapshot={() => columnsStore.createSizeSnapshot()}
+            setIsResizing={(status: boolean) => columnsStore.setIsResizing(status)}
             columnsSwap={(moved, [target, placement]) => columnsStore.swapColumns(moved, [target, placement])}
             selectActionHelper={selectActionHelper}
             cellEventsController={cellEventsController}

--- a/packages/pluggableWidgets/datagrid-web/src/components/GridHeader.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/GridHeader.tsx
@@ -9,7 +9,7 @@ import { HeaderSkeletonLoader } from "./loader/HeaderSkeletonLoader";
 type GridHeaderProps = {
     availableColumns: GridColumn[];
     columns: GridColumn[];
-    columnsCreateSizeSnapshot: () => void;
+    setIsResizing: (status: boolean) => void;
     columnsDraggable: boolean;
     columnsFilterable: boolean;
     columnsHidable: boolean;
@@ -26,7 +26,7 @@ type GridHeaderProps = {
 export function GridHeader({
     availableColumns,
     columns,
-    columnsCreateSizeSnapshot,
+    setIsResizing,
     columnsDraggable,
     columnsFilterable,
     columnsHidable,
@@ -76,7 +76,8 @@ export function GridHeader({
                         resizable={columnsResizable && columns.at(-1) !== column}
                         resizer={
                             <ColumnResizer
-                                onResizeStart={columnsCreateSizeSnapshot}
+                                onResizeStart={() => setIsResizing(true)}
+                                onResizeEnds={() => setIsResizing(false)}
                                 setColumnWidth={(width: number) => column.setSize(width)}
                             />
                         }

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -239,14 +239,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
 });
 
 function gridStyle(columns: GridColumn[], optional: OptionalColumns): CSSProperties {
-    const columnSizes = columns.map(c => {
-        const isLast = columns.at(-1) === c;
-        const columnResizedSize = c.size;
-        if (columnResizedSize) {
-            return isLast ? "minmax(min-content, auto)" : `${columnResizedSize}px`;
-        }
-        return c.getCssWidth();
-    });
+    const columnSizes = columns.map(c => c.getCssWidth());
 
     const sizes: string[] = [];
 

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -78,7 +78,7 @@ export interface WidgetProps<C extends GridColumn, T extends ObjectItem = Object
     availableColumns: GridColumn[];
 
     columnsSwap: (source: ColumnId, target: [ColumnId, "after" | "before"]) => void;
-    columnsCreateSizeSnapshot: () => void;
+    setIsResizing: (status: boolean) => void;
 }
 
 export const Widget = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElement => {
@@ -178,7 +178,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
                         <GridHeader
                             availableColumns={props.availableColumns}
                             columns={visibleColumns}
-                            columnsCreateSizeSnapshot={props.columnsCreateSizeSnapshot}
+                            setIsResizing={props.setIsResizing}
                             columnsDraggable={props.columnsDraggable}
                             columnsFilterable={props.columnsFilterable}
                             columnsHidable={props.columnsHidable}

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/ColumnGroupStore.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/ColumnGroupStore.ts
@@ -24,11 +24,12 @@ export interface IColumnGroupStore {
     columnFilters: ColumnFilterStore[];
 
     swapColumns(source: ColumnId, target: [ColumnId, "after" | "before"]): void;
-    createSizeSnapshot(): void;
+    setIsResizing(status: boolean): void;
 }
 
 export interface IColumnParentStore {
     isLastVisible(column: ColumnStore): boolean;
+    isResizing: boolean;
     sorting: IColumnSortingStore;
 }
 
@@ -39,6 +40,7 @@ export class ColumnGroupStore implements IColumnGroupStore, IColumnParentStore {
     readonly columnFilters: ColumnFilterStore[];
 
     sorting: ColumnsSortingStore;
+    isResizing: boolean = false;
 
     constructor(
         props: Pick<DatagridContainerProps, "columns" | "datasource">,
@@ -62,6 +64,7 @@ export class ColumnGroupStore implements IColumnGroupStore, IColumnParentStore {
 
         makeObservable<ColumnGroupStore, "_allColumns" | "_allColumnsOrdered">(this, {
             _allColumns: observable,
+            isResizing: observable,
 
             loaded: computed,
             _allColumnsOrdered: computed,
@@ -71,7 +74,7 @@ export class ColumnGroupStore implements IColumnGroupStore, IColumnParentStore {
             columnSettings: computed.struct,
             filterSettings: computed({ keepAlive: true }),
             updateProps: action,
-            createSizeSnapshot: action,
+            setIsResizing: action,
             swapColumns: action,
             setColumnSettings: action
         });
@@ -102,8 +105,12 @@ export class ColumnGroupStore implements IColumnGroupStore, IColumnParentStore {
         });
     }
 
-    createSizeSnapshot(): void {
-        this._allColumns.forEach(c => c.takeSizeSnapshot());
+    setIsResizing(status: boolean): void {
+        this.isResizing = status;
+
+        if (this.isResizing) {
+            this._allColumns.forEach(c => c.takeSizeSnapshot());
+        }
     }
 
     get loaded(): boolean {

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/column/ColumnStore.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/column/ColumnStore.tsx
@@ -28,6 +28,8 @@ export class ColumnStore implements GridColumn {
     private baseInfo: BaseColumnInfo;
     private parentStore: IColumnParentStore;
 
+    private frozenSize: number | undefined;
+
     // dynamic props from PW API
     private _visible?: DynamicValue<boolean> = undefined; // can't render when unavailable
     private _header?: DynamicValue<string> = undefined; // can render when unavailable
@@ -184,6 +186,7 @@ export class ColumnStore implements GridColumn {
 
     takeSizeSnapshot(): void {
         const size = this.headerElementRef?.clientWidth;
+        this.frozenSize = this.size;
         if (size) {
             this.setSize(size);
         }
@@ -230,7 +233,7 @@ export class ColumnStore implements GridColumn {
     get settings(): ColumnPersonalizationSettings {
         return {
             columnId: this.columnId,
-            size: this.size,
+            size: this.parentStore.isResizing ? this.frozenSize : this.size,
             hidden: this.isHidden,
             orderWeight: this.orderWeight,
             sortDir: this.sortDir,

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.26.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.26.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
@@ -55,6 +55,7 @@ export function mockGridColumn(c: ColumnsType, index: number): GridColumn {
         isLastVisible(_column: ColumnStore): boolean {
             return false;
         },
+        isResizing: false,
         sorting: {
             getDirection(_columnId: ColumnId): ["asc" | "desc", number] | undefined {
                 return undefined;
@@ -97,7 +98,7 @@ export function mockWidgetProps(): WidgetProps<GridColumn, ObjectItem> {
         visibleColumns: columns,
         availableColumns: columns,
         columnsSwap: jest.fn(),
-        columnsCreateSizeSnapshot: jest.fn(),
+        setIsResizing: jest.fn(),
         selectionStatus: "unknown",
         setPage: jest.fn(),
         processedRows: 0,


### PR DESCRIPTION
### Pull request type

Performance improvement

### Description

Save personalization settings only at the end pf the resizing, this prevents writing setting multiple times while user is dragging the cursor.