### PR TITLE
[WC-2838]: Implement RefreshIndicator component on Datagrid 2

### DIFF
--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -429,6 +429,82 @@ $root: ".widget-datagrid";
         display: contents;
     }
 
+    &-refresh-container {
+        grid-column: 1 / -1;
+        padding: 0;
+    }
+
+    &-refresh-indicator {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        background-color: var(--border-color-default, #ced0d3);
+        border: none;
+        border-radius: 2px;
+        color: var(--brand-primary, $dg-brand-primary);
+        height: 4px;
+        width: 100%;
+
+        &::-webkit-progress-bar {
+            background-color: transparent;
+        }
+
+        &::-webkit-progress-value {
+            background-color: currentColor;
+            transition: all 0.2s;
+        }
+
+        &::-moz-progress-bar {
+            background-color: currentColor;
+            transition: all 0.2s;
+        }
+
+        &::-ms-fill {
+            border: none;
+            background-color: currentColor;
+            transition: all 0.2s;
+        }
+
+        &:indeterminate {
+            background-size: 200% 100%;
+            background-image: linear-gradient(
+                to right,
+                transparent 50%,
+                currentColor 50%,
+                currentColor 60%,
+                transparent 60%,
+                transparent 71.5%,
+                currentColor 71.5%,
+                currentColor 84%,
+                transparent 84%
+            );
+            animation: progress-linear 2s infinite linear;
+        }
+
+        &:indeterminate::-moz-progress-bar {
+            background-color: transparent;
+        }
+
+        &:indeterminate::-ms-fill {
+            animation-name: none;
+        }
+
+        @keyframes progress-linear {
+            0% {
+                background-size: 200% 100%;
+                background-position: left -31.25% top 0%;
+            }
+            50% {
+                background-size: 800% 100%;
+                background-position: left -49% top 0%;
+            }
+            100% {
+                background-size: 400% 100%;
+                background-position: left -102% top 0%;
+            }
+        }
+    }
+
     &.widget-datagrid-selection-method-click {
         .tr.tr-selected .td {
             background-color: $dg-grid-selected-row-background;

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -432,10 +432,7 @@ $root: ".widget-datagrid";
     &-refresh-container {
         grid-column: 1 / -1;
         padding: 0;
-
-        &--hidden {
-            display: none;
-        }
+        position: relative;
     }
 
     &-refresh-indicator {

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -432,6 +432,10 @@ $root: ".widget-datagrid";
     &-refresh-container {
         grid-column: 1 / -1;
         padding: 0;
+
+        &--hidden {
+            display: none;
+        }
     }
 
     &-refresh-indicator {
@@ -444,6 +448,9 @@ $root: ".widget-datagrid";
         color: var(--brand-primary, $dg-brand-primary);
         height: 4px;
         width: 100%;
+        position: absolute;
+        left: 0;
+        right: 0;
 
         &::-webkit-progress-bar {
             background-color: transparent;

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -482,7 +482,7 @@ $root: ".widget-datagrid";
                 currentColor 84%,
                 transparent 84%
             );
-            animation: progress-linear 2s infinite linear;
+            animation: progress-linear 3s infinite linear;
         }
 
         &:indeterminate::-moz-progress-bar {

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- We added a new refresh indicator to be showed when datagrid refreshes.
+- We implemented a new property to show a refresh indicator. With the refresh indicator, any datasource change shows a progress bar on top of Datagrid 2.
 
 ## [3.2.0] - 2025-08-18
 

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- We added a new refresh indicator to be showed when datagrid refreshes.
+
 ## [3.2.0] - 2025-08-18
 
 ### Changed

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -145,6 +145,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             isFetchingNextBatch={false}
             loadingType="spinner"
             columnsLoading={false}
+            refreshIndicator={props.refreshIndicator}
         />
     );
 }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -146,8 +146,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             isFetchingNextBatch={false}
             loadingType="spinner"
             columnsLoading={false}
-            refreshIndicator={props.refreshIndicator}
-            refreshInterval={props.refreshInterval ?? 0}
+            showRefreshIndicator={false}
         />
     );
 }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -147,6 +147,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             loadingType="spinner"
             columnsLoading={false}
             refreshIndicator={props.refreshIndicator}
+            refreshInterval={props.refreshInterval ?? 0}
         />
     );
 }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -141,6 +141,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             cellEventsController={eventsController}
             checkboxEventsController={eventsController}
             focusController={focusController}
+            isFirstLoad={false}
             isLoading={false}
             isFetchingNextBatch={false}
             loadingType="spinner"

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -123,8 +123,7 @@ const Container = observer((props: Props): ReactElement => {
             isLoading={props.datasource.status === "loading"}
             loadingType={props.loadingType}
             columnsLoading={!columnsStore.loaded}
-            refreshIndicator={props.refreshIndicator}
-            refreshInterval={props.refreshInterval}
+            showRefreshIndicator={rootStore.loaderCtrl.showRefreshIndicator}
         />
     );
 });

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -122,6 +122,7 @@ const Container = observer((props: Props): ReactElement => {
             isFetchingNextBatch={rootStore.loaderCtrl.isFetchingNextBatch}
             loadingType={props.loadingType}
             columnsLoading={!columnsStore.loaded}
+            refreshIndicator={props.refreshIndicator}
         />
     );
 });

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -124,6 +124,7 @@ const Container = observer((props: Props): ReactElement => {
             loadingType={props.loadingType}
             columnsLoading={!columnsStore.loaded}
             refreshIndicator={props.refreshIndicator}
+            refreshInterval={props.refreshInterval}
         />
     );
 });

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -1,22 +1,22 @@
+import { useOnResetFiltersEvent } from "@mendix/widget-plugin-external-events/hooks";
+import { useClickActionHelper } from "@mendix/widget-plugin-grid/helpers/ClickActionHelper";
+import { useFocusTargetController } from "@mendix/widget-plugin-grid/keyboard-navigation/useFocusTargetController";
 import { useSelectionHelper } from "@mendix/widget-plugin-grid/selection";
 import { generateUUID } from "@mendix/widget-plugin-platform/framework/generate-uuid";
+import { observer } from "mobx-react-lite";
 import { ReactElement, ReactNode, createElement, useCallback, useMemo } from "react";
 import { DatagridContainerProps } from "../typings/DatagridProps";
 import { Cell } from "./components/Cell";
 import { Widget } from "./components/Widget";
 import { WidgetHeaderContext } from "./components/WidgetHeaderContext";
-import { useSelectActionHelper } from "./helpers/SelectActionHelper";
-import { useClickActionHelper } from "@mendix/widget-plugin-grid/helpers/ClickActionHelper";
+import { ProgressStore } from "./features/data-export/ProgressStore";
+import { useDataExport } from "./features/data-export/useDataExport";
 import { useCellEventsController } from "./features/row-interaction/CellEventsController";
 import { useCheckboxEventsController } from "./features/row-interaction/CheckboxEventsController";
-import { useFocusTargetController } from "@mendix/widget-plugin-grid/keyboard-navigation/useFocusTargetController";
-import { useOnResetFiltersEvent } from "@mendix/widget-plugin-external-events/hooks";
+import { useSelectActionHelper } from "./helpers/SelectActionHelper";
 import { IColumnGroupStore } from "./helpers/state/ColumnGroupStore";
-import { observer } from "mobx-react-lite";
 import { RootGridStore } from "./helpers/state/RootGridStore";
 import { useRootStore } from "./helpers/state/useRootStore";
-import { useDataExport } from "./features/data-export/useDataExport";
-import { ProgressStore } from "./features/data-export/ProgressStore";
 
 interface Props extends DatagridContainerProps {
     columnsStore: IColumnGroupStore;

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -118,8 +118,9 @@ const Container = observer((props: Props): ReactElement => {
             cellEventsController={cellEventsController}
             checkboxEventsController={checkboxEventsController}
             focusController={focusController}
-            isLoading={rootStore.loaderCtrl.isLoading}
+            isFirstLoad={rootStore.loaderCtrl.isFirstLoad}
             isFetchingNextBatch={rootStore.loaderCtrl.isFetchingNextBatch}
+            isLoading={props.datasource.status === "loading"}
             loadingType={props.loadingType}
             columnsLoading={!columnsStore.loaded}
             refreshIndicator={props.refreshIndicator}

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -57,6 +57,10 @@
                         <enumerationValue key="skeleton">Skeleton</enumerationValue>
                     </enumerationValues>
                 </property>
+                <property key="refreshIndicator" type="boolean" defaultValue="false">
+                    <caption>Show refresh indicator</caption>
+                    <description>Show a refresh indicator when the data is being loaded.</description>
+                </property>
             </propertyGroup>
             <propertyGroup caption="Columns">
                 <property key="columns" type="object" isList="true">

--- a/packages/pluggableWidgets/datagrid-web/src/components/GridBody.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/GridBody.tsx
@@ -8,7 +8,7 @@ interface Props {
     className?: string;
     children?: React.ReactNode;
     loadingType: LoadingTypeEnum;
-    isLoading: boolean;
+    // isLoading: boolean;
     isFetchingNextBatch?: boolean;
     columnsHidable: boolean;
     columnsSize: number;
@@ -20,9 +20,9 @@ export function GridBody(props: Props): ReactElement {
     const { children } = props;
 
     const content = (): React.ReactElement => {
-        if (props.isLoading) {
-            return <Loader {...props} rowsSize={props.rowsSize > 0 ? props.rowsSize : props.pageSize} />;
-        }
+        // if (props.isLoading) {
+        //     return <Loader {...props} rowsSize={props.rowsSize > 0 ? props.rowsSize : props.pageSize} />;
+        // }
         return (
             <Fragment>
                 {children}

--- a/packages/pluggableWidgets/datagrid-web/src/components/GridBody.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/GridBody.tsx
@@ -8,6 +8,7 @@ interface Props {
     className?: string;
     children?: React.ReactNode;
     loadingType: LoadingTypeEnum;
+    isFirstLoad: boolean;
     isFetchingNextBatch?: boolean;
     columnsHidable: boolean;
     columnsSize: number;
@@ -19,6 +20,9 @@ export function GridBody(props: Props): ReactElement {
     const { children } = props;
 
     const content = (): React.ReactElement => {
+        if (props.isFirstLoad) {
+            return <Loader {...props} rowsSize={props.rowsSize > 0 ? props.rowsSize : props.pageSize} />;
+        }
         return (
             <Fragment>
                 {children}

--- a/packages/pluggableWidgets/datagrid-web/src/components/GridBody.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/GridBody.tsx
@@ -8,7 +8,6 @@ interface Props {
     className?: string;
     children?: React.ReactNode;
     loadingType: LoadingTypeEnum;
-    // isLoading: boolean;
     isFetchingNextBatch?: boolean;
     columnsHidable: boolean;
     columnsSize: number;
@@ -20,9 +19,6 @@ export function GridBody(props: Props): ReactElement {
     const { children } = props;
 
     const content = (): React.ReactElement => {
-        // if (props.isLoading) {
-        //     return <Loader {...props} rowsSize={props.rowsSize > 0 ? props.rowsSize : props.pageSize} />;
-        // }
         return (
             <Fragment>
                 {children}

--- a/packages/pluggableWidgets/datagrid-web/src/components/RefreshIndicator.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/RefreshIndicator.tsx
@@ -1,14 +1,9 @@
-import classNames from "classnames";
 import { createElement, ReactElement } from "react";
 
-export function RefreshIndicator({ show }: { show: boolean }): ReactElement {
+export function RefreshIndicator(): ReactElement {
     return (
         <div className="tr" role="row">
-            <div
-                className={classNames("th widget-datagrid-refresh-container", {
-                    "widget-datagrid-refresh-container--hidden": !show
-                })}
-            >
+            <div className="th widget-datagrid-refresh-container">
                 <progress className="widget-datagrid-refresh-indicator" />
             </div>
         </div>

--- a/packages/pluggableWidgets/datagrid-web/src/components/RefreshIndicator.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/RefreshIndicator.tsx
@@ -1,9 +1,14 @@
+import classNames from "classnames";
 import { createElement, ReactElement } from "react";
 
-export function RefreshIndicator(): ReactElement {
+export function RefreshIndicator({ show }: { show: boolean }): ReactElement {
     return (
         <div className="tr" role="row">
-            <div className="th widget-datagrid-refresh-container">
+            <div
+                className={classNames("th widget-datagrid-refresh-container", {
+                    "widget-datagrid-refresh-container--hidden": !show
+                })}
+            >
                 <progress className="widget-datagrid-refresh-indicator" />
             </div>
         </div>

--- a/packages/pluggableWidgets/datagrid-web/src/components/RefreshIndicator.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/RefreshIndicator.tsx
@@ -1,0 +1,11 @@
+import { createElement, ReactElement } from "react";
+
+export function RefreshIndicator(): ReactElement {
+    return (
+        <div className="tr" role="row">
+            <div className="th widget-datagrid-refresh-container">
+                <progress className="widget-datagrid-refresh-indicator" />
+            </div>
+        </div>
+    );
+}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -195,7 +195,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
                         isLoading={props.columnsLoading}
                         preview={props.preview}
                     />
-                    {showRefreshIndicator ? <RefreshIndicator /> : null}
+                    <RefreshIndicator show={showRefreshIndicator} />
                     <GridBody
                         isFirstLoad={props.isFirstLoad}
                         isFetchingNextBatch={props.isFetchingNextBatch}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -71,8 +71,7 @@ export interface WidgetProps<C extends GridColumn, T extends ObjectItem = Object
     isFetchingNextBatch: boolean;
     loadingType: LoadingTypeEnum;
     columnsLoading: boolean;
-    refreshIndicator: boolean;
-    refreshInterval: number;
+    showRefreshIndicator: boolean;
 
     // Helpers
     cellEventsController: EventsController;
@@ -135,8 +134,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
         paging,
         pagingPosition,
         preview,
-        refreshIndicator,
-        refreshInterval,
+        showRefreshIndicator,
         selectActionHelper,
         setPage,
         visibleColumns
@@ -166,8 +164,6 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
     });
 
     const selectionEnabled = selectActionHelper.selectionType !== "None";
-
-    const showRefreshIndicator = refreshIndicator && refreshInterval > 1 && props.isLoading && !props.isFirstLoad;
 
     return (
         <Fragment>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -66,6 +66,7 @@ export interface WidgetProps<C extends GridColumn, T extends ObjectItem = Object
     cancelExportLabel?: string;
     selectRowLabel?: string;
     selectAllRowsLabel?: string;
+    isFirstLoad: boolean;
     isLoading: boolean;
     isFetchingNextBatch: boolean;
     loadingType: LoadingTypeEnum;
@@ -164,6 +165,8 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
 
     const selectionEnabled = selectActionHelper.selectionType !== "None";
 
+    const showRefreshIndicator = refreshIndicator && props.isLoading && !props.isFirstLoad;
+
     return (
         <Fragment>
             {showTopBar && <WidgetTopBar>{pagination}</WidgetTopBar>}
@@ -192,9 +195,9 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
                         isLoading={props.columnsLoading}
                         preview={props.preview}
                     />
-                    {refreshIndicator && props.isLoading ? <RefreshIndicator /> : null}
+                    {showRefreshIndicator ? <RefreshIndicator /> : null}
                     <GridBody
-                        // isLoading={props.isLoading}
+                        isFirstLoad={props.isFirstLoad}
                         isFetchingNextBatch={props.isFetchingNextBatch}
                         loadingType={props.loadingType}
                         columnsHidable={columnsHidable}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -195,7 +195,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
                         isLoading={props.columnsLoading}
                         preview={props.preview}
                     />
-                    <RefreshIndicator show={showRefreshIndicator} />
+                    {showRefreshIndicator ? <RefreshIndicator /> : null}
                     <GridBody
                         isFirstLoad={props.isFirstLoad}
                         isFetchingNextBatch={props.isFetchingNextBatch}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -72,6 +72,7 @@ export interface WidgetProps<C extends GridColumn, T extends ObjectItem = Object
     loadingType: LoadingTypeEnum;
     columnsLoading: boolean;
     refreshIndicator: boolean;
+    refreshInterval: number;
 
     // Helpers
     cellEventsController: EventsController;
@@ -135,6 +136,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
         pagingPosition,
         preview,
         refreshIndicator,
+        refreshInterval,
         selectActionHelper,
         setPage,
         visibleColumns
@@ -165,7 +167,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
 
     const selectionEnabled = selectActionHelper.selectionType !== "None";
 
-    const showRefreshIndicator = refreshIndicator && props.isLoading && !props.isFirstLoad;
+    const showRefreshIndicator = refreshIndicator && refreshInterval > 1 && props.isLoading && !props.isFirstLoad;
 
     return (
         <Fragment>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -70,6 +70,7 @@ export interface WidgetProps<C extends GridColumn, T extends ObjectItem = Object
     isFetchingNextBatch: boolean;
     loadingType: LoadingTypeEnum;
     columnsLoading: boolean;
+    refreshIndicator: boolean;
 
     // Helpers
     cellEventsController: EventsController;
@@ -132,6 +133,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
         paging,
         pagingPosition,
         preview,
+        refreshIndicator,
         selectActionHelper,
         setPage,
         visibleColumns
@@ -190,9 +192,9 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
                         isLoading={props.columnsLoading}
                         preview={props.preview}
                     />
-                    <RefreshIndicator />
+                    {refreshIndicator && props.isLoading ? <RefreshIndicator /> : null}
                     <GridBody
-                        isLoading={props.isLoading}
+                        // isLoading={props.isLoading}
                         isFetchingNextBatch={props.isFetchingNextBatch}
                         loadingType={props.loadingType}
                         columnsHidable={columnsHidable}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -25,6 +25,7 @@ import { FocusTargetController } from "@mendix/widget-plugin-grid/keyboard-navig
 import { observer } from "mobx-react-lite";
 import { RowsRenderer } from "./RowsRenderer";
 import { GridHeader } from "./GridHeader";
+import { RefreshIndicator } from "./RefreshIndicator";
 
 export interface WidgetProps<C extends GridColumn, T extends ObjectItem = ObjectItem> {
     CellComponent: CellComponent<C>;
@@ -189,6 +190,7 @@ const Main = observer(<C extends GridColumn>(props: WidgetProps<C>): ReactElemen
                         isLoading={props.columnsLoading}
                         preview={props.preview}
                     />
+                    <RefreshIndicator />
                     <GridBody
                         isLoading={props.isLoading}
                         isFetchingNextBatch={props.isFetchingNextBatch}

--- a/packages/pluggableWidgets/datagrid-web/src/controllers/DerivedLoaderController.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/controllers/DerivedLoaderController.ts
@@ -1,9 +1,16 @@
 import { computed, makeObservable } from "mobx";
 
 type DerivedLoaderControllerSpec = {
+    showSilentRefresh: boolean;
+    refreshIndicator: boolean;
     exp: { exporting: boolean };
     cols: { loaded: boolean };
-    query: { isFetchingNextBatch: boolean; isFirstLoad: boolean; isRefreshing: boolean; showRefreshIndicator: boolean };
+    query: {
+        isFetchingNextBatch: boolean;
+        isFirstLoad: boolean;
+        isRefreshing: boolean;
+        isSilentRefresh: boolean;
+    };
 };
 
 export class DerivedLoaderController {
@@ -33,10 +40,20 @@ export class DerivedLoaderController {
     }
 
     get isRefreshing(): boolean {
-        return this.spec.query.isRefreshing;
+        const { isSilentRefresh, isRefreshing } = this.spec.query;
+
+        if (this.spec.showSilentRefresh) {
+            return isSilentRefresh || isRefreshing;
+        }
+
+        return !isSilentRefresh && isRefreshing;
     }
 
     get showRefreshIndicator(): boolean {
-        return this.spec.query.showRefreshIndicator;
+        if (!this.spec.refreshIndicator) {
+            return false;
+        }
+
+        return this.isRefreshing;
     }
 }

--- a/packages/pluggableWidgets/datagrid-web/src/controllers/DerivedLoaderController.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/controllers/DerivedLoaderController.ts
@@ -3,19 +3,19 @@ import { computed, makeObservable } from "mobx";
 type DerivedLoaderControllerSpec = {
     exp: { exporting: boolean };
     cols: { loaded: boolean };
-    query: { isFetchingNextBatch: boolean; isLoading: boolean; isRefreshing: boolean };
+    query: { isFetchingNextBatch: boolean; isFirstLoad: boolean; isRefreshing: boolean };
 };
 
 export class DerivedLoaderController {
     constructor(private spec: DerivedLoaderControllerSpec) {
         makeObservable(this, {
-            isLoading: computed,
+            isFirstLoad: computed,
             isFetchingNextBatch: computed,
             isRefreshing: computed
         });
     }
 
-    get isLoading(): boolean {
+    get isFirstLoad(): boolean {
         const { cols, exp, query } = this.spec;
         if (!cols.loaded) {
             return true;
@@ -25,7 +25,7 @@ export class DerivedLoaderController {
             return false;
         }
 
-        return query.isLoading;
+        return query.isFirstLoad;
     }
 
     get isFetchingNextBatch(): boolean {

--- a/packages/pluggableWidgets/datagrid-web/src/controllers/DerivedLoaderController.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/controllers/DerivedLoaderController.ts
@@ -3,7 +3,7 @@ import { computed, makeObservable } from "mobx";
 type DerivedLoaderControllerSpec = {
     exp: { exporting: boolean };
     cols: { loaded: boolean };
-    query: { isFetchingNextBatch: boolean; isFirstLoad: boolean; isRefreshing: boolean };
+    query: { isFetchingNextBatch: boolean; isFirstLoad: boolean; isRefreshing: boolean; showRefreshIndicator: boolean };
 };
 
 export class DerivedLoaderController {
@@ -34,5 +34,9 @@ export class DerivedLoaderController {
 
     get isRefreshing(): boolean {
         return this.spec.query.isRefreshing;
+    }
+
+    get showRefreshIndicator(): boolean {
+        return this.spec.query.showRefreshIndicator;
     }
 }

--- a/packages/pluggableWidgets/datagrid-web/src/helpers/state/RootGridStore.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/helpers/state/RootGridStore.ts
@@ -82,6 +82,8 @@ export class RootGridStore extends BaseControllerHost {
         this.loaderCtrl = new DerivedLoaderController({
             exp: exportCtrl,
             cols: this.columnsStore,
+            showSilentRefresh: props.refreshInterval > 1,
+            refreshIndicator: props.refreshIndicator,
             query
         });
 

--- a/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
@@ -111,6 +111,7 @@ export function mockWidgetProps(): WidgetProps<GridColumn, ObjectItem> {
         loadingType: "spinner",
         columnsLoading: false,
         refreshIndicator: false,
+        refreshInterval: 0,
         focusController: new FocusTargetController(
             new PositionController(),
             new VirtualGridLayout(1, columns.length, 10)

--- a/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
@@ -109,6 +109,7 @@ export function mockWidgetProps(): WidgetProps<GridColumn, ObjectItem> {
         isFetchingNextBatch: false,
         loadingType: "spinner",
         columnsLoading: false,
+        refreshIndicator: false,
         focusController: new FocusTargetController(
             new PositionController(),
             new VirtualGridLayout(1, columns.length, 10)

--- a/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
@@ -110,8 +110,7 @@ export function mockWidgetProps(): WidgetProps<GridColumn, ObjectItem> {
         isFetchingNextBatch: false,
         loadingType: "spinner",
         columnsLoading: false,
-        refreshIndicator: false,
-        refreshInterval: 0,
+        showRefreshIndicator: false,
         focusController: new FocusTargetController(
             new PositionController(),
             new VirtualGridLayout(1, columns.length, 10)

--- a/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/test-utils.tsx
@@ -105,6 +105,7 @@ export function mockWidgetProps(): WidgetProps<GridColumn, ObjectItem> {
         selectActionHelper: mockSelectionProps(),
         cellEventsController: { getProps: () => Object.create({}) },
         checkboxEventsController: { getProps: () => Object.create({}) },
+        isFirstLoad: false,
         isLoading: false,
         isFetchingNextBatch: false,
         loadingType: "spinner",

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -96,6 +96,7 @@ export interface DatagridContainerProps {
     itemSelectionMode: ItemSelectionModeEnum;
     showSelectAllToggle: boolean;
     loadingType: LoadingTypeEnum;
+    refreshIndicator: boolean;
     columns: ColumnsType[];
     columnsFilterable: boolean;
     pageSize: number;
@@ -144,6 +145,7 @@ export interface DatagridPreviewProps {
     itemSelectionMode: ItemSelectionModeEnum;
     showSelectAllToggle: boolean;
     loadingType: LoadingTypeEnum;
+    refreshIndicator: boolean;
     columns: ColumnsPreviewType[];
     columnsFilterable: boolean;
     pageSize: number | null;

--- a/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
+++ b/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
@@ -17,6 +17,7 @@ describe("DatasourceController loading states", () => {
         provider = new GateProvider({ datasource: list.loading() });
         host.setup();
         controller = new DatasourceController(host, { gate: provider.gate });
+        controller.setup();
     });
 
     describe("when datasource is loading", () => {
@@ -38,7 +39,6 @@ describe("DatasourceController loading states", () => {
         it("isRefreshing is true after refresh call", () => {
             provider.setProps({ datasource: list(0) });
             expect(provider.gate.props.datasource.status).toBe("available");
-            controller.setup();
             controller.refresh();
             expect(controller.isRefreshing).toBe(true);
             provider.setProps({ datasource: list.loading() });
@@ -60,8 +60,8 @@ describe("DatasourceController loading states", () => {
             provider.setProps({ datasource });
         });
 
-        it("isFirstLoad returns true and loading states return false", () => {
-            expect(controller.isFirstLoad).toBe(true);
+        it("All loading states return false", () => {
+            expect(controller.isFirstLoad).toBe(false);
             expect(controller.isRefreshing).toBe(false);
             expect(controller.isFetchingNextBatch).toBe(false);
         });

--- a/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
+++ b/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
@@ -1,8 +1,11 @@
+import { BaseControllerHost } from "@mendix/widget-plugin-mobx-kit/BaseControllerHost";
 import { GateProvider } from "@mendix/widget-plugin-mobx-kit/GateProvider";
-import { ReactiveControllerHost } from "@mendix/widget-plugin-mobx-kit/main";
+// import { ReactiveControllerHost } from "@mendix/widget-plugin-mobx-kit/main";
 import { list } from "@mendix/widget-plugin-test-utils";
 import { ListValue } from "mendix";
 import { DatasourceController } from "../query/DatasourceController";
+
+class TestControllerHost extends BaseControllerHost {}
 
 describe("DatasourceController loading states", () => {
     let controller: DatasourceController;
@@ -10,8 +13,9 @@ describe("DatasourceController loading states", () => {
     let provider: GateProvider<{ datasource: ListValue }>;
 
     beforeEach(() => {
-        const host = { addController: jest.fn() } as unknown as ReactiveControllerHost;
+        const host = new TestControllerHost();
         provider = new GateProvider({ datasource: list.loading() });
+        host.setup();
         controller = new DatasourceController(host, { gate: provider.gate });
     });
 
@@ -34,12 +38,13 @@ describe("DatasourceController loading states", () => {
         it("isRefreshing is true after refresh call", () => {
             provider.setProps({ datasource: list(0) });
             expect(provider.gate.props.datasource.status).toBe("available");
+            controller.setup();
             controller.refresh();
             expect(controller.isRefreshing).toBe(true);
             provider.setProps({ datasource: list.loading() });
             expect(provider.gate.props.datasource.status).toBe("loading");
             expect(controller.isRefreshing).toBe(true);
-            expect(controller.isFirstLoad).toBe(true);
+            expect(controller.isFirstLoad).toBe(false);
         });
 
         it("isFetchingNextBatch returns true after setLimit call", () => {
@@ -55,7 +60,7 @@ describe("DatasourceController loading states", () => {
             provider.setProps({ datasource });
         });
 
-        it("all loading states return false", () => {
+        it("isFirstLoad returns true and loading states return false", () => {
             expect(controller.isFirstLoad).toBe(true);
             expect(controller.isRefreshing).toBe(false);
             expect(controller.isFetchingNextBatch).toBe(false);

--- a/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
+++ b/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
@@ -32,14 +32,14 @@ describe("DatasourceController loading states", () => {
 
         it("refresh has no effect if ds is loading", () => {
             expect(provider.gate.props.datasource.status).toBe("loading");
-            controller.refresh();
+            controller.backgroundRefresh();
             expect(controller.isRefreshing).toBe(false);
         });
 
         it("isRefreshing is true after refresh call", () => {
             provider.setProps({ datasource: list(0), refreshIndicator: false, refreshInterval: 0 });
             expect(provider.gate.props.datasource.status).toBe("available");
-            controller.refresh();
+            controller.backgroundRefresh();
             expect(controller.isRefreshing).toBe(true);
             provider.setProps({ datasource: list.loading(), refreshIndicator: false, refreshInterval: 0 });
             expect(provider.gate.props.datasource.status).toBe("loading");
@@ -67,7 +67,7 @@ describe("DatasourceController loading states", () => {
         });
 
         it("triggers refresh when called", () => {
-            controller.refresh();
+            controller.backgroundRefresh();
             expect(datasource.reload).toHaveBeenCalled();
         });
 

--- a/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
+++ b/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
@@ -10,11 +10,11 @@ class TestControllerHost extends BaseControllerHost {}
 describe("DatasourceController loading states", () => {
     let controller: DatasourceController;
     let datasource: ListValue;
-    let provider: GateProvider<{ datasource: ListValue }>;
+    let provider: GateProvider<{ datasource: ListValue; refreshIndicator: boolean; refreshInterval: number }>;
 
     beforeEach(() => {
         const host = new TestControllerHost();
-        provider = new GateProvider({ datasource: list.loading() });
+        provider = new GateProvider({ datasource: list.loading(), refreshIndicator: false, refreshInterval: 0 });
         host.setup();
         controller = new DatasourceController(host, { gate: provider.gate });
         controller.setup();
@@ -23,7 +23,7 @@ describe("DatasourceController loading states", () => {
     describe("when datasource is loading", () => {
         beforeEach(() => {
             datasource = list.loading();
-            provider.setProps({ datasource });
+            provider.setProps({ datasource, refreshIndicator: false, refreshInterval: 0 });
         });
 
         it("isFirstLoad returns true by default", () => {
@@ -37,11 +37,11 @@ describe("DatasourceController loading states", () => {
         });
 
         it("isRefreshing is true after refresh call", () => {
-            provider.setProps({ datasource: list(0) });
+            provider.setProps({ datasource: list(0), refreshIndicator: false, refreshInterval: 0 });
             expect(provider.gate.props.datasource.status).toBe("available");
             controller.refresh();
             expect(controller.isRefreshing).toBe(true);
-            provider.setProps({ datasource: list.loading() });
+            provider.setProps({ datasource: list.loading(), refreshIndicator: false, refreshInterval: 0 });
             expect(provider.gate.props.datasource.status).toBe("loading");
             expect(controller.isRefreshing).toBe(true);
             expect(controller.isFirstLoad).toBe(false);
@@ -57,7 +57,7 @@ describe("DatasourceController loading states", () => {
     describe("when datasource is not loading", () => {
         beforeEach(() => {
             datasource = list(0);
-            provider.setProps({ datasource });
+            provider.setProps({ datasource, refreshIndicator: false, refreshInterval: 0 });
         });
 
         it("All loading states return false", () => {

--- a/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
+++ b/packages/shared/widget-plugin-grid/src/__tests__/DatasourceController.spec.ts
@@ -21,8 +21,8 @@ describe("DatasourceController loading states", () => {
             provider.setProps({ datasource });
         });
 
-        it("isLoading returns true by default", () => {
-            expect(controller.isLoading).toBe(true);
+        it("isFirstLoad returns true by default", () => {
+            expect(controller.isFirstLoad).toBe(true);
         });
 
         it("refresh has no effect if ds is loading", () => {
@@ -39,13 +39,13 @@ describe("DatasourceController loading states", () => {
             provider.setProps({ datasource: list.loading() });
             expect(provider.gate.props.datasource.status).toBe("loading");
             expect(controller.isRefreshing).toBe(true);
-            expect(controller.isLoading).toBe(false);
+            expect(controller.isFirstLoad).toBe(true);
         });
 
         it("isFetchingNextBatch returns true after setLimit call", () => {
             controller.setLimit(20);
             expect(controller.isFetchingNextBatch).toBe(true);
-            expect(controller.isLoading).toBe(false);
+            expect(controller.isFirstLoad).toBe(true);
         });
     });
 
@@ -56,7 +56,7 @@ describe("DatasourceController loading states", () => {
         });
 
         it("all loading states return false", () => {
-            expect(controller.isLoading).toBe(false);
+            expect(controller.isFirstLoad).toBe(true);
             expect(controller.isRefreshing).toBe(false);
             expect(controller.isFetchingNextBatch).toBe(false);
         });

--- a/packages/shared/widget-plugin-grid/src/__tests__/RefreshController.spec.ts
+++ b/packages/shared/widget-plugin-grid/src/__tests__/RefreshController.spec.ts
@@ -3,8 +3,8 @@ import { RefreshController } from "../query/RefreshController";
 
 describe("RefreshController", () => {
     let host: ReactiveControllerHost;
-    let queryHelper: { refresh: jest.Mock };
-    let atom: { get: () => { refresh: jest.Mock } };
+    let queryHelper: { backgroundRefresh: jest.Mock };
+    let atom: { get: () => { backgroundRefresh: jest.Mock } };
     let addControllerMock: jest.Mock;
 
     beforeEach(() => {
@@ -13,7 +13,7 @@ describe("RefreshController", () => {
             addController: addControllerMock
         } as unknown as ReactiveControllerHost;
         queryHelper = {
-            refresh: jest.fn()
+            backgroundRefresh: jest.fn()
         };
         atom = { get: () => queryHelper };
         jest.useFakeTimers();
@@ -40,7 +40,7 @@ describe("RefreshController", () => {
         expect(dispose).toBeInstanceOf(Function);
 
         jest.advanceTimersByTime(1000);
-        expect(queryHelper.refresh).toHaveBeenCalledTimes(1);
+        expect(queryHelper.backgroundRefresh).toHaveBeenCalledTimes(1);
     });
 
     it("should clear the timer when dispose is called", () => {
@@ -50,6 +50,6 @@ describe("RefreshController", () => {
 
         dispose!();
         jest.advanceTimersByTime(1000);
-        expect(queryHelper.refresh).not.toHaveBeenCalled();
+        expect(queryHelper.backgroundRefresh).not.toHaveBeenCalled();
     });
 });

--- a/packages/shared/widget-plugin-grid/src/query/DatasourceController.ts
+++ b/packages/shared/widget-plugin-grid/src/query/DatasourceController.ts
@@ -5,7 +5,7 @@ import { action, autorun, computed, IComputedValue, makeAutoObservable, when } f
 import { QueryController } from "./query-controller";
 import { disposeBatch } from "@mendix/widget-plugin-mobx-kit/disposeBatch";
 
-type Gate = DerivedPropsGate<{ datasource: ListValue }>;
+type Gate = DerivedPropsGate<{ datasource: ListValue; refreshIndicator: boolean; refreshInterval: number }>;
 
 type DatasourceControllerSpec = { gate: Gate };
 
@@ -112,6 +112,11 @@ export class DatasourceController implements ReactiveController, QueryController
         const data = (): DatasourceController => [this.datasource].map(() => Object.create(this))[0];
 
         return computed(data);
+    }
+
+    get showRefreshIndicator(): boolean {
+        const { refreshIndicator, refreshInterval } = this.gate.props;
+        return refreshIndicator && refreshInterval > 1 && this.isDSLoading && !this.isFirstLoad;
     }
 
     setup(): () => void {

--- a/packages/shared/widget-plugin-grid/src/query/RefreshController.ts
+++ b/packages/shared/widget-plugin-grid/src/query/RefreshController.ts
@@ -2,7 +2,7 @@ import { autoEffect } from "@mendix/widget-plugin-mobx-kit/autoEffect";
 import { ReactiveController, ReactiveControllerHost } from "@mendix/widget-plugin-mobx-kit/main";
 
 interface QueryHelper {
-    refresh(): void;
+    backgroundRefresh(): void;
 }
 
 interface ObservableAtom {
@@ -34,7 +34,7 @@ export class RefreshController implements ReactiveController {
 
     private scheduleRefresh(helper: QueryHelper, delay: number): () => void {
         const timerId = setTimeout(() => {
-            helper.refresh();
+            helper.backgroundRefresh();
         }, delay);
         return () => {
             clearTimeout(timerId);

--- a/packages/shared/widget-plugin-grid/src/query/query-controller.ts
+++ b/packages/shared/widget-plugin-grid/src/query/query-controller.ts
@@ -12,7 +12,7 @@ type Members =
     | "hasMoreItems";
 
 export interface QueryController extends Pick<ListValue, Members> {
-    refresh(): void;
+    backgroundRefresh(): void;
     setPageSize(size: number): void;
     hasMoreItems: boolean;
     isFirstLoad: boolean;

--- a/packages/shared/widget-plugin-grid/src/query/query-controller.ts
+++ b/packages/shared/widget-plugin-grid/src/query/query-controller.ts
@@ -15,7 +15,7 @@ export interface QueryController extends Pick<ListValue, Members> {
     refresh(): void;
     setPageSize(size: number): void;
     hasMoreItems: boolean;
-    isLoading: boolean;
+    isFirstLoad: boolean;
     isRefreshing: boolean;
     isFetchingNextBatch: boolean;
 }


### PR DESCRIPTION
### Pull request type

New feature (non-breaking change which adds functionality)

---

### Description

Implement a new property to show a refresh indicator. With the refresh indicator any datasource change triggers the progress bar on top of the Datagrid2.