### PR TITLE
[WC-3143]: Add prop style to DG2

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Widget.tsx
@@ -89,7 +89,7 @@ export const Widget = observer(<C extends GridColumn>(props: WidgetProps<C>): Re
             className={className}
             selectionMethod={selectActionHelper.selectionMethod}
             selection={selectionEnabled}
-            style={{}}
+            style={props.styles}
             exporting={exporting}
         >
             <Main {...props} data={exporting ? [] : props.data} />


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

A user mentioned that they cannot add styles (width: 600rem) to the datagrid2, and that it was possible before.