### PR TITLE
[WC-3142] TakePicture: language function default to English over Dutch

### DIFF
--- a/packages/modules/web-actions/CHANGELOG.md
+++ b/packages/modules/web-actions/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the default fallback language for any language other than English was Dutch.
+
 ## [2.11.0] - 2025-04-16
 
 ### Changed

--- a/packages/modules/web-actions/src/javascriptsource/webactions/actions/TakePicture.js
+++ b/packages/modules/web-actions/src/javascriptsource/webactions/actions/TakePicture.js
@@ -392,9 +392,9 @@ export async function TakePicture(picture, showConfirmationScreen, pictureQualit
     function prepareLanguage() {
         const englishFn = english => english;
         try {
-            return mx.session.sessionData.locale.code.toLowerCase().includes("en")
-                ? englishFn
-                : (_english, dutch) => dutch;
+            return mx.session.sessionData.locale.code.toLowerCase().includes("nl")
+                ? (_english, dutch) => dutch
+                : englishFn;
         } catch (_) {
             return englishFn;
         }


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

- Fixed an issue where the default fallback language if anything other than English was selected, was Dutch. The fix reversed to be English by default.

### What should be covered while testing?

- Change the language to German or anything other than English and check what language is displayed
- The language should be English
