### PR TITLE
[WC-2752]: fix DG2 refresh in client issue

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We've stopped showing the loading indicator when all data were already loaded. The loading indicator was incorrectly displayed during client refresh operations involving a microflow.
+
 ## [2.28.1] - 2024-11-21
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mendix/datagrid-web",
     "widgetName": "Datagrid",
-    "version": "2.28.1",
+    "version": "2.28.2",
     "description": "",
     "copyright": "© Mendix Technology BV 2023. All rights reserved.",
     "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -91,7 +91,7 @@ const Container = observer((props: Props): ReactElement => {
         }
 
         return props.datasource.status === ValueStatus.Loading;
-    }, [exportProgress, isRefreshing, props.datasource.status]);
+    }, [exportProgress, isRefreshing, props.datasource.status, props.datasource.hasMoreItems]);
 
     return (
         <Widget

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -86,6 +86,10 @@ const Container = observer((props: Props): ReactElement => {
             return false;
         }
 
+        if (!props.datasource.hasMoreItems) {
+            return false;
+        }
+
         return props.datasource.status === ValueStatus.Loading;
     }, [exportProgress, isRefreshing, props.datasource.status]);
 

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.28.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.28.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

The issue some customers are facing is when using refresh in client on a microflow in a page with the last version of Datagrid 2 (v2.28). The issue is that when using this microflow on a datagrid to update the data regularly, the loading indicators keep showing up, on every update, and the user simply don't want that. They want the datagrid loading indicator to only show up when doing datasource changes, adding items, or when navigating between pages (paginating).