### PR TITLE
[WC-3047] Gallery: Improve preview with limited rows and fade out

### DIFF
--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- We fixed an issue where the configured column count wouldn't show up in the preview of the widget
+- We fixed an issue where the column count was not reflected properly in the preview mode.
 
 ### Added
 

--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the configured column count wouldn't show up in the preview of the widget
+
 ### Added
 
 - Added a 'horizontal divider' option to Borders design property for Gallery list items, allowing improved visual separation and customization.

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.editorPreview.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.editorPreview.tsx
@@ -11,17 +11,22 @@ import { createElement, ReactElement, ReactNode, useCallback, useMemo } from "re
 import { GalleryPreviewProps } from "../typings/GalleryProps";
 import { Gallery as GalleryComponent } from "./components/Gallery";
 import { useItemEventsController } from "./features/item-interaction/ItemEventsController";
-import { useGridPositions } from "./features/useGridPositions";
+import { useGridPositionsPreview } from "./features/useGridPositionsPreview";
 import { useItemPreviewHelper } from "./helpers/ItemPreviewHelper";
 import { useItemSelectHelper } from "./helpers/useItemSelectHelper";
 import "./ui/GalleryPreview.scss";
-
-const numberOfItems = 3;
 
 const SortAPI = getGlobalSortContext();
 
 function Preview(props: GalleryPreviewProps): ReactElement {
     const { emptyPlaceholder } = props;
+    const { numberOfColumns, numberOfRows, containerRef, numberOfItems } = useGridPositionsPreview({
+        phoneItems: props.phoneItems ?? 1,
+        tabletItems: props.tabletItems ?? 1,
+        desktopItems: props.desktopItems ?? 1,
+        totalItems: props.pageSize ?? 3
+    });
+
     const items: ObjectItem[] = Array.from({ length: numberOfItems }).map((_, index) => ({
         id: String(index) as GUID
     }));
@@ -66,48 +71,49 @@ function Preview(props: GalleryPreviewProps): ReactElement {
     );
 
     return (
-        <GalleryComponent
-            className={props.class}
-            desktopItems={props.content.widgetCount > 0 ? numberOfItems : props.desktopItems!}
-            emptyPlaceholderRenderer={useCallback(
-                (renderWrapper: (children: ReactNode) => ReactElement) => (
-                    <emptyPlaceholder.renderer caption="Empty list message: Place widgets here">
-                        {renderWrapper(null)}
-                    </emptyPlaceholder.renderer>
-                ),
-                [emptyPlaceholder]
-            )}
-            header={
-                <SortAPI.Provider value={sortAPI}>
-                    <props.filtersPlaceholder.renderer caption="Place widgets like filter widget(s) and action button(s) here">
-                        <div />
-                    </props.filtersPlaceholder.renderer>
-                </SortAPI.Provider>
-            }
-            showHeader
-            hasMoreItems={false}
-            items={items}
-            itemHelper={useItemPreviewHelper({
-                contentValue: props.content,
-                hasOnClick: props.onClick !== null
-            })}
-            numberOfItems={props.pageSize ?? numberOfItems}
-            page={0}
-            pageSize={props.pageSize ?? numberOfItems}
-            paging={props.pagination === "buttons"}
-            paginationPosition={props.pagingPosition}
-            paginationType={props.pagination}
-            showPagingButtons={props.showPagingButtons}
-            showEmptyStatePreview={props.showEmptyPlaceholder === "custom"}
-            phoneItems={props.phoneItems!}
-            tabletItems={props.tabletItems!}
-            selectHelper={selectHelper}
-            itemEventsController={itemEventsController}
-            focusController={focusController}
-            getPosition={getPositionCallback}
-            showRefreshIndicator={false}
-            preview
-        />
+        <div ref={containerRef}>
+            <GalleryComponent
+                className={props.class}
+                desktopItems={props.desktopItems!}
+                emptyPlaceholderRenderer={useCallback(
+                    (renderWrapper: (children: ReactNode) => ReactElement) => (
+                        <emptyPlaceholder.renderer caption="Empty list message: Place widgets here">
+                            {renderWrapper(null)}
+                        </emptyPlaceholder.renderer>
+                    ),
+                    [emptyPlaceholder]
+                )}
+                header={
+                    <SortAPI.Provider value={sortAPI}>
+                        <props.filtersPlaceholder.renderer caption="Place widgets like filter widget(s) and action button(s) here">
+                            <div />
+                        </props.filtersPlaceholder.renderer>
+                    </SortAPI.Provider>
+                }
+                showHeader
+                hasMoreItems={false}
+                items={items}
+                itemHelper={useItemPreviewHelper({
+                    contentValue: props.content,
+                    hasOnClick: props.onClick !== null
+                })}
+                numberOfItems={props.pageSize!}
+                page={0}
+                pageSize={props.pageSize!}
+                paging={props.pagination === "buttons"}
+                paginationPosition={props.pagingPosition}
+                paginationType={props.pagination}
+                showPagingButtons={props.showPagingButtons}
+                showEmptyStatePreview={props.showEmptyPlaceholder === "custom"}
+                phoneItems={props.phoneItems!}
+                tabletItems={props.tabletItems!}
+                selectHelper={selectHelper}
+                itemEventsController={itemEventsController}
+                focusController={focusController}
+                getPosition={getPositionCallback}
+                preview
+            />
+        </div>
     );
 }
 

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.editorPreview.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.editorPreview.tsx
@@ -33,13 +33,6 @@ function Preview(props: GalleryPreviewProps): ReactElement {
 
     const selectHelper = useItemSelectHelper(props.itemSelection, undefined);
 
-    const { numberOfColumns, numberOfRows } = useGridPositions({
-        phoneItems: props.phoneItems ?? 1,
-        tabletItems: props.tabletItems ?? 1,
-        desktopItems: props.desktopItems ?? 1,
-        totalItems: items.length
-    });
-
     const getPositionCallback = useCallback(
         (index: number) => getColumnAndRowBasedOnIndex(numberOfColumns, items.length, index),
         [numberOfColumns, items.length]
@@ -111,6 +104,7 @@ function Preview(props: GalleryPreviewProps): ReactElement {
                 itemEventsController={itemEventsController}
                 focusController={focusController}
                 getPosition={getPositionCallback}
+                showRefreshIndicator={false}
                 preview
             />
         </div>

--- a/packages/pluggableWidgets/gallery-web/src/features/useGridPositionsPreview.ts
+++ b/packages/pluggableWidgets/gallery-web/src/features/useGridPositionsPreview.ts
@@ -12,7 +12,7 @@ type GridPositionReturn = {
     numberOfItems: number;
 };
 
-function useNumberOfRows(): [React.RefObject<HTMLDivElement>, number] {
+function useObservedColumns(): [React.RefObject<HTMLDivElement>, number] {
     const containerRef = useRef<HTMLDivElement>(null);
     const [numberOfColumns, setNumberOfColumns] = useState(12);
 
@@ -31,8 +31,6 @@ function useNumberOfRows(): [React.RefObject<HTMLDivElement>, number] {
 
         resizeObserver.observe(containerRef.current);
 
-        setNumberOfColumns(containerRef.current.offsetWidth);
-
         return () => resizeObserver.disconnect();
     }, []);
 
@@ -42,7 +40,7 @@ function useNumberOfRows(): [React.RefObject<HTMLDivElement>, number] {
 export function useGridPositionsPreview(
     config: GridPositionsProps
 ): GridPositionReturn & { containerRef: React.RefObject<HTMLDivElement> } {
-    const [containerRef, numberOfColumns] = useNumberOfRows();
+    const [containerRef, numberOfColumns] = useObservedColumns();
     const maxItems = numberOfColumns * 3;
     const numberOfItems = Math.min(maxItems, config.totalItems);
     const numberOfRows = Math.ceil(numberOfItems / numberOfColumns);

--- a/packages/pluggableWidgets/gallery-web/src/features/useGridPositionsPreview.ts
+++ b/packages/pluggableWidgets/gallery-web/src/features/useGridPositionsPreview.ts
@@ -1,5 +1,5 @@
 import { ObjectItem } from "mendix";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { GalleryProps } from "../components/Gallery";
 
 export type GridPositionsProps = Pick<GalleryProps<ObjectItem>, "desktopItems" | "phoneItems" | "tabletItems"> & {

--- a/packages/pluggableWidgets/gallery-web/src/features/useGridPositionsPreview.ts
+++ b/packages/pluggableWidgets/gallery-web/src/features/useGridPositionsPreview.ts
@@ -1,0 +1,56 @@
+import { ObjectItem } from "mendix";
+import { useEffect, useState, useRef } from "react";
+import { GalleryProps } from "../components/Gallery";
+
+export type GridPositionsProps = Pick<GalleryProps<ObjectItem>, "desktopItems" | "phoneItems" | "tabletItems"> & {
+    totalItems: number;
+};
+
+type GridPositionReturn = {
+    numberOfColumns: number;
+    numberOfRows: number;
+    numberOfItems: number;
+};
+
+function useNumberOfRows(): [React.RefObject<HTMLDivElement>, number] {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [numberOfColumns, setNumberOfColumns] = useState(12);
+
+    useEffect(() => {
+        if (!containerRef.current) return;
+
+        const resizeObserver = new ResizeObserver(() => {
+            if (!containerRef.current) return;
+
+            setNumberOfColumns(
+                getComputedStyle(containerRef.current.querySelector(".widget-gallery-items")!)
+                    .getPropertyValue("grid-template-columns")
+                    .split(" ").length
+            );
+        });
+
+        resizeObserver.observe(containerRef.current);
+
+        setNumberOfColumns(containerRef.current.offsetWidth);
+
+        return () => resizeObserver.disconnect();
+    }, []);
+
+    return [containerRef, numberOfColumns];
+}
+
+export function useGridPositionsPreview(
+    config: GridPositionsProps
+): GridPositionReturn & { containerRef: React.RefObject<HTMLDivElement> } {
+    const [containerRef, numberOfColumns] = useNumberOfRows();
+    const maxItems = numberOfColumns * 3;
+    const numberOfItems = Math.min(maxItems, config.totalItems);
+    const numberOfRows = Math.ceil(numberOfItems / numberOfColumns);
+
+    return {
+        containerRef,
+        numberOfColumns,
+        numberOfRows,
+        numberOfItems
+    };
+}

--- a/packages/pluggableWidgets/gallery-web/src/ui/GalleryPreview.scss
+++ b/packages/pluggableWidgets/gallery-web/src/ui/GalleryPreview.scss
@@ -1,9 +1,19 @@
-.widget-gallery {
-    .widget-gallery-preview:nth-last-child(2) > div {
-        opacity: 0.5;
-    }
+.widget-gallery-content {
+    position: relative;
+}
 
-    .widget-gallery-preview:last-child > div {
-        opacity: 0.2;
-    }
+.widget-gallery-content::before {
+    content: "";
+    display: block;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 0) 33.33%,
+        rgba(255, 255, 255, 0.5) 66.66%,
+        rgba(255, 255, 255, 0.75) 100%
+    );
+    z-index: 1;
 }


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

Fixed an issue where the displayed number of columns in preview mode wouldn't match the configuration
Added functionality where the row count doesn't exceed 3 - in cases where it should because of the column count x page size
Added functionality where the rows of the widget slowly fade out in a vertical gradient

### What should be covered while testing?

If the rows in no circumstance exceed the count of 3.
Therefore configure a page size and column count which would normally cause the row count to exceed 3.
Test this on al viewports
Test if there is a fade-away gradient overlaying the grid items