### PR TITLE
[WC-3079] Prevent Gallery from breaking in iframes

### DIFF
--- a/packages/pluggableWidgets/dropdown-sort-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/dropdown-sort-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue with Gallery widget causing errors when Mendix app is being used in an iframe.
+
 ## [1.2.2] - 2025-03-31
 
 ### Fixed

--- a/packages/pluggableWidgets/dropdown-sort-web/package.json
+++ b/packages/pluggableWidgets/dropdown-sort-web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mendix/dropdown-sort-web",
     "widgetName": "DropdownSort",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "Adds sorting functionality to Gallery widget.",
     "copyright": "© Mendix Technology BV 2025. All rights reserved.",
     "license": "Apache-2.0",

--- a/packages/pluggableWidgets/dropdown-sort-web/src/package.xml
+++ b/packages/pluggableWidgets/dropdown-sort-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="DropdownSort" version="3.3.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="DropdownSort" version="3.3.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="DropdownSort.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue with Gallery widget causing errors when Mendix app is being used in an iframe.
+
 ## [3.4.0] - 2025-09-12
 
 ### Fixed

--- a/packages/pluggableWidgets/gallery-web/package.json
+++ b/packages/pluggableWidgets/gallery-web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mendix/gallery-web",
     "widgetName": "Gallery",
-    "version": "3.4.0",
+    "version": "3.4.1",
     "description": "A flexible gallery widget that renders columns, rows and layouts.",
     "copyright": "© Mendix Technology BV 2025. All rights reserved.",
     "license": "Apache-2.0",

--- a/packages/pluggableWidgets/gallery-web/src/package.xml
+++ b/packages/pluggableWidgets/gallery-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Gallery" version="3.4.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Gallery" version="3.4.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Gallery.xml" />
         </widgetFiles>

--- a/packages/shared/widget-plugin-sorting/src/react/context.ts
+++ b/packages/shared/widget-plugin-sorting/src/react/context.ts
@@ -11,8 +11,11 @@ export interface SortAPI {
 
 const SORT_PATH = "com.mendix.widgets.web.sortable.sortContext";
 
+// this is a magical way to check if we are running in design preview
+const isDesignPreview = window.navigator.appVersion?.startsWith("Mendix Modeler");
+
 export function getGlobalSortContext(): Context<SortAPI | null> {
-    const scope = window.top === window ? window : window.top;
+    const scope = isDesignPreview ? window.top : window;
     return ((scope as any)[SORT_PATH] ??= createContext<SortAPI | null>(null));
 }
 


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)
---

### Description

Gallery was string to get the top level window object, but this object is not available due to security reasons when the app is working in an iframe. Use `globalThis` to get the "local" window object.