### PR TITLE
[WC-3091] Fix issue with not loaded captions in Dropdown sort

### DIFF
--- a/packages/pluggableWidgets/dropdown-sort-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/dropdown-sort-web/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - We fixed an issue with Gallery widget causing errors when Mendix app is being used in an iframe.
 
+- We fixed an issue with Dropdown sort widget not showing attribute captions correctly.
+
 ## [1.2.2] - 2025-03-31
 
 ### Fixed

--- a/packages/shared/widget-plugin-sorting/src/helpers/SortStoreProvider.ts
+++ b/packages/shared/widget-plugin-sorting/src/helpers/SortStoreProvider.ts
@@ -1,4 +1,3 @@
-import { AttributeMetaData, DynamicValue } from "mendix";
 import { SortOrderStore } from "../stores/SortOrderStore";
 import { SortStoreHost } from "../stores/SortStoreHost";
 import { SortInstruction } from "../types/store";
@@ -6,10 +5,6 @@ import { SortInstruction } from "../types/store";
 interface SortStoreProviderSpec {
     host: SortStoreHost;
     initSortOrder?: SortInstruction[];
-    attributes: Array<{
-        attribute: AttributeMetaData;
-        caption?: DynamicValue<string>;
-    }>;
 }
 
 export class SortStoreProvider {
@@ -18,11 +13,7 @@ export class SortStoreProvider {
 
     constructor(spec: SortStoreProviderSpec) {
         this._host = spec.host;
-        const options = spec.attributes.map(item => ({
-            value: item.attribute.id,
-            caption: item.caption?.value ?? "empty"
-        }));
-        this.store = new SortOrderStore({ options, initSortOrder: spec.initSortOrder });
+        this.store = new SortOrderStore({ initSortOrder: spec.initSortOrder });
     }
 
     setup(): () => void {

--- a/packages/shared/widget-plugin-sorting/src/react/hocs/withLinkedSortStore.tsx
+++ b/packages/shared/widget-plugin-sorting/src/react/hocs/withLinkedSortStore.tsx
@@ -1,6 +1,6 @@
 import { useSetup } from "@mendix/widget-plugin-mobx-kit/react/useSetup";
 import { AttributeMetaData, DynamicValue } from "mendix";
-import { createElement, FC } from "react";
+import { createElement, FC, useEffect } from "react";
 import { SortStoreProvider } from "../../helpers/SortStoreProvider";
 import { BasicSortStore } from "../../types/store";
 import { SortAPI } from "../context";
@@ -24,7 +24,9 @@ export function withLinkedSortStore<P extends RequiredProps>(
                 })
         );
 
-        store.setProps(props);
+        useEffect(() => {
+            store.setProps({ attributes: props.attributes });
+        }, [store, props.attributes]);
 
         return <Component {...props} sortStore={store} />;
     };

--- a/packages/shared/widget-plugin-sorting/src/react/hocs/withLinkedSortStore.tsx
+++ b/packages/shared/widget-plugin-sorting/src/react/hocs/withLinkedSortStore.tsx
@@ -20,10 +20,11 @@ export function withLinkedSortStore<P extends RequiredProps>(
             () =>
                 new SortStoreProvider({
                     host: props.sortAPI.host,
-                    initSortOrder: props.sortAPI.host.sortOrder,
-                    attributes: props.attributes
+                    initSortOrder: props.sortAPI.host.sortOrder
                 })
         );
+
+        store.setProps(props);
 
         return <Component {...props} sortStore={store} />;
     };


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

Widget didn't take captions into account besides first loading. This change makes the caption re-render if they change by observing them.