### PR TITLE
fix: do not use array index as react list-key

### DIFF
--- a/packages/pluggableWidgets/maps-web/src/components/GoogleMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/GoogleMap.tsx
@@ -101,7 +101,7 @@ function GoogleMap(props: GoogleMapsProps): ReactElement {
                         {locations
                             .concat(currentLocation ? [currentLocation] : [])
                             .filter(m => !!m)
-                            .map((marker, index) => (
+                            .map(marker => (
                                 <GoogleMapsMarker
                                     key={`marker_${marker.id ?? marker.latitude + "_" + marker.longitude}`}
                                     {...marker}

--- a/packages/pluggableWidgets/maps-web/src/components/GoogleMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/GoogleMap.tsx
@@ -102,7 +102,10 @@ function GoogleMap(props: GoogleMapsProps): ReactElement {
                             .concat(currentLocation ? [currentLocation] : [])
                             .filter(m => !!m)
                             .map((marker, index) => (
-                                <GoogleMapsMarker key={`marker_${index}`} {...marker} />
+                                <GoogleMapsMarker
+                                    key={`marker_${marker.id ?? marker.latitude + "_" + marker.longitude}`}
+                                    {...marker}
+                                />
                             ))}
                     </GoogleMapComponent>
                 ) : (

--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -89,7 +89,7 @@ export function LeafletMap(props: LeafletProps): ReactElement {
                     {locations
                         .concat(currentLocation ? [currentLocation] : [])
                         .filter(m => !!m)
-                        .map((marker, index) => (
+                        .map(marker => (
                             <MarkerComponent
                                 icon={
                                     marker.url
@@ -100,7 +100,7 @@ export function LeafletMap(props: LeafletProps): ReactElement {
                                         : defaultMarkerIcon
                                 }
                                 interactive={!!marker.title || !!marker.onClick}
-                                key={`marker_${index}`}
+                                key={`marker_${marker.id ?? marker.latitude + "_" + marker.longitude}`}
                                 eventHandlers={{
                                     click: marker.title ? undefined : marker.onClick
                                 }}

--- a/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/LeafletMap.spec.ts.snap
+++ b/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/LeafletMap.spec.ts.snap
@@ -178,7 +178,7 @@ exports[`Leaflet maps renders a map with current location 1`] = `
           }
         }
         interactive={false}
-        key="marker_0"
+        key="marker_51.906688_4.48837"
         position={
           {
             "lat": 51.906688,
@@ -251,7 +251,7 @@ exports[`Leaflet maps renders a map with markers 1`] = `
           }
         }
         interactive={true}
-        key="marker_0"
+        key="marker_51.906688_4.48837"
         position={
           {
             "lat": 51.906688,
@@ -288,7 +288,7 @@ exports[`Leaflet maps renders a map with markers 1`] = `
           }
         }
         interactive={true}
-        key="marker_1"
+        key="marker_51.922823_4.479632"
         position={
           {
             "lat": 51.922823,

--- a/packages/pluggableWidgets/maps-web/src/utils/data.ts
+++ b/packages/pluggableWidgets/maps-web/src/utils/data.ts
@@ -39,7 +39,8 @@ function fromDatasource(marker: DynamicMarkersType, item: ObjectItem): ModeledMa
         longitude,
         title: title ? title.get(item).value : "",
         action: onClickAttribute ? onClickAttribute.get(item).execute : undefined,
-        customMarker: marker.customMarkerDynamic?.value?.uri
+        customMarker: marker.customMarkerDynamic?.value?.uri,
+        id: item.id
     };
 }
 

--- a/packages/pluggableWidgets/maps-web/typings/shared.d.ts
+++ b/packages/pluggableWidgets/maps-web/typings/shared.d.ts
@@ -7,6 +7,7 @@ export interface ModeledMarker {
     title?: string;
     customMarker?: string;
     action?: () => void;
+    id?: string;
 }
 
 export interface Marker {
@@ -15,6 +16,7 @@ export interface Marker {
     url: string;
     onClick?: () => void;
     title?: string;
+    id?: string;
 }
 
 export interface SharedProps extends Dimensions {


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description
Both `GoogleMap` and `LeafletMap` components use the array index as key for the list-items.
This is discouraged: https://react.dev/learn/rendering-lists#rules-of-keys

In fact, this caused issues for us when rendering large amounts of locations and when filtering them.
This would present in hover-texts showing a different title than the popup. In fact, when examining the html, it turned out that multiple locations would get the same title.

I resolved the issue by using the object guid as key for the list. If there is no key (e.g. for static markers) i use a combination of the lat and lng.

<!--
Please uncomment and fill in the following section
to describe which part of the package needs to be tested
and how it can be tested.
-->

### What should be covered while testing?
- Do locations render correctly, i.e. the mouse-over title corresponds with the text in the popup.
  - For large datasets
  - When filtering the locations that are rendered.

