### PR TITLE
fix: unknown listener type: undefined

### DIFF
--- a/packages/pluggableWidgets/maps-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-web/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - We fixed an issue where GoogleMap and LeafletMap uses array index for the list item which causes issues when filtering large amounts of locations. Thanks to @jeroen-huizer-conclusion for the contribution.
 
+- We fixed an issue where where browser console throw warning of unknown listener when the location has title in LeafletMap. Thanks to @jeroen-huizer-conclusion for the contribution.
+
 ## [4.0.0] - 2024-05-02
 
 ### Fixed

--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -101,9 +101,7 @@ export function LeafletMap(props: LeafletProps): ReactElement {
                                 }
                                 interactive={!!marker.title || !!marker.onClick}
                                 key={`marker_${marker.id ?? marker.latitude + "_" + marker.longitude}`}
-                                eventHandlers={{
-                                    click: marker.title ? undefined : marker.onClick
-                                }}
+                                eventHandlers={marker.title ? undefined : { click: marker.onClick }}
                                 position={{ lat: marker.latitude, lng: marker.longitude }}
                                 title={marker.title}
                             >


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description
Using `LeafletMap`, when locations are configured to have both a title and an onclick action, the browser console would log a warning: `unknown listener type: undefined`. For us this was quite annoying because we render 100's of locations.

I resolved this by not adding eventhandlers to the marker when the location has a title.
I'm not sure whether `GoogleMap` also has this issue.

### What should be covered while testing?
- When a location does not have a title and does not have an onclick action: clicking should do nothing
- When a location has a title, but not an onclick: clicking should open a popup
- When a location does not have a title, but does have an onclick: clicking the location should execute the onclick action
- When a location has a title and an onclick action: clicking should open a popup, clicking the popup should execute the action
