### PR TITLE
[WC-2959] Fix resizing glitch in DG2

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where columns weren't resizing correctly when vertical borders were enabled.
+
 ## [2.30.5] - 2025-05-26
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mendix/datagrid-web",
     "widgetName": "Datagrid",
-    "version": "2.30.5",
+    "version": "2.30.6",
     "description": "",
     "copyright": "© Mendix Technology BV 2025. All rights reserved.",
     "license": "Apache-2.0",

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnResizer.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnResizer.tsx
@@ -27,7 +27,7 @@ export function ColumnResizer({
             setIsResizing(true);
             if (resizerReference.current) {
                 const column = resizerReference.current.parentElement!;
-                setCurrentWidth(column.clientWidth);
+                setCurrentWidth(column.offsetWidth);
             }
             onStart();
         },

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/column/ColumnStore.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/column/ColumnStore.tsx
@@ -185,7 +185,7 @@ export class ColumnStore implements GridColumn {
     }
 
     takeSizeSnapshot(): void {
-        const size = this.headerElementRef?.clientWidth;
+        const size = this.headerElementRef?.offsetWidth;
         this.frozenSize = this.size;
         if (size) {
             this.setSize(size);

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.30.5" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.30.6" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>


### PR DESCRIPTION

### Pull request type
Bug fix (non-breaking change which fixes an issue)

---

### Description

Added borders are not reflected in `clientWidth`, this made columns jump. Switching to `offsetWidth` fixes the issue as it takes border size into account. 