### PR TITLE
[WC-3203] Gallery: Enable row count display on virtual scroll

### DIFF
--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -8,10 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- We added missing dutch translations for Gallery.
+- We fixed an issue where the row count wasn't displayed when "Virtual scroll" is on.
 
 ### Added
 
+- We added missing dutch translations for Gallery.
 - We added a refresh interval property, to allow defining an interval (in seconds) for refreshing the content in Gallery
 
 ## [3.7.0] - 2025-11-11

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.editorConfig.ts
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.editorConfig.ts
@@ -34,10 +34,6 @@ export function getProperties(values: GalleryPreviewProps, defaultProperties: Pr
         hidePropertyIn(defaultProperties, values, "onConfigurationChange");
     }
 
-    // Hide scrolling settings for now.
-    hidePropertiesIn(defaultProperties, values, ["showPagingButtons", "showTotalCount"]);
-    /** Pagination */
-
     if (values.pagination === "buttons") {
         hidePropertyIn(defaultProperties, values, "showTotalCount");
     } else {


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

- We fixed an issue where the row count wasn't display when "Virtual scroll" was set to "On". This should have been the case, similar to how this works on DataGrid 2.

### What should be covered while testing?

- Set "Show total count" to "ON"
- Observe if this count appears in the Gallery widget