### PR TITLE
[WC-2915]: add view and tableBetter to toolbar group keys

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
@@ -15,7 +15,9 @@ const toolbarGroupKeys: Array<keyof RichTextPreviewProps> = [
     "align",
     "code",
     "header",
-    "remove"
+    "remove",
+    "view",
+    "tableBetter"
 ];
 
 export function getProperties(values: RichTextPreviewProps, defaultProperties: Properties): Properties {


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

Hide `View` and `Table` options when rich text is not in custom or advanced mode.