### PR TITLE
Wc 3039/fix combobox validation connection to input

### DIFF
--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where validation was not connected to combobox, causing issues for screenreaders.
+
 ## [2.5.1] - 2025-09-19
 
 ### Fixed

--- a/packages/pluggableWidgets/combobox-web/src/components/ComboboxWrapper.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/ComboboxWrapper.tsx
@@ -14,8 +14,8 @@ interface ComboboxWrapperProps extends PropsWithChildren {
     validation?: string;
     isLoading: boolean;
     isMultiselectActive?: boolean;
+    inputId: string;
 }
-
 export const ComboboxWrapper = forwardRef(
     (props: ComboboxWrapperProps, ref: RefObject<HTMLDivElement>): ReactElement => {
         const {
@@ -26,7 +26,8 @@ export const ComboboxWrapper = forwardRef(
             validation,
             children,
             isLoading,
-            isMultiselectActive
+            isMultiselectActive,
+            inputId
         } = props;
         const { id, onClick } = getToggleButtonProps();
 
@@ -56,7 +57,7 @@ export const ComboboxWrapper = forwardRef(
                         </div>
                     )}
                 </div>
-                {validation && <ValidationAlert>{validation}</ValidationAlert>}
+                {validation && <ValidationAlert referenceId={inputId}>{validation}</ValidationAlert>}
             </Fragment>
         );
     }

--- a/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/MultiSelection/MultiSelection.tsx
@@ -96,6 +96,7 @@ export function MultiSelection({
                 validation={selector.validation}
                 isLoading={lazyLoading && selector.options.isLoading}
                 isMultiselectActive={selectedItems?.length > 0}
+                inputId={options.inputId}
             >
                 <div
                     className={classNames(
@@ -139,6 +140,8 @@ export function MultiSelection({
                         placeholder=" "
                         {...inputProps}
                         aria-labelledby={hasLabel ? inputProps["aria-labelledby"] : undefined}
+                        aria-describedby={selector.validation ? options.inputId + "-error" : undefined}
+                        aria-invalid={!!selector.validation}
                     />
                     <InputPlaceholder isEmpty={selectedItems.length <= 0}>{memoizedselectedCaptions}</InputPlaceholder>
                 </div>

--- a/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
+++ b/packages/pluggableWidgets/combobox-web/src/components/SingleSelection/SingleSelection.tsx
@@ -69,7 +69,8 @@ export function SingleSelection({
         },
         { suppressRefError: true }
     );
-
+    console.log(inputProps);
+    console.log(options);
     return (
         <Fragment>
             <ComboboxWrapper
@@ -79,6 +80,7 @@ export function SingleSelection({
                 getToggleButtonProps={getToggleButtonProps}
                 validation={selector.validation}
                 isLoading={lazyLoading && selector.options.isLoading}
+                inputId={options.inputId}
             >
                 <div
                     className={classNames("widget-combobox-selected-items", {
@@ -93,6 +95,8 @@ export function SingleSelection({
                         {...inputProps}
                         placeholder=" "
                         aria-labelledby={hasLabel ? inputProps["aria-labelledby"] : undefined}
+                        aria-describedby={selector.validation ? options.inputId + "-error" : undefined}
+                        aria-invalid={!!selector.validation}
                     />
                     <InputPlaceholder
                         isEmpty={!selector.currentId || !selector.caption.render(selectedItem, "label")}

--- a/packages/shared/widget-plugin-component-kit/src/Alert.tsx
+++ b/packages/shared/widget-plugin-component-kit/src/Alert.tsx
@@ -5,24 +5,35 @@ export interface AlertProps {
     children?: ReactNode;
     className?: string;
     bootstrapStyle: "default" | "primary" | "success" | "info" | "warning" | "danger";
+    inputElementId?: string;
     role?: string;
 }
 
 export interface ValidationAlertProps {
     children?: ReactNode;
     className?: string;
+    referenceId?: string;
 }
 
 // cloning from https://gitlab.rnd.mendix.com/appdev/appdev/-/blob/master/client/src/widgets/web/helpers/Alert.tsx
-export const ValidationAlert = ({ className, children }: ValidationAlertProps): ReactElement => (
-    <Alert className={classNames("mx-validation-message", className)} bootstrapStyle="danger" role="alert">
+export const ValidationAlert = ({ className, children, referenceId }: ValidationAlertProps): ReactElement => (
+    <Alert
+        className={classNames("mx-validation-message", className)}
+        bootstrapStyle="danger"
+        role="alert"
+        inputElementId={referenceId}
+    >
         {children}
     </Alert>
 );
 
-export const Alert = ({ className, bootstrapStyle, children, role }: AlertProps): ReactNode =>
+export const Alert = ({ className, bootstrapStyle, children, role, inputElementId }: AlertProps): ReactNode =>
     Children.count(children) > 0 ? (
-        <div className={classNames(`alert alert-${bootstrapStyle}`, className)} role={role}>
+        <div
+            className={classNames(`alert alert-${bootstrapStyle}`, className)}
+            role={role}
+            id={inputElementId + "-error"}
+        >
             {children}
         </div>
     ) : null;


### PR DESCRIPTION
<!--
IMPORTANT: Please read and follow instructions below on how to
open and submit your pull request.

REQUIRED STEPS:
1. Specify correct pull request type.
2. Write meaningful description.
3. Run `pnpm lint` and `pnpm test` in packages you changed and make sure they have no errors.
4. Add new tests (if needed) to cover new functionality.
5. Read checklist below.

CHECKLIST:
- Do you have a JIRA story for your pull request?
    - If yes, please format the PR title to match the `[XX-000]: description` pattern.
    - If no, please write your PR title using conventional commit rules.
- Does your change require a new version of the widget/module?
    - If yes, run `pnpm -w changelog` or update the `CHANGELOG.md` and bump the version manually.
    - If no, ignore.
- Do you have related PRs in other Mendix repositories?
    - If yes, please link all related pull requests in the description.
    - If no, ignore.
- Does your change touch XML, or is it a new feature or behavior?
    - If yes, if necessary, please create a PR with updates in the documentation (https://github.com/mendix/docs).
    - If no, ignore.
 - Is your change a bug fix or a new feature?
      - If yes, please add a description (last section in the template) of what should be tested and what steps are needed to test it.
     - If no, ignore.
-->

<!--
What type of changes does your PR introduce?
Uncomment relevant sections below by removing `<!--` at the beginning of the line.
-->

### Pull request type

Bug fix (non-breaking change which fixes an issue)



---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description

Currently in the combobox the validation field and input field are not programatically connected. This means that while you can visually see that there's an error, someone using a screenreader might not get to hear this error. To fix this I added a aria-describedby that appears when there is validation info, and aria-invalid which is set to true when there is a validation message. 
<!--
Please uncomment and fill in the following section
to describe which part of the package needs to be tested
and how it can be tested.
-->

### What should be covered while testing?

- The combobox should work as it always has
- The aria-describedby should only appear when there's a validation message
- Aria-invalid should only be set to true when there is a validation message visible.
