### PR TITLE
[WC-2925] Gallery: Horizontal divider for list items

### DIFF
--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_gallery-design-properties.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_gallery-design-properties.scss
@@ -33,6 +33,21 @@
     }
 }
 
+.widget-gallery-divided-horizontal {
+    .widget-gallery-item {
+        position: relative;
+        &:not(:last-child)::after {
+            content: "";
+            display: block;
+            position: absolute;
+            left: 0;
+            right: 0;
+            border-bottom: 1px solid var(--grid-border-color, $dg-grid-border-color);
+            margin-top: calc(var(--spacing-small, $dg-spacing-small) / 2);
+        }
+    }
+}
+
 // Hover styles
 .widget-gallery-hover {
     .widget-gallery-items {

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/design-properties.json
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/design-properties.json
@@ -59,6 +59,10 @@
                 {
                     "name": "Horizontal",
                     "class": "widget-gallery-bordered-horizontal"
+                },
+                {
+                    "name": "Horizontal divider",
+                    "class": "widget-gallery-divided-horizontal"
                 }
             ]
         },

--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a 'horizontal divider' option to Borders design property for Gallery list items, allowing improved visual separation and customization.
+
 ## [3.3.0] - 2025-08-28
 
 ### Added


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

- Introduced a new horizontal divider option for Gallery list items.
- Updated design properties to support horizontal dividers, improving visual separation and customization.

This enhances the Gallery widget’s flexibility for list item styling.

### What should be covered while testing?

- Set 'horizontal borders' design property to list divider
- Check if this divider is properly displayed
