### PR TITLE
[]: Remove lint warnings from pluggable widgets

### DIFF
--- a/packages/pluggableWidgets/badge-button-web/src/components/__tests__/BadgeButton.spec.ts
+++ b/packages/pluggableWidgets/badge-button-web/src/components/__tests__/BadgeButton.spec.ts
@@ -6,8 +6,11 @@ import { BadgeButton, BadgeButtonProps } from "../BadgeButton";
 describe("BadgeButton", () => {
     const createBadgeButton = (
         props: BadgeButtonProps
-    ): ShallowWrapper<BadgeButtonProps, Readonly<{}>, Component<{}, {}, any>> =>
-        shallow(createElement(BadgeButton, props));
+    ): ShallowWrapper<
+        BadgeButtonProps,
+        Readonly<NonNullable<unknown>>,
+        Component<NonNullable<unknown>, NonNullable<unknown>, any>
+    > => shallow(createElement(BadgeButton, props));
 
     it("renders the structure correctly", () => {
         const badgeProps: BadgeButtonProps = {

--- a/packages/pluggableWidgets/badge-web/src/Badge.editorPreview.tsx
+++ b/packages/pluggableWidgets/badge-web/src/Badge.editorPreview.tsx
@@ -5,9 +5,7 @@ import { BadgePreviewProps } from "../typings/BadgeProps";
 import { Badge } from "./components/Badge";
 
 export const preview = (props: BadgePreviewProps): ReactElement => {
-    // TODO: Change PIW preview props typing (class -> className) generation to remove the ts-ignore below
-    // @ts-ignore
-    const { className, style, type, value } = props;
+    const { class: className, style, type, value } = props;
 
     return <Badge type={type} value={value ? value : ""} className={className} style={parseStyle(style)} />;
 };

--- a/packages/pluggableWidgets/combobox-web/src/__tests__/__mocks__/intersectionObserverMock.ts
+++ b/packages/pluggableWidgets/combobox-web/src/__tests__/__mocks__/intersectionObserverMock.ts
@@ -4,19 +4,19 @@ export class IntersectionObserver {
     rootMargin = "";
     thresholds = [];
 
-    disconnect() {
+    disconnect(): null {
         return null;
     }
 
-    observe() {
+    observe(): null {
         return null;
     }
 
-    takeRecords() {
+    takeRecords(): [] {
         return [];
     }
 
-    unobserve() {
+    unobserve(): null {
         return null;
     }
 }

--- a/packages/pluggableWidgets/heatmap-chart-web/src/HeatMap.editorConfig.ts
+++ b/packages/pluggableWidgets/heatmap-chart-web/src/HeatMap.editorConfig.ts
@@ -81,7 +81,7 @@ export function getPreview(values: HeatMapPreviewProps, isDarkMode: boolean): St
         light: { structure: HeatMapLight, legend: HeatMapLegendLight }
     };
 
-    const getImage = (type: "structure" | "legend") => {
+    const getImage = (type: "structure" | "legend"): string => {
         const colorMode = isDarkMode ? "dark" : "light";
         return items[colorMode][type];
     };

--- a/packages/pluggableWidgets/rating-web/src/StarRating.editorPreview.tsx
+++ b/packages/pluggableWidgets/rating-web/src/StarRating.editorPreview.tsx
@@ -33,6 +33,6 @@ export function preview(props: StarRatingPreviewProps): ReactElement {
     );
 }
 
-export function getPreviewCss() {
+export function getPreviewCss(): string {
     return require("./ui/rating-main.scss");
 }

--- a/packages/pluggableWidgets/rich-text-web/src/utils/formats/button.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/formats/button.ts
@@ -42,7 +42,7 @@ class Button extends Inline {
         return domNode;
     }
 
-    static formats(domNode: Element) {
+    static formats(domNode: Element): Record<string, string | null> {
         return ATTRIBUTES.reduce((formats: Record<string, string | null>, attribute) => {
             if (domNode.hasAttribute(attribute)) {
                 formats[attribute] = domNode.getAttribute(attribute);

--- a/packages/pluggableWidgets/rich-text-web/src/utils/helpers.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/helpers.ts
@@ -3,7 +3,7 @@ import Quill from "quill";
 import { Delta, Op } from "quill/core";
 import { RichTextContainerProps } from "typings/RichTextProps";
 
-function getHeightScale(height: number, heightUnit: "pixels" | "percentageOfParent" | "percentageOfView") {
+function getHeightScale(height: number, heightUnit: "pixels" | "percentageOfParent" | "percentageOfView"): string {
     return `${height}${heightUnit === "pixels" ? "px" : heightUnit === "percentageOfView" ? "vh" : "%"}`;
 }
 

--- a/packages/pluggableWidgets/switch-web/src/Switch.editorPreview.tsx
+++ b/packages/pluggableWidgets/switch-web/src/Switch.editorPreview.tsx
@@ -4,9 +4,9 @@ import { SwitchPreviewProps } from "../typings/SwitchProps";
 import Switch from "./components/Switch";
 
 export function preview(props: SwitchPreviewProps): ReactElement {
-    return <Switch id="switch-preview" validation={undefined} editable={!props.readOnly ?? true} isChecked />;
+    return <Switch id="switch-preview" validation={undefined} editable={!props.readOnly} isChecked />;
 }
 
-export function getPreviewCss() {
+export function getPreviewCss(): string {
     return require("./ui/switch-main.scss");
 }

--- a/packages/pluggableWidgets/switch-web/src/Switch.tsx
+++ b/packages/pluggableWidgets/switch-web/src/Switch.tsx
@@ -1,4 +1,4 @@
-import { createElement, KeyboardEvent, MouseEvent, useCallback } from "react";
+import { createElement, KeyboardEvent, MouseEvent, ReactElement, useCallback } from "react";
 import { executeAction } from "@mendix/widget-plugin-platform/framework/execute-action";
 import { isAvailable } from "@mendix/widget-plugin-platform/framework/is-available";
 import SwitchComponent from "./components/Switch";
@@ -6,7 +6,7 @@ import SwitchComponent from "./components/Switch";
 import { SwitchContainerProps } from "../typings/SwitchProps";
 import "./ui/switch-main.scss";
 
-export function Switch(props: SwitchContainerProps) {
+export function Switch(props: SwitchContainerProps): ReactElement {
     const isChecked = isAvailable(props.booleanAttribute);
     const editable = !props.booleanAttribute.readOnly;
 

--- a/packages/pluggableWidgets/switch-web/src/components/Switch.tsx
+++ b/packages/pluggableWidgets/switch-web/src/components/Switch.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, KeyboardEvent, createElement } from "react";
+import { MouseEvent, KeyboardEvent, createElement, ReactElement } from "react";
 import classNames from "classnames";
 import { Alert } from "@mendix/widget-plugin-component-kit/Alert";
 import { SwitchContainerProps } from "../../typings/SwitchProps";
@@ -11,7 +11,7 @@ export interface SwitchProps extends Pick<SwitchContainerProps, "id" | "tabIndex
     validation: string | undefined;
 }
 
-export default function Switch(props: SwitchProps) {
+export default function Switch(props: SwitchProps): ReactElement {
     return (
         <div className="widget-switch">
             <div

--- a/packages/pluggableWidgets/time-series-chart-web/src/TimeSeries.editorConfig.ts
+++ b/packages/pluggableWidgets/time-series-chart-web/src/TimeSeries.editorConfig.ts
@@ -93,7 +93,7 @@ export function getPreview(values: TimeSeriesPreviewProps, isDarkMode: boolean):
         }
     };
 
-    const getImage = (viewMode: "series" | "range", type: "structure" | "legend") => {
+    const getImage = (viewMode: "series" | "range", type: "structure" | "legend"): string => {
         const colorMode = isDarkMode ? "dark" : "light";
         return items[viewMode][colorMode][type];
     };

--- a/packages/pluggableWidgets/timeline-web/src/utils/utils.ts
+++ b/packages/pluggableWidgets/timeline-web/src/utils/utils.ts
@@ -1,11 +1,20 @@
-import { GroupByKeyEnum, GroupByMonthOptionsEnum, TimelineContainerProps } from "../../typings/TimelineProps";
+import {
+    GroupByDayOptionsEnum,
+    GroupByKeyEnum,
+    GroupByMonthOptionsEnum,
+    TimelineContainerProps
+} from "../../typings/TimelineProps";
 
 export type GroupHeaderConfig = Pick<
     TimelineContainerProps,
     "groupByKey" | "groupByDayOptions" | "groupByMonthOptions"
 >;
 
-export function getHeaderOption({ groupByKey, groupByDayOptions, groupByMonthOptions }: GroupHeaderConfig) {
+export function getHeaderOption({
+    groupByKey,
+    groupByDayOptions,
+    groupByMonthOptions
+}: GroupHeaderConfig): "year" | GroupByDayOptionsEnum | GroupByMonthOptionsEnum {
     return groupByKey === "day" ? groupByDayOptions : groupByKey === "month" ? groupByMonthOptions : "year";
 }
 

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorPreview.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorPreview.tsx
@@ -9,7 +9,7 @@ import { VideoPlayerPreviewProps } from "../typings/VideoPlayerProps";
 
 declare function require(name: string): string;
 
-export class preview extends Component<VideoPlayerPreviewProps, {}> {
+export class preview extends Component<VideoPlayerPreviewProps, NonNullable<unknown>> {
     render(): JSX.Element {
         return (
             <SizeContainer


### PR DESCRIPTION
### Pull request type

Refactoring (e.g. file rename, variable rename, etc.)

---

### Description

Fix lint warnings from widgets, except warnings on react hooks like `useEffect`, `useCallback`...