### PR TITLE
fix: html element id on single element

### DIFF
--- a/packages/pluggableWidgets/html-element-web/src/HTMLElement.tsx
+++ b/packages/pluggableWidgets/html-element-web/src/HTMLElement.tsx
@@ -24,7 +24,7 @@ export function HTMLElement(props: HTMLElementContainerProps): ReactElement | nu
         <Fragment>
             {items.map(item => (
                 <HTMLTag
-                    key={item?.id}
+                    key={item?.id || `${props.name}_${index}`}
                     tagName={tag as keyof JSX.IntrinsicElements}
                     attributes={{
                         ...prepareAttributes(createAttributeResolver(item), props.attributes, props.class, props.style),


### PR DESCRIPTION
HTML Element widget cause error in the log
>Warning: Each child in a list should have a unique "key" prop.%s%s See https://reactjs.org/link/warning-keys for more information.%s
>    at HTMLTag (http://naviva.local:8080/dist/HTMLElement-JMsVPxAr.js:1503:40)

When not using a tagUseRepeat the there is no key set, as `item?.id ` will be empty
This will cause an issues when the the HTML Element widget is placed multiple times in the same parent.

Solution set `key` to the name of the widget.