### PR TITLE
fix: letters OL are converted to UL

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/src/utils/formats/quill-table-better/formats/table.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/formats/quill-table-better/formats/table.ts
@@ -163,7 +163,7 @@ class TableCell extends Container {
     html() {
         const reg = /<(ol)[^>]*><li[^>]* data-list="bullet">(?:.*?)<\/li><\/(ol)>/gi;
         return this.domNode.outerHTML.replace(reg, (match: string, $1: string, $2: string) => {
-            return match.replace($1, "ul").replace($2, "ul");
+             return match.replace(/<ol/, '<ul').replace(/<\/ol>/, '</ul>');
         });
     }
 


### PR DESCRIPTION
Hello, 

This PR is created according to ticket number 273055.

Please note that solution which we proposed is based on [this resource](https://github.com/attoae/quill-table-better/pull/146).

Looks like it's known issue in the library which you guys using. 

Please note that we didn't perform full regression tests on the widget.