### PR TITLE
chore: add debug-widget Claude Code skill

### DIFF
--- a/.claude/skills/debug-widget/SKILL.md
+++ b/.claude/skills/debug-widget/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: debug-widget
+description: Use when debugging a Mendix pluggable widget bug — visual glitch, broken scrolling, missing data, stale state, or interaction bugs that need runtime evidence before fixing.
+---
+
+# Debug Widget
+
+## Overview
+
+Evidence-first debugging for Mendix pluggable widgets. You MUST reproduce the bug with Playwright before reading source code, and MUST verify the fix with Playwright before declaring success.
+
+**REQUIRED BACKGROUND:** `superpowers:systematic-debugging` for general root-cause methodology.
+
+## Prerequisites
+
+Before starting, confirm with the user:
+
+1. **Test project running?** The Mendix app must be live at `http://localhost:8080`. Ask: "Is the Studio Pro project running?"
+2. **MX_PROJECT_PATH set?** Needed for deploying the built widget. Ask if not provided.
+3. **JIRA/bug description?** Extract: widget package, symptom, reproduction steps.
+
+## Workflow
+
+### Phase 1: Reproduce
+
+1. **Identify the target** from the bug report:
+    - Widget package (`combobox-web`, `datagrid-web`, …)
+    - Symptom type — see Bug Categories table below
+    - Reproduction steps from JIRA
+
+2. **Find the page** — see [page-discovery.md](page-discovery.md)
+
+3. **Write a diagnostic Playwright script** that follows the JIRA reproduction steps and captures the symptom as a measurable assertion or console output diff.
+
+    See [diagnostic-patterns.md](diagnostic-patterns.md) for templates by bug category.
+
+    Save it as: `packages/pluggableWidgets/<widget>-web/e2e/<bug-id>-diagnostic.spec.js`
+
+4. **Run it:**
+
+    ```bash
+    cd packages/pluggableWidgets/<widget>-web
+    npx playwright test e2e/<bug-id>-diagnostic.spec.js --headed
+    ```
+
+5. **Confirm reproduction:**
+    - Script shows wrong values / assertion fails → **proceed to Phase 2**
+    - Script does NOT demonstrate the bug → fix the script (selectors, timing, page URL). Do NOT proceed to Phase 2 until the script confirms the symptom.
+
+### Phase 2: Analyze + Fix
+
+Now you may read source code.
+
+1. **Trace the reactive chain** from DOM symptom to root cause.
+   See [reactive-chain.md](reactive-chain.md).
+    - Simple widgets (combobox, badge): React props → hooks → component render
+    - Complex widgets (datagrid, gallery): React props → Gate → MobX stores → Observer components
+
+2. **Find root cause** using `superpowers:systematic-debugging` Phase 1–3:
+    - Read error messages and trace data flow
+    - Form a single hypothesis, test minimally
+    - Do NOT attempt a fix without understanding WHY
+
+3. **Apply the fix** at the root cause, not the symptom.
+
+### Phase 3: Build + Deploy
+
+1. **Bump the version** (patch for bugfixes, minor for new behavior). Two files must stay in sync:
+    - `packages/pluggableWidgets/<widget>-web/package.json` — `"version"` field
+    - `packages/pluggableWidgets/<widget>-web/src/package.xml` — `version=` attribute on `<clientModule>`
+
+2. **Add a changelog entry** in `packages/pluggableWidgets/<widget>-web/CHANGELOG.md` under the existing `## [Unreleased]` section:
+
+    ```markdown
+    ### Fixed
+
+    - We fixed an issue where <brief description of the bug>.
+    ```
+
+3. **Ensure `MX_PROJECT_PATH` is set** to the Studio Pro project directory (ask the user if not already set).
+
+4. **Build and deploy the widget:**
+
+    ```bash
+    export MX_PROJECT_PATH=/Users/<user>/Mendix/<ProjectName>
+    pnpm --filter @mendix/<widget>-web run build
+    ```
+
+    The build copies the `.mpk` directly into `$MX_PROJECT_PATH/widgets/`. If shared packages were modified, build them first — check the widget's `AGENTS.md` for the dependency list.
+
+5. Once the build succeeds, proceed directly to Phase 4 — no manual browser refresh or Studio Pro action needed.
+
+### Phase 4: Verify (GATE — must pass before declaring success)
+
+**You CANNOT claim the fix works until the Playwright script confirms it.**
+
+1. **Re-run the same diagnostic script** from Phase 1:
+
+    ```bash
+    cd packages/pluggableWidgets/<widget>-web
+    npx playwright test e2e/<bug-id>-diagnostic.spec.js --headed
+    ```
+
+    Playwright's `page.goto("http://localhost:8080/...")` navigates fresh and picks up the latest deployed widget automatically — no manual browser refresh needed.
+
+2. **Evaluate result:**
+    - Assertion passes / console output shows correct values → **fix confirmed**
+    - Still failing → **return to Phase 2**. Do NOT guess another fix. Log what changed, what was expected, what happened. If this is the 3rd failed attempt, question the architecture per `superpowers:systematic-debugging` Phase 4.5.
+
+3. **After confirmed fix:**
+    - Run unit tests: `cd packages/pluggableWidgets/<widget>-web && pnpm run test`
+    - Convert the diagnostic script into a regression test (change `console.log` to `expect()` assertions), or delete it
+    - Report findings to user
+
+## Build-Verify Loop
+
+```
+Phase 2 (fix) → Phase 3 (build + deploy) → Phase 4 (verify)
+                                                │
+                                      passes? ──┤
+                                      yes: done │
+                                      no: ──────→ back to Phase 2
+                                                (max 3 attempts, then question architecture)
+```
+
+## Bug Categories
+
+| Category    | Symptom Signals                               | Diagnostic Pattern                              |
+| ----------- | --------------------------------------------- | ----------------------------------------------- |
+| Layout/CSS  | Wrong size, overflow broken, misaligned       | Dimensions, CSS custom properties, `max-height` |
+| Data        | Missing rows, wrong values, stale content     | Row count, datasource status, item text         |
+| Stale State | Value not updating, external change ignored   | Read display → trigger change → read again      |
+| Interaction | Click/keyboard unresponsive, wrong selection  | Event handling, `aria-selected`, MobX actions   |
+| Performance | Janky scroll, slow render, high rerender rate | Frame timing, render count, DOM node count      |
+| Lifecycle   | Flash of old content, double render           | Gate prop timing, MobX reaction order           |
+
+## Common Mistakes
+
+- **Skip Playwright reproduction** — if you didn't reproduce it, you don't understand it. No exceptions.
+- **Fix the symptom, not the cause** — masking at the consumer layer won't hold. Trace to root.
+- **Skip session cleanup** — always call `window.mx.session.logout()` after each test. Mendix caps at 5 concurrent sessions.
+- **Forget to rebuild shared packages** — if `widget-plugin-grid` or other workspace deps changed, build them first.
+- **Wrong page config** — the widget appears on multiple pages. Match the config to the bug scenario.
+- **Forget to deploy .mpk** — building alone doesn't deploy. Copy the `.mpk` to `$MX_PROJECT_PATH/widgets/`.
+
+## Extending This Skill
+
+This skill applies to **all** pluggable widgets and grows with each debugging session. After fixing a bug, consider adding:
+
+| What to add                           | Where                                                                  | When                                                                                      |
+| ------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| New bug category / diagnostic pattern | `diagnostic-patterns.md`                                               | You encountered a symptom type not yet covered                                            |
+| Widget-specific selectors             | `diagnostic-patterns.md` (under the relevant pattern's selector table) | You debugged a widget and know its key CSS selectors                                      |
+| Widget architecture section           | `reactive-chain.md`                                                    | The widget uses DI/MobX and isn't documented there yet                                    |
+| New page discovery method             | `page-discovery.md`                                                    | Existing tiers didn't work for a specific project setup                                   |
+| Widget context file                   | `packages/pluggableWidgets/<widget>-web/AGENTS.md`                     | The widget has no AGENTS.md — create one to document its architecture for future sessions |
+
+**Keep patterns widget-agnostic.** Use `<placeholder>` selectors in templates. Add widget-specific selector tables below each pattern so the next developer can reuse your selectors without re-discovering them.
+
+## Reference Files
+
+| File                                             | Contents                                         |
+| ------------------------------------------------ | ------------------------------------------------ |
+| [page-discovery.md](page-discovery.md)           | Tier 0/1/2/3 page discovery procedures with code |
+| [reactive-chain.md](reactive-chain.md)           | Architecture tiers, tracing procedure, key files |
+| [diagnostic-patterns.md](diagnostic-patterns.md) | Playwright script templates by bug category      |

--- a/.claude/skills/debug-widget/diagnostic-patterns.md
+++ b/.claude/skills/debug-widget/diagnostic-patterns.md
@@ -1,0 +1,305 @@
+# Diagnostic Script Patterns
+
+## Contents
+
+- [Script Skeleton](#script-skeleton)
+- [Layout / CSS](#layout--css)
+- [Data](#data)
+- [Interaction](#interaction)
+- [Stale State / Value Update](#stale-state--value-update)
+- [Performance](#performance)
+- [Session Management](#session-management)
+- [Adding New Patterns](#adding-new-patterns)
+
+---
+
+## Script Skeleton
+
+Every diagnostic script follows this structure. Generate one per bug — keep it focused on the specific symptom.
+
+```javascript
+// <bug-description>.spec.js — temporary, delete or convert to regression test after use
+import { test } from "@playwright/test";
+
+test.afterEach(async ({ page }) => {
+    // REQUIRED: prevent exceeding Mendix's 5-session license limit
+    await page.evaluate(() => window.mx.session.logout());
+});
+
+test("diagnostic: <bug description>", async ({ page }) => {
+    // 1. Navigate
+    await page.goto("<page-url>");
+    await page.waitForLoadState("networkidle");
+    await page.locator("<widget-selector>").waitFor({ state: "visible", timeout: 15000 });
+
+    // 2. Capture BEFORE metrics
+    const before = await page.locator("<target-element>").evaluate(el => ({
+        // ...metric capture — see templates below
+    }));
+    console.log("BEFORE:", JSON.stringify(before, null, 2));
+
+    // 3. Trigger the condition that reveals the bug
+    // await page.locator("...").click();
+    // await page.waitForTimeout(300); // allow MobX + CSS reflow to settle
+
+    // 4. Capture AFTER metrics (same as BEFORE)
+    const after = await page.locator("<target-element>").evaluate(el => ({
+        // ...same metric capture
+    }));
+    console.log("AFTER:", JSON.stringify(after, null, 2));
+
+    // 5. Diagnosis log
+    console.log("DIAGNOSIS:", {
+        // compare before vs after to confirm/deny hypothesis
+    });
+});
+```
+
+**Run from widget package directory:**
+
+```bash
+npx playwright test e2e/<script>.spec.js --headed
+```
+
+---
+
+## Layout / CSS
+
+Capture dimensions, overflow state, and CSS custom properties:
+
+```javascript
+const metrics = await page.locator(".widget-datagrid-grid-body").evaluate(el => {
+    const style = getComputedStyle(el);
+    const container = el.closest("[class*='widget-datagrid-grid']");
+    const containerStyle = container ? getComputedStyle(container) : null;
+
+    return {
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        offsetWidth: el.offsetWidth,
+        maxHeight: style.maxHeight,
+        overflow: style.overflow,
+        overflowY: style.overflowY,
+        hasScrollbar: el.scrollHeight > el.clientHeight,
+        // Read CSS custom properties from the container
+        gridBodyHeight: containerStyle?.getPropertyValue("--widgets-grid-body-height"),
+        gridColumns: containerStyle?.getPropertyValue("--widgets-grid-template-columns")
+    };
+});
+```
+
+**For CSS grid layout issues:**
+
+```javascript
+const gridMetrics = await page.locator("[role='grid']").evaluate(el => ({
+    gridTemplateColumns: getComputedStyle(el).gridTemplateColumns,
+    columnCount: el.querySelectorAll("[role='columnheader']").length,
+    childCount: el.children.length
+}));
+```
+
+---
+
+## Data
+
+Count items and verify content correctness:
+
+```javascript
+const dataMetrics = await page.locator(".widget-datagrid").evaluate(el => {
+    const rows = el.querySelectorAll("[role='row']:not([class*='header'])");
+    const headers = el.querySelectorAll("[role='columnheader']");
+    return {
+        rowCount: rows.length,
+        columnCount: headers.length,
+        firstRowText: rows[0]?.textContent?.trim().slice(0, 100),
+        lastRowText: rows[rows.length - 1]?.textContent?.trim().slice(0, 100),
+        hasLoadingIndicator: !!el.querySelector("[class*='loading']"),
+        hasEmptyState: !!el.querySelector("[class*='empty']")
+    };
+});
+```
+
+**For datasource / pagination state:**
+
+```javascript
+const pagingState = await page.evaluate(() => {
+    // Read Mendix datasource state if accessible
+    const pager = document.querySelector(".widget-datagrid .pagination-bar");
+    return {
+        paginationText: pager?.textContent?.trim(),
+        hasNextButton: !!document.querySelector(".btn-next-page:not([disabled])"),
+        hasPrevButton: !!document.querySelector(".btn-prev-page:not([disabled])")
+    };
+});
+```
+
+---
+
+## Interaction
+
+Verify event handling and selection feedback:
+
+```javascript
+// Click a row and verify selection state changes
+await page.locator("[role='row']").nth(1).click();
+await page.waitForTimeout(100);
+
+const selectionState = await page.locator(".widget-datagrid").evaluate(el => ({
+    selectedCount: el.querySelectorAll("[role='row'][aria-selected='true']").length,
+    checkedCount: el.querySelectorAll("input[type='checkbox']:checked").length,
+    hasSelectedClass: el.querySelectorAll(".tr-selected").length
+}));
+```
+
+**For column hiding:**
+
+```javascript
+// Open column selector and hide first column
+await page.locator(".column-selector-button").click();
+const columnsBefore = await page.locator("[role='columnheader']").count();
+await page.locator(".column-selectors > li").first().click();
+await page.waitForTimeout(300);
+const columnsAfter = await page.locator("[role='columnheader']").count();
+console.log("Columns hidden:", columnsBefore - columnsAfter);
+```
+
+---
+
+## Stale State / Value Update
+
+Verify that a widget's displayed value updates when the underlying attribute changes externally (via popup, microflow, another widget on the same page).
+
+**Generic pattern** (adapt selectors to your widget):
+
+```javascript
+// 1. Read the current displayed value
+const valueBefore = await page.locator("<widget-display-selector>").textContent();
+console.log("BEFORE:", valueBefore);
+
+// 2. Trigger the external change (follow JIRA reproduction steps)
+// Common patterns:
+//   a) Click Edit button → change value in popup → close popup
+//   b) Click a button that triggers a microflow/nanoflow changing the attribute
+//   c) Change value in a different widget bound to the same attribute
+await page.locator("<trigger-selector>").click();
+await page.waitForLoadState("networkidle");
+// ... perform the external change ...
+await page.waitForLoadState("networkidle");
+
+// 3. Read the displayed value again
+const valueAfter = await page.locator("<widget-display-selector>").textContent();
+console.log("AFTER:", valueAfter);
+
+// 4. Compare — this is your BEFORE baseline (should show bug: changed === false)
+console.log("DIAGNOSIS:", {
+    changed: valueBefore !== valueAfter,
+    valueBefore,
+    valueAfter
+});
+
+// For regression test: convert to assertion
+// expect(valueAfter).not.toBe(valueBefore);
+```
+
+**Widget-specific selectors** (add rows as you debug new widgets):
+
+| Widget                               | Display value selector                                 | Notes                     |
+| ------------------------------------ | ------------------------------------------------------ | ------------------------- |
+| Combobox (text mode)                 | `.widget-combobox .widget-combobox-placeholder-text`   | Single-select label       |
+| Combobox (custom content)            | `.widget-combobox .widget-combobox-placeholder-custom` | Custom content mode       |
+| Combobox input                       | `.widget-combobox .widget-combobox-input`              | Search/filter input field |
+| Combobox clear button                | `.widget-combobox .widget-combobox-clear-button`       | Visible when value is set |
+| _Add rows as you debug more widgets_ |                                                        |                           |
+
+**Also useful for:** text inputs, date pickers, dropdown filters, reference selectors, or any widget that should reflect attribute changes made by microflows, popups, or sibling widgets.
+
+---
+
+## Performance
+
+Frame timing during interactions (scroll, load more):
+
+```javascript
+const perfMetrics = await page.evaluate(
+    () =>
+        new Promise(resolve => {
+            const frameTimes = [];
+            let last = performance.now();
+            let count = 0;
+
+            function measure(ts) {
+                frameTimes.push(ts - last);
+                last = ts;
+                if (++count < 30) requestAnimationFrame(measure);
+                else {
+                    const avg = frameTimes.reduce((a, b) => a + b) / frameTimes.length;
+                    resolve({
+                        avgFrameMs: Math.round(avg),
+                        maxFrameMs: Math.round(Math.max(...frameTimes)),
+                        estimatedFps: Math.round(1000 / avg),
+                        frameCount: frameTimes.length
+                    });
+                }
+            }
+            requestAnimationFrame(measure);
+        })
+);
+```
+
+**Render count** (add to component temporarily for deep debugging):
+
+```javascript
+// In browser console after navigating to the page:
+const counts = {};
+document.querySelectorAll("[data-testid]").forEach(el => {
+    counts[el.dataset.testid] = (counts[el.dataset.testid] || 0) + 1;
+});
+console.table(counts);
+```
+
+---
+
+## Session Management
+
+**Always include this in every diagnostic script.** Mendix enforces a 5-session license limit — failing to logout will block subsequent test runs.
+
+```javascript
+// At the top of every diagnostic file, before any test.describe:
+test.afterEach(async ({ page }) => {
+    await page.evaluate(() => window.mx.session.logout());
+});
+```
+
+If the page navigation fails before the session is created, the evaluate may throw. Wrap it:
+
+```javascript
+test.afterEach(async ({ page }) => {
+    try {
+        await page.evaluate(() => window.mx.session.logout());
+    } catch {
+        // Page never loaded — no session to clean up
+    }
+});
+```
+
+This pattern is copied from all existing E2E tests in the widget packages (e.g., `datagrid-web/e2e/DataGrid.spec.js:6`).
+
+---
+
+## Adding New Patterns
+
+After a debugging session, if the bug category wasn't covered above, add a new section here.
+
+**Recipe for a new pattern:**
+
+1. **Section header:** `## <Category Name>` — must match an entry in the Bug Categories table in `SKILL.md`
+2. **Generic Playwright code** with `<placeholder>` selectors so any widget developer can adapt it
+3. **Widget-specific selector table** with rows for each widget you tested — saves the next developer from re-discovering selectors
+4. **"Also useful for:" line** listing other widgets where the pattern applies
+
+**Then update:**
+
+- The Contents list at the top of this file
+- The Bug Categories table in `SKILL.md` if the category is new
+
+**Guideline:** Keep the generic template free of widget-specific class names. Put all widget-specific selectors in the table below the template. This way one pattern serves all widgets.

--- a/.claude/skills/debug-widget/page-discovery.md
+++ b/.claude/skills/debug-widget/page-discovery.md
@@ -1,0 +1,186 @@
+# Page Discovery for Widget Debugging
+
+## Contents
+
+- [Tier 0: Running Test Project (MX_PROJECT_PATH)](#tier-0-running-test-project)
+- [Tier 1: User-Provided URL](#tier-1-user-provided-url)
+- [Tier 2: Grep Test Project XML](#tier-2-grep-test-project-xml)
+- [Tier 3: Playwright Runtime Discovery](#tier-3-playwright-runtime-discovery)
+- [Widget Type Reference](#widget-type-reference)
+
+---
+
+## Tier 0: Running Test Project
+
+**When to use:** The user has `MX_PROJECT_PATH` set and the Studio Pro project is running at `http://localhost:8080`. This is the standard path for customer bug reproductions.
+
+The app is already live — no XML grepping needed. Go directly to **Tier 3 (Playwright Runtime Discovery)** to find which page contains the widget configuration that matches the bug.
+
+**Skip Tier 2** — the customer's test project page structure won't match the widget package's bundled test project XML.
+
+**Typical setup confirmation:**
+
+```bash
+# Verify app is reachable
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8080
+# Expected: 200 or 302
+```
+
+---
+
+## Tier 1: User-Provided URL
+
+Navigate directly:
+
+```
+http://localhost:8080<url>   (e.g., http://localhost:8080/p/filtering-multi)
+```
+
+Done. Skip tiers 2 and 3.
+
+---
+
+## Tier 2: Grep Test Project XML
+
+**When to use:** Widget has a deployed test project. Currently only `datagrid-web` and `column-chart-web` have them.
+
+**Check availability:**
+
+```bash
+ls packages/pluggableWidgets/<widget>-web/tests/testProject/deployment/web/pages/ 2>/dev/null
+```
+
+**Find pages containing the widget:**
+
+```bash
+PAGES="packages/pluggableWidgets/<widget>-web/tests/testProject/deployment/web/pages/en_US"
+grep -rl '"widget":"com.mendix.widget.web.<package>.<Name>"' "$PAGES"
+```
+
+Widget IDs follow the pattern `com.mendix.widget.web.<package>.<ClassName>`, e.g.:
+
+- `com.mendix.widget.web.datagrid.Datagrid`
+- `com.mendix.widget.web.columnchart.ColumnChart`
+
+**Narrow by config** (e.g., virtual scrolling only):
+
+```bash
+grep -l '"pagination":"virtualScrolling"' "$PAGES"/**/*.page.xml
+```
+
+**Extract the URL from a matched page file:**
+
+```bash
+head -c 500 "<matched-file>.page.xml" | grep -oE "url='[^']*'"
+```
+
+Pages without a `url=` attribute are the home page (`/`) or pop-up pages opened by actions.
+
+**Page XML structure notes:**
+
+- Root element: `<m:page url='/p/...' title='...'>`
+- Widgets declared as `"widget":"com.mendix.widget.web.<package>.<Name>"` in JSON inside `data-mendix-props`
+- Instance selector: `"class":"mx-name-<instanceName>"` → `.mx-name-<instanceName>` in DOM
+
+---
+
+## Tier 3: Playwright Runtime Discovery
+
+**When to use:** Widget has no deployed test project, or you need to check a live running app.
+
+**Prerequisite:** App running at `localhost:8080` (or set `URL` env var for `playwright.config.cjs`).
+
+```javascript
+// discovery.spec.js — run standalone, delete after use
+import { test } from "@playwright/test";
+
+// Replace with the widget's root CSS class or mx-name pattern
+const WIDGET_SELECTOR = ".widget-datagrid"; // e.g., .widget-gallery, .widget-combobox
+
+test("discover pages containing target widget", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Collect navigation links from sidebar
+    const navLinks = await page.$$eval("a[href*='/p/']", links =>
+        links.map(l => ({ text: l.textContent?.trim(), href: l.getAttribute("href") }))
+    );
+
+    // Also try home page
+    const allUrls = ["/", ...navLinks.map(l => l.href)];
+
+    const found = [];
+    for (const url of allUrls) {
+        try {
+            await page.goto(url);
+            await page.waitForLoadState("networkidle");
+
+            const widgets = await page.$$(WIDGET_SELECTOR);
+            if (widgets.length > 0) {
+                // Optionally read config from DOM
+                const info = await page.evaluate(sel => {
+                    const el = document.querySelector(sel);
+                    return {
+                        classes: el?.className,
+                        dataAttrs: Object.fromEntries(
+                            [...(el?.attributes ?? [])]
+                                .filter(a => a.name.startsWith("data-"))
+                                .map(a => [a.name, a.value])
+                        )
+                    };
+                }, WIDGET_SELECTOR);
+
+                found.push({ url, count: widgets.length, info });
+                console.log(`FOUND on ${url}: ${widgets.length} widget(s)`);
+                console.log(JSON.stringify(info, null, 2));
+            }
+        } catch (e) {
+            // Page may not load or require auth — skip
+        }
+    }
+
+    console.log("\nSummary:", found.map(f => `${f.url} (${f.count})`).join(", ") || "none found");
+
+    await page.evaluate(() => window.mx.session.logout());
+});
+```
+
+**Run:**
+
+```bash
+cd packages/pluggableWidgets/<widget>-web
+npx playwright test e2e/discovery.spec.js --headed
+```
+
+**CSS class patterns by widget family:**
+
+| Widget       | Root CSS Class                                                     |
+| ------------ | ------------------------------------------------------------------ |
+| Datagrid     | `.widget-datagrid`                                                 |
+| Gallery      | `.widget-gallery`                                                  |
+| Combobox     | `.widget-combobox`                                                 |
+| Color Picker | `.widget-color-picker`                                             |
+| Accordion    | `.widget-accordion`                                                |
+| Any          | `.mx-name-<instanceName>` (always works if instance name is known) |
+
+**Checking config in the DOM:**
+Some widgets expose config via `data-` attributes or CSS classes that you can check with `page.evaluate()`:
+
+- Virtual scrolling: look for `data-has-locked-height` on `.widget-datagrid-grid-body`
+- Column hiding available: look for `.column-selector-button`
+- Checkbox mode: look for `[role='checkbox']` in header row
+
+---
+
+## Widget Type Reference
+
+| Package            | Widget ID                                       | Notes             |
+| ------------------ | ----------------------------------------------- | ----------------- |
+| `datagrid-web`     | `com.mendix.widget.web.datagrid.Datagrid`       | Has test project  |
+| `column-chart-web` | `com.mendix.widget.web.columnchart.ColumnChart` | Has test project  |
+| `gallery-web`      | `com.mendix.widget.web.gallery.Gallery`         | No test project   |
+| `combobox-web`     | `com.mendix.widget.web.combobox.Combobox`       | No test project   |
+| `accordion-web`    | `com.mendix.widget.web.accordion.Accordion`     | No test project   |
+| (pattern)          | `com.mendix.widget.web.<package>.<Name>`        | Naming convention |
+
+Widget package name → widget ID: drop the `-web` suffix, use the class name from `src/<Name>.tsx`.

--- a/.claude/skills/debug-widget/reactive-chain.md
+++ b/.claude/skills/debug-widget/reactive-chain.md
@@ -1,0 +1,113 @@
+# Reactive Chain Tracing
+
+## Contents
+
+- [Architecture Tiers](#architecture-tiers)
+- [Tracing Procedure](#tracing-procedure)
+- [Key Files: datagrid-web](#key-files-datagrid-web)
+- [Example: Virtual Scrolling Bug](#example-virtual-scrolling-bug)
+
+---
+
+## Architecture Tiers
+
+Before tracing, identify which architecture tier the widget uses:
+
+| Tier                    | Examples                                       | Trace Path                                                                   |
+| ----------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Simple**              | badge-web, color-picker-web, format-string-web | React props → Component render → DOM                                         |
+| **Complex (DI + MobX)** | datagrid-web, gallery-web                      | React props → Gate → MobX stores → ComputedAtoms → Observer components → DOM |
+
+**How to tell:** Look for a `model/containers/` directory or `Brandi` imports in the widget's `src/`. If they exist, it's a complex widget with dependency injection.
+
+---
+
+## Tracing Procedure
+
+### Step A: Identify the DOM layer
+
+Use your diagnostic script or browser DevTools to pin down:
+
+- Which element is wrong? (CSS class, `role`, `data-` attribute)
+- What CSS properties are incorrect? (`max-height`, `grid-template-columns`, `display`)
+- What CSS custom properties feed those? (`--widgets-grid-body-height`, `--columns`)
+- What data attributes indicate state? (`data-has-locked-height`, `aria-selected`)
+
+### Step B: Find the rendering component
+
+Grep the widget source for the CSS class or element attribute:
+
+```bash
+grep -r "widget-datagrid-grid-body\|data-has-locked-height" packages/pluggableWidgets/datagrid-web/src/
+```
+
+This points to the React component responsible for rendering the broken element.
+
+### Step C: Identify the data source
+
+**Simple widgets:** The component reads directly from React props. Check the `.tsx` entry file and trace from props to the rendered value.
+
+**Complex widgets:**
+
+1. Component uses an injection hook: `usePaginationVM()`, `useColumnsStore()`, `useGridSizeStore()`
+2. Find the hook in `src/model/hooks/injection-hooks.ts`
+3. Hook resolves a DI token from `src/model/tokens.ts`
+4. Token is bound in a `BindingGroup` inside `src/model/containers/<Widget>.container.ts`
+5. The bound class or factory function is the store or computed atom
+6. The store reads from `gate.props` — the MobX observable that React props flow through
+
+### Step D: Trace the computed value
+
+For `ComputedAtom<T>` values (the most common pattern in complex widgets):
+
+- Find the factory function, e.g., `gridStyleAtom`, `rowsAtom`, `pageSizeAtom`
+- Read the factory to find its MobX dependencies
+- Each dependency is either another `ComputedAtom` or a direct `observable` on a store
+- Follow the chain until you find where the wrong value originates
+
+### Step E: Find the root cause
+
+Ask: where is the wrong value **first produced**?
+
+Common root cause patterns:
+
+- **Stale lock**: A value is computed once and cached, but the reset condition doesn't cover all invalidating events (e.g., `lockGridBodyHeight` only reset on page-size change, not column-count change)
+- **Missing reactive dependency**: MobX doesn't track a read because it happened outside `computed()` or `autorun()` context
+- **Wrong gate timing**: Effect fires on the React props cycle before MobX has propagated — use the MobX computed value as the dependency, not the raw React prop
+- **Shared package mismatch**: Type errors or wrong behavior when a shared package (`widget-plugin-grid`) was not rebuilt after changes
+
+---
+
+## Key Files: datagrid-web
+
+Use this as the template when a widget doesn't have an AGENTS.md yet. Always check for `AGENTS.md` in the widget directory first — it will have widget-specific routing.
+
+| Layer           | File                                             | Role                                           |
+| --------------- | ------------------------------------------------ | ---------------------------------------------- |
+| Entry           | `src/Datagrid.tsx`                               | React component, creates container             |
+| Container setup | `src/model/hooks/useDatagridContainer.ts`        | Initializes DI containers                      |
+| DI bindings     | `src/model/containers/Datagrid.container.ts`     | `BindingGroup` objects, `injected()` calls     |
+| Tokens          | `src/model/tokens.ts`                            | `CORE`, `DG`, `SA_TOKENS`                      |
+| Injection hooks | `src/model/hooks/injection-hooks.ts`             | `useColumnsStore()`, `usePaginationVM()`, etc. |
+| Gate            | `src/model/services/MainGateProvider.service.ts` | React → MobX props bridge                      |
+| Grid sizing     | `src/model/stores/GridSize.store.ts`             | `lockGridBodyHeight()`, virtual scroll height  |
+| Column state    | `src/helpers/state/column/ColumnGroupStore.tsx`  | Visibility, ordering, filters                  |
+| CSS layout      | `src/model/models/grid.model.ts`                 | `gridStyleAtom` — CSS custom properties        |
+| Components      | `src/components/*.tsx`                           | Observer components                            |
+
+**Full architecture reference:** `packages/pluggableWidgets/datagrid-web/AGENTS.md`
+
+---
+
+## Example: Virtual Scrolling Bug
+
+**Symptom:** Scrollbar disappears after hiding a column.
+
+**Trace:**
+
+1. **DOM:** `.widget-datagrid-grid-body` has `max-height: 781px` — this is the locked height. `scrollHeight` dropped below `clientHeight` → no overflow → no scrollbar.
+2. **CSS var:** `--widgets-grid-body-height: 781px` on `.widget-datagrid-grid`. This is set from `GridSizeStore.gridBodyHeight`.
+3. **Component:** `GridBody.tsx` applies `style={{ maxHeight: gridBodyHeight }}` from `useGridSizeStore()`.
+4. **Store:** `GridSizeStore.lockGridBodyHeight()` sets `gridBodyHeight` once and only resets it when `pageSizeAtom` changes — not when column count changes.
+5. **Root cause:** Missing reset condition in `lockGridBodyHeight()`. When a column is hidden, row heights can decrease (text no longer wraps), but the locked height stays stale.
+6. **Fix:** Add a `lockedAtColumnCount` guard mirroring the existing `lockedAtPageSize` guard. Wire `visibleColumnsCountAtom` into `GridSizeStore` via DI.


### PR DESCRIPTION
### Pull request type

<!-- No code changes (changes to documentation, CI, metadata, etc.)
<!---->

---

### Description

Adds `.claude/skills/debug-widget/` — a Claude Code skill for debugging Mendix pluggable widgets.

**Why:** Widget bugs in this repo follow repeatable patterns (stale state, layout regressions, data not updating). Without a shared process each session re-discovers the same things: which page to open, how to find widget selectors, how the Gate/MobX reactive chain works. This skill encodes that knowledge once.

**Core constraint:** reproduce the bug with a Playwright script *before* reading source code; verify the fix with the same script *before* claiming success.

**Files added:**

| File | Purpose |
|------|---------|
| `SKILL.md` | 4-phase loop: Reproduce → Analyze+Fix → Build+Deploy → Verify |
| `diagnostic-patterns.md` | Playwright script templates by bug category (Layout, Data, Stale State, Interaction, Performance) |
| `page-discovery.md` | Tier 0–3 page discovery from live app → URL → XML grep → Playwright crawl |
| `reactive-chain.md` | Simple vs. DI+MobX architecture tiers, trace procedure, key files for `datagrid-web` |

**Example:** WC-3355 (combobox value not updating externally) — skill drove writing a Stale State diagnostic script, tracing the issue to `combobox-web`'s hook not reacting to external attribute changes, and verifying the fix via Playwright before declaring success.