### PR TITLE
[WC-3003] Use screen breakpoints from variables in gallery [2.32]

### DIFF
--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_gallery.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_gallery.scss
@@ -3,8 +3,8 @@
 
    Override styles of Gallery widget
 ========================================================================== */
-$gallery-screen-lg: 992px;
-$gallery-screen-md: 768px;
+$gallery-screen-lg: $screen-lg;
+$gallery-screen-md: $screen-md;
 
 @mixin grid-items($number, $suffix) {
     @for $i from 1 through $number {

--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where gallery widget wasn't following screen breakpoints defined in custom-variables file.
+
 ## [1.14.1] - 2025-05-26
 
 ### Added

--- a/packages/pluggableWidgets/gallery-web/package.json
+++ b/packages/pluggableWidgets/gallery-web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mendix/gallery-web",
     "widgetName": "Gallery",
-    "version": "1.14.1",
+    "version": "1.14.2",
     "description": "A flexible gallery widget that renders columns, rows and layouts.",
     "copyright": "© Mendix Technology BV 2025. All rights reserved.",
     "license": "Apache-2.0",

--- a/packages/pluggableWidgets/gallery-web/src/package.xml
+++ b/packages/pluggableWidgets/gallery-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Gallery" version="1.14.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Gallery" version="1.14.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Gallery.xml" />
         </widgetFiles>


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

Rely on atlas variables for screen breakpoint sizes.