### PR TITLE
[WC-2737] Fix export to excel issues

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue where Export to Excel was not working in certain cases.
+
 ## [2.28.0] - 2024-11-13
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mendix/datagrid-web",
     "widgetName": "Datagrid",
-    "version": "2.28.0",
+    "version": "2.28.1",
     "description": "",
     "copyright": "© Mendix Technology BV 2023. All rights reserved.",
     "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/features/data-export/useDataExport.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/features/data-export/useDataExport.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ExportController } from "./ExportController";
 import { ProgressStore } from "./ProgressStore";
 import { getExportRegistry } from "./registry";
@@ -15,17 +15,17 @@ export function useDataExport(
     columnsStore: IColumnGroupStore,
     progress: ProgressStore
 ): [store: ProgressStore, abort: () => void] {
-    const [entry] = useState(() => addController(props.name, progress));
+    const [entry] = useState(() => createEntry(props.name, progress));
     const abort = useCallback(() => entry?.controller.abort(), [entry]);
 
     // Remove entry when widget unmounted.
-    useEffect(
-        () => () => {
+    useEffect(() => {
+        addController(entry);
+        return () => {
             entry?.controller.abort();
             removeController(entry);
-        },
-        [entry]
-    );
+        };
+    }, [entry]);
 
     useEffect(() => {
         entry?.controller.emit("sourcechange", props.datasource);
@@ -45,25 +45,35 @@ export function useDataExport(
     return [progress, abort];
 }
 
-function addController(name: string, progress: ProgressStore): ResourceEntry | null {
-    const registry = getExportRegistry();
-
-    if (registry.has(name)) {
-        return null;
-    }
-
-    const entry = {
+function createEntry(name: string, progress: ProgressStore): ResourceEntry {
+    return {
         key: name,
         controller: new ExportController(progress)
     };
+}
 
+function addController(entry: ResourceEntry): void {
+    const registry = getExportRegistry();
+
+    // this overrides existing entries
+    // but this is expected behaviour, the last one wins.
+    // In the scenario where a new page has a data grid
+    // with the same name and gets mounted while the old one
+    // is not yet unmounted the new one has to win.
     registry.set(entry.key, entry.controller);
-
-    return entry;
 }
 
 function removeController(entry: ResourceEntry | null): void {
-    if (entry) {
-        getExportRegistry().delete(entry.key);
+    if (!entry) {
+        return;
+    }
+
+    const registry = getExportRegistry();
+
+    // only remove the exact controller we placed
+    // it can happen that other grid has overridden the key
+    // in this case we don't do anything.
+    if (registry.get(entry.key) === entry.controller) {
+        registry.delete(entry.key);
     }
 }

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.28.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.28.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Pull request type


Bug fix (non-breaking change which fixes an issue)

### Description

While switching pages it could happen that the new page is mounted while the old one is not yet unmounted, this led to issue with export controllers not being placed for the new data grids. This change makes it always override the existing controller, but removing a controller on unmount stage only affects own controller.