### PR TITLE
[WC-2823] Don't save ininitialized filters to the personalization

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   Fixed issue with loading indicator not being displayed in some scenarios
 
+-   We fixed an issue where an incorrect filter type was saved to personalization when a column was hidden by default.
+
 ### Breaking changes
 
 -   Drop-down filter is rewritten with new, more accurate HTML for better accessibility, which may break existing CSS styling for projects using drop-down filter

--- a/packages/pluggableWidgets/datagrid-web/e2e/DataGrid.spec.js
+++ b/packages/pluggableWidgets/datagrid-web/e2e/DataGrid.spec.js
@@ -99,9 +99,15 @@ test.describe("capabilities: hiding", () => {
     test("hide column saved on configuration attribute capability", async ({ page }) => {
         await page.goto("/");
         await page.waitForLoadState("networkidle");
+
+        // hide first column
         await page.locator(".mx-name-datagrid5 .column-selector-button").click();
         await page.locator(".column-selectors > li").first().click();
+
+        // check if it is really hidden
         await expect(page.locator(".mx-name-datagrid5 .column-header").first()).toHaveText("Last Name");
+
+        // check config saved to the attribute and visible in the text area
         const textArea = page.locator(".mx-name-textArea1 textarea");
         await expect(textArea).not.toBeEmpty();
         const textAreaValue = await textArea.inputValue();
@@ -113,10 +119,7 @@ test.describe("capabilities: hiding", () => {
                 { columnId: "0", hidden: true },
                 { columnId: "1", hidden: false }
             ],
-            columnFilters: [
-                ["0", ["equal", null, null]],
-                ["1", ["equal", null, null]]
-            ],
+            columnFilters: [],
             groupFilters: [],
             sortOrder: [],
             columnOrder: ["0", "1"]

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mendix/datagrid-web",
     "widgetName": "Datagrid",
-    "version": "2.30.0",
+    "version": "2.30.1",
     "description": "",
     "copyright": "© Mendix Technology BV 2025. All rights reserved.",
     "private": true,

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.30.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.30.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>

--- a/packages/shared/widget-plugin-filtering/src/stores/input/BaseInputFilterStore.ts
+++ b/packages/shared/widget-plugin-filtering/src/stores/input/BaseInputFilterStore.ts
@@ -42,6 +42,7 @@ export class BaseInputFilterStore<A extends Argument, Fn extends AllFunctions> {
         makeObservable<this, "_attributes" | "setState">(this, {
             _attributes: observable.ref,
             filterFunction: observable,
+            isInitialized: observable,
             condition: computed,
             setState: action,
             UNSAFE_setDefaults: action,
@@ -63,7 +64,7 @@ export class BaseInputFilterStore<A extends Argument, Fn extends AllFunctions> {
 
     UNSAFE_setDefaults = (state: StateTuple<Fn, Val<A>>): void => {
         this.defaultState = state;
-        if (this.isInitialized === false) {
+        if (!this.isInitialized) {
             this.setState(state);
             this.isInitialized = true;
         }

--- a/packages/shared/widget-plugin-filtering/src/stores/input/DateInputFilterStore.ts
+++ b/packages/shared/widget-plugin-filtering/src/stores/input/DateInputFilterStore.ts
@@ -195,7 +195,10 @@ export class DateInputFilterStore
         );
     }
 
-    toJSON(): InputData {
+    toJSON(): InputData | undefined {
+        if (!this.isInitialized) {
+            return undefined;
+        }
         return [
             this.filterFunction,
             this.arg1.value ? this.arg1.value.toJSON() : null,

--- a/packages/shared/widget-plugin-filtering/src/stores/input/NumberInputFilterStore.ts
+++ b/packages/shared/widget-plugin-filtering/src/stores/input/NumberInputFilterStore.ts
@@ -40,7 +40,10 @@ export class NumberInputFilterStore
         }
     }
 
-    toJSON(): InputData {
+    toJSON(): InputData | undefined {
+        if (!this.isInitialized) {
+            return undefined;
+        }
         return [
             this.filterFunction,
             this.arg1.value ? this.arg1.value.toJSON() : null,

--- a/packages/shared/widget-plugin-filtering/src/stores/input/StringInputFilterStore.ts
+++ b/packages/shared/widget-plugin-filtering/src/stores/input/StringInputFilterStore.ts
@@ -44,7 +44,11 @@ export class StringInputFilterStore
         this.arg2.updateProps(formatter as ListAttributeValue<string>["formatter"]);
     }
 
-    toJSON(): InputData {
+    toJSON(): InputData | undefined {
+        if (!this.isInitialized) {
+            return undefined;
+        }
+
         return [this.filterFunction, this.arg1.value ?? null, this.arg2.value ?? null];
     }
 


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---


### Description

When a column is hidden by default, a corresponding filter widget is never mounted and has no way of communicating it's default values to the data grid, and the data grid was assuming the default "equals" filter. Later on, the saved "equal" was overriding the actual value from the filter. To prevent this from happening - don't return value for storage if the filter is not yet properly initialized (as from default value or view state).