### PR TITLE
[WC-3171] DG: Fix custom content cell overflow

### DIFF
--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where custom content would overflow its container cell.
+
 ## [3.7.0] DataWidgets - 2025-11-11
 
 ### Changed

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -266,6 +266,7 @@ $root: ".widget-datagrid";
 
         > .td-custom-content {
             flex-grow: 1;
+            min-width: 0;
         }
 
         > .empty-placeholder {


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

- Fixed an issue where custom content i.e. DateTime picker and TextBox would overflow its container cell

### What should be covered while testing?

- Set DateTime picker and TextBox as custom content in a large number of columns (i.e. 10 columns)
- Observe if the content overflows
- Set Popup Menu as custom content and check if that works without regressions (this change is related to past issues with DG and Popup Menu)