### PR TITLE
feat: add showMultiDayTimes property to calendar component

### DIFF
--- a/packages/pluggableWidgets/calendar-web/src/Calendar.xml
+++ b/packages/pluggableWidgets/calendar-web/src/Calendar.xml
@@ -131,6 +131,10 @@
                     <caption>Show all events</caption>
                     <description>Auto-adjust calendar height to display all events without "more" links</description>
                 </property>
+                <property key="showMultiDayTimes" type="boolean" defaultValue="false">
+                    <caption>Show multi-day times</caption>
+                    <description>Show start and end times for events that span multiple days in the week and day views instead of placing them in the all-day row</description>
+                </property>
                 <property key="step" type="integer" defaultValue="30">
                     <caption>Step</caption>
                     <description>Determines the selectable time increments in week and day views</description>

--- a/packages/pluggableWidgets/calendar-web/src/__tests__/Calendar.spec.tsx
+++ b/packages/pluggableWidgets/calendar-web/src/__tests__/Calendar.spec.tsx
@@ -17,6 +17,7 @@ jest.mock("react-big-calendar", () => {
             resizable,
             selectable,
             showAllEvents,
+            showMultiDayTimes,
             min,
             max,
             events,
@@ -31,6 +32,7 @@ jest.mock("react-big-calendar", () => {
                 data-resizable={resizable}
                 data-selectable={selectable}
                 data-show-all-events={showAllEvents}
+                data-show-multi-day-times={showMultiDayTimes}
                 data-min={min?.toISOString()}
                 data-max={max?.toISOString()}
                 data-events-count={events?.length ?? 0}
@@ -91,6 +93,7 @@ const customViewProps: CalendarContainerProps = {
     customViewShowFriday: true,
     customViewShowSaturday: false,
     showAllEvents: true,
+    showMultiDayTimes: true,
     step: 60,
     timeslots: 2,
     toolbarItems: [],
@@ -195,5 +198,181 @@ describe("CalendarPropsBuilder validation", () => {
         const result = buildWithStepTimeslots(30, 2);
         expect(result.step).toBe(30);
         expect(result.timeslots).toBe(2);
+    });
+});
+
+describe("CalendarPropsBuilder showMultiDayTimes", () => {
+    const mockLocalizer = {
+        format: jest.fn(),
+        parse: jest.fn(),
+        startOfWeek: jest.fn(),
+        getDay: jest.fn(),
+        messages: {}
+    } as any;
+
+    it("passes showMultiDayTimes=true to calendar props", () => {
+        const props = { ...customViewProps, showMultiDayTimes: true };
+        const builder = new CalendarPropsBuilder(props);
+        const result = builder.build(mockLocalizer, "en");
+        expect(result.showMultiDayTimes).toBe(true);
+    });
+
+    it("passes showMultiDayTimes=false to calendar props", () => {
+        const props = { ...customViewProps, showMultiDayTimes: false };
+        const builder = new CalendarPropsBuilder(props);
+        const result = builder.build(mockLocalizer, "en");
+        expect(result.showMultiDayTimes).toBe(false);
+    });
+});
+
+describe("CalendarPropsBuilder multi-day time formats", () => {
+    const mockLocalizer = {
+        format: jest.fn((date: Date, pattern: string, _culture: string) => {
+            // Simulate locale-aware formatting using the pattern
+            const hours = date.getHours();
+            const minutes = date.getMinutes().toString().padStart(2, "0");
+            return `${hours}:${minutes} (${pattern})`;
+        }),
+        parse: jest.fn(),
+        startOfWeek: jest.fn(),
+        getDay: jest.fn(),
+        messages: {}
+    } as any;
+
+    const buildWithTimeFormat = (timeFormatValue: string) => {
+        const props = {
+            ...customViewProps,
+            timeFormat: dynamic(timeFormatValue)
+        };
+        const builder = new CalendarPropsBuilder(props);
+        return builder.build(mockLocalizer, "en");
+    };
+
+    it("sets eventTimeRangeStartFormat using the configured time pattern", () => {
+        const result = buildWithTimeFormat("HH:mm");
+        const start = new Date("2025-04-28T22:00:00Z");
+        const end = new Date("2025-04-29T02:00:00Z");
+
+        expect(result.formats!.eventTimeRangeStartFormat).toBeDefined();
+        const label = (result.formats!.eventTimeRangeStartFormat as Function)({ start, end }, "en", mockLocalizer);
+        expect(label).toContain("HH:mm");
+        expect(label).toMatch(/– $/);
+    });
+
+    it("sets eventTimeRangeEndFormat using the configured time pattern", () => {
+        const result = buildWithTimeFormat("HH:mm");
+        const start = new Date("2025-04-28T22:00:00Z");
+        const end = new Date("2025-04-29T02:00:00Z");
+
+        expect(result.formats!.eventTimeRangeEndFormat).toBeDefined();
+        const label = (result.formats!.eventTimeRangeEndFormat as Function)({ start, end }, "en", mockLocalizer);
+        expect(label).toContain("HH:mm");
+        expect(label).toMatch(/^ – /);
+    });
+
+    it("uses the same pattern for eventTimeRangeFormat, start, and end formats", () => {
+        const result = buildWithTimeFormat("h:mm a");
+        const start = new Date("2025-04-28T22:00:00Z");
+        const end = new Date("2025-04-29T02:00:00Z");
+
+        const rangeLabel = (result.formats!.eventTimeRangeFormat as Function)({ start, end }, "en", mockLocalizer);
+        const startLabel = (result.formats!.eventTimeRangeStartFormat as Function)({ start, end }, "en", mockLocalizer);
+        const endLabel = (result.formats!.eventTimeRangeEndFormat as Function)({ start, end }, "en", mockLocalizer);
+
+        // All three should use the same "h:mm a" pattern passed to localizer.format
+        expect(rangeLabel).toContain("h:mm a");
+        expect(startLabel).toContain("h:mm a");
+        expect(endLabel).toContain("h:mm a");
+    });
+
+    it("does not set start/end formats when no timeFormat is configured", () => {
+        const props = { ...customViewProps, timeFormat: undefined };
+        const builder = new CalendarPropsBuilder(props);
+        const result = builder.build(mockLocalizer, "en");
+
+        expect(result.formats!.eventTimeRangeStartFormat).toBeUndefined();
+        expect(result.formats!.eventTimeRangeEndFormat).toBeUndefined();
+    });
+});
+
+describe("CalendarPropsBuilder showEventDate hides multi-day formats", () => {
+    const mockLocalizer = {
+        format: jest.fn((_date: Date, pattern: string) => `formatted(${pattern})`),
+        parse: jest.fn(),
+        startOfWeek: jest.fn(),
+        getDay: jest.fn(),
+        messages: {}
+    } as any;
+
+    it("blanks eventTimeRangeStartFormat when showEventDate=false", () => {
+        const props = {
+            ...customViewProps,
+            showEventDate: dynamic(false),
+            timeFormat: dynamic("HH:mm")
+        };
+        const builder = new CalendarPropsBuilder(props);
+        const result = builder.build(mockLocalizer, "en");
+
+        const label = (result.formats!.eventTimeRangeStartFormat as Function)(
+            { start: new Date(), end: new Date() },
+            "en",
+            mockLocalizer
+        );
+        expect(label).toBe("");
+    });
+
+    it("blanks eventTimeRangeEndFormat when showEventDate=false", () => {
+        const props = {
+            ...customViewProps,
+            showEventDate: dynamic(false),
+            timeFormat: dynamic("HH:mm")
+        };
+        const builder = new CalendarPropsBuilder(props);
+        const result = builder.build(mockLocalizer, "en");
+
+        const label = (result.formats!.eventTimeRangeEndFormat as Function)(
+            { start: new Date(), end: new Date() },
+            "en",
+            mockLocalizer
+        );
+        expect(label).toBe("");
+    });
+
+    it("blanks eventTimeRangeFormat when showEventDate=false", () => {
+        const props = {
+            ...customViewProps,
+            showEventDate: dynamic(false),
+            timeFormat: dynamic("HH:mm")
+        };
+        const builder = new CalendarPropsBuilder(props);
+        const result = builder.build(mockLocalizer, "en");
+
+        const label = (result.formats!.eventTimeRangeFormat as Function)(
+            { start: new Date(), end: new Date() },
+            "en",
+            mockLocalizer
+        );
+        expect(label).toBe("");
+    });
+
+    it("preserves all time range formats when showEventDate=true", () => {
+        const props = {
+            ...customViewProps,
+            showEventDate: dynamic(true),
+            timeFormat: dynamic("p")
+        };
+        const builder = new CalendarPropsBuilder(props);
+        const result = builder.build(mockLocalizer, "en");
+
+        const start = new Date("2025-04-28T22:00:00Z");
+        const end = new Date("2025-04-29T02:00:00Z");
+
+        const rangeLabel = (result.formats!.eventTimeRangeFormat as Function)({ start, end }, "en", mockLocalizer);
+        const startLabel = (result.formats!.eventTimeRangeStartFormat as Function)({ start, end }, "en", mockLocalizer);
+        const endLabel = (result.formats!.eventTimeRangeEndFormat as Function)({ start, end }, "en", mockLocalizer);
+
+        expect(rangeLabel).not.toBe("");
+        expect(startLabel).not.toBe("");
+        expect(endLabel).not.toBe("");
     });
 });

--- a/packages/pluggableWidgets/calendar-web/src/__tests__/__snapshots__/Calendar.spec.tsx.snap
+++ b/packages/pluggableWidgets/calendar-web/src/__tests__/__snapshots__/Calendar.spec.tsx.snap
@@ -15,6 +15,7 @@ exports[`Calendar renders correctly with basic props 1`] = `
     data-resizable="true"
     data-selectable="true"
     data-show-all-events="true"
+    data-show-multi-day-times="true"
     data-step="60"
     data-testid="mock-calendar"
     data-timeslots="2"

--- a/packages/pluggableWidgets/calendar-web/src/helpers/CalendarPropsBuilder.ts
+++ b/packages/pluggableWidgets/calendar-web/src/helpers/CalendarPropsBuilder.ts
@@ -83,6 +83,7 @@ export class CalendarPropsBuilder {
             startAccessor: (event: CalendarEvent) => event.start,
             titleAccessor: (event: CalendarEvent) => event.title,
             showAllEvents: this.props.showAllEvents,
+            showMultiDayTimes: this.props.showMultiDayTimes,
             min: this.minTime,
             max: this.maxTime,
             step: this.step,
@@ -161,6 +162,16 @@ export class CalendarPropsBuilder {
                 culture: string,
                 loc: DateLocalizer
             ) => `${formatWith(start, culture, loc)} – ${formatWith(end, culture, loc)}`;
+            formats.eventTimeRangeStartFormat = (
+                { start }: { start: Date; end: Date },
+                culture: string,
+                loc: DateLocalizer
+            ) => `${formatWith(start, culture, loc)} – `;
+            formats.eventTimeRangeEndFormat = (
+                { end }: { start: Date; end: Date },
+                culture: string,
+                loc: DateLocalizer
+            ) => ` – ${formatWith(end, culture, loc)}`;
             formats.agendaTimeRangeFormat = (
                 { start, end }: { start: Date; end: Date },
                 culture: string,
@@ -260,6 +271,8 @@ export class CalendarPropsBuilder {
         // Ensure showEventDate=false always hides event time ranges
         if (this.props.showEventDate?.value === false) {
             formats.eventTimeRangeFormat = () => "";
+            formats.eventTimeRangeStartFormat = () => "";
+            formats.eventTimeRangeEndFormat = () => "";
         }
 
         return formats;

--- a/packages/pluggableWidgets/calendar-web/typings/CalendarProps.d.ts
+++ b/packages/pluggableWidgets/calendar-web/typings/CalendarProps.d.ts
@@ -90,6 +90,7 @@ export interface CalendarContainerProps {
     minHour: number;
     maxHour: number;
     showAllEvents: boolean;
+    showMultiDayTimes: boolean;
     step: number;
     timeslots: number;
     toolbarItems: ToolbarItemsType[];
@@ -145,6 +146,7 @@ export interface CalendarPreviewProps {
     minHour: number | null;
     maxHour: number | null;
     showAllEvents: boolean;
+    showMultiDayTimes: boolean;
     step: number | null;
     timeslots: number | null;
     toolbarItems: ToolbarItemsPreviewType[];


### PR DESCRIPTION
# Pull Request Description

<!--
IMPORTANT: Please read and follow instructions below on how to
open and submit your pull request.

REQUIRED STEPS:
1. Specify correct pull request type.
2. Write meaningful description.
3. Run `pnpm lint` and `pnpm test` in packages you changed and make sure they have no errors.
4. Add new tests (if needed) to cover new functionality.
5. Read checklist below.

CHECKLIST:
- Do you have a JIRA story for your pull request?
    - If yes, please format the PR title to match the `[XX-000]: description` pattern.
    - If no, please write your PR title using conventional commit rules.
- Does your change require mentioning in changelogs?
    - If yes, run `pnpm -w changelog` or update the `CHANGELOG.md` manually.
    - If no, ignore.
- Does your change touch XML, or is it a new feature or behavior?
    - If yes, if necessary, please create a PR with updates in the documentation (https://github.com/mendix/docs).
    - If no, ignore.
 - Is your change a bug fix or a new feature?
    - If yes, please add a description (last section in the template) of what should be tested and what steps are needed to test it.
    - If no, ignore.
-->

## Pull request type

- [x] New feature (non-breaking change which adds functionality)

---

## Description

Added a new `showMultiDayTimes` property to the Calendar widget that allows events spanning multiple days to display start and end times in the week and day views instead of being placed in the all-day row. This provides better visibility and control over multi-day events in the calendar's time-based views.

### Related Issues

<!-- Add JIRA story number or link if applicable -->

### Changes Made

- **Calendar.xml**: Added new `showMultiDayTimes` boolean property with default value `false` to the View Options section
- **CalendarPropsBuilder.ts**: Integrated `showMultiDayTimes` property to pass it through to react-big-calendar props
- **CalendarProps.d.ts**: Updated TypeScript type definitions to include the new `showMultiDayTimes` property
- **Calendar.spec.tsx**: Added comprehensive test coverage for the new property with both `true` and `false` scenarios
- **Calendar.spec.tsx.snap**: Updated snapshot file to reflect test changes

### Testing

<!-- Describe how you tested your changes -->
- [x] Ran `pnpm lint` - no errors
- [x] Ran `pnpm test` - all tests passing (in calendar-web package)
- [x] Added/updated tests for new functionality
- [x] Verified manually in development environment

**Test Coverage Details:**
- Unit tests added for `showMultiDayTimes` property passing through `CalendarPropsBuilder`
- Tests verify both `true` and `false` scenarios
- Snapshot tests updated to reflect new property integration
- All existing tests continue to pass

---

## What should be covered while testing?

### Test Steps

1. **Enable the showMultiDayTimes property:**
   - Open a Mendix test project with the Calendar widget
   - Set the `showMultiDayTimes` property to `true` in the widget configuration
   - Ensure the calendar has events that span multiple days

2. **Test multi-day events in Week view:**
   - Switch to Week view
   - Verify that multi-day events now display with start and end times instead of appearing in the all-day row
   - Confirm that the time display is accurate across the event duration

3. **Test multi-day events in Day view:**
   - Switch to Day view
   - Verify that multi-day events are properly displayed with times
   - Ensure the display is consistent with the Week view

4. **Test default behavior (showMultiDayTimes = false):**
   - Set `showMultiDayTimes` to `false` (or use default)
   - Verify that multi-day events appear in the all-day row as before
   - Ensure backward compatibility

5. **Test with different event durations:**
   - Test with events spanning exactly 2 days
   - Test with events spanning 3+ days
   - Verify visual representation and timing accuracy for all scenarios

### Expected Behavior

- When `showMultiDayTimes=true`, multi-day events in week and day views should display start and end times in the time grid
- When `showMultiDayTimes=false` (default), multi-day events should behave as before, appearing in the all-day section
- All existing calendar functionality should remain unaffected
- The property should be properly saved and persisted through page refreshes

### Screenshots/Videos (if applicable)

<!-- Add screenshots comparing the behavior with showMultiDayTimes enabled vs disabled -->

---

## Checklist

- [ ] PR title follows the required format (`[XX-000]: description` for JIRA or conventional commits)
  - **Current format:** `feat: add showMultiDayTimes property to calendar component` (conventional commit)
- [x] Changes are documented (parameter added to XML with caption and description)
- [ ] Changelog updated (if applicable - run `pnpm -w changelog` or update manually)
  - **Note:** Need to add entry to `CHANGELOG.md` under Unreleased section for version bump to 2.4.0 (minor version bump for new feature)
- [x] No console errors or warnings
- [x] Code follows project conventions
- [x] All linting rules pass
- [x] All unit tests pass
- [x] New functionality has test coverage
- [x] Performance impact considered (minimal - simple property pass-through)
- [x] Accessibility standards met
