### PR TITLE
[WC-3349] FIX: restore scroll position on datasource refresh

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the scroll position was lost after saving changes in a popup opened from the widget when using non-persistent entities with virtual scrolling or load-more pagination.
+
 ## [3.9.0] - 2026-03-23
 
 ### Changed

--- a/packages/pluggableWidgets/datagrid-web/src/model/hooks/useInfiniteControl.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/model/hooks/useInfiniteControl.tsx
@@ -1,12 +1,15 @@
-import { RefObject, UIEvent, useCallback, useEffect } from "react";
+import { RefObject, UIEvent, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { useOnScreen } from "@mendix/widget-plugin-hooks/useOnScreen";
-import { useGridSizeStore } from "@mendix/datagrid-web/src/model/hooks/injection-hooks";
+import { useGridSizeStore, useQueryService } from "@mendix/datagrid-web/src/model/hooks/injection-hooks";
 import { VIRTUAL_SCROLLING_OFFSET } from "../stores/GridSize.store";
 
 export function useInfiniteControl(): [trackBodyScrolling: ((e: any) => void) | undefined] {
     const gridSizeStore = useGridSizeStore();
+    const query = useQueryService();
 
     const isVisible = useOnScreen(gridSizeStore.gridBodyRef as RefObject<HTMLElement>);
+    const savedScrollTop = useRef(0);
+    const prevIsRefreshing = useRef(false);
 
     const trackBodyScrolling = useCallback(
         (e: UIEvent<HTMLDivElement>) => {
@@ -62,6 +65,20 @@ export function useInfiniteControl(): [trackBodyScrolling: ((e: any) => void) | 
             resizeObserver.unobserve(observeTarget);
         };
     }, [gridSizeStore]);
+
+    useLayoutEffect(() => {
+        const body = gridSizeStore.gridBodyRef.current;
+        if (!body || !gridSizeStore.hasVirtualScrolling) {
+            prevIsRefreshing.current = query.isRefreshing;
+            return;
+        }
+        if (query.isRefreshing && !prevIsRefreshing.current) {
+            savedScrollTop.current = body.scrollTop;
+        } else if (!query.isRefreshing && prevIsRefreshing.current && savedScrollTop.current > 0) {
+            body.scrollTop = savedScrollTop.current;
+        }
+        prevIsRefreshing.current = query.isRefreshing;
+    });
 
     return [gridSizeStore.hasVirtualScrolling ? trackBodyScrolling : undefined];
 }

--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the scroll position was lost after saving changes in a popup opened from the widget when using non-persistent entities with virtual scrolling or load-more pagination.
+
 ## [3.9.0] - 2026-03-23
 
 ### Fixed

--- a/packages/pluggableWidgets/gallery-web/src/components/GalleryContent.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/components/GalleryContent.tsx
@@ -2,14 +2,16 @@ import { useInfiniteControl } from "@mendix/widget-plugin-grid/components/Infini
 import classNames from "classnames";
 import { observer } from "mobx-react-lite";
 import { PropsWithChildren, ReactElement } from "react";
-import { usePaginationConfig, usePaginationVM } from "../model/hooks/injection-hooks";
+import { useLoaderViewModel, usePaginationConfig, usePaginationVM } from "../model/hooks/injection-hooks";
 
 export const GalleryContent = observer(function GalleryContent({ children }: PropsWithChildren): ReactElement {
     const paginationVM = usePaginationVM();
+    const loaderVM = useLoaderViewModel();
     const isInfinite = usePaginationConfig().isVirtualScrolling;
     const [trackScrolling, bodySize, containerRef] = useInfiniteControl({
         hasMoreItems: paginationVM.hasMoreItems,
         isInfinite,
+        isRefreshing: loaderVM.isRefreshing,
         setPage: paginationVM.setPage.bind(paginationVM)
     });
 

--- a/packages/shared/widget-plugin-grid/src/components/InfiniteBody.tsx
+++ b/packages/shared/widget-plugin-grid/src/components/InfiniteBody.tsx
@@ -1,4 +1,3 @@
-import { useOnScreen } from "@mendix/widget-plugin-hooks/useOnScreen";
 import classNames from "classnames";
 import {
     CSSProperties,
@@ -10,11 +9,13 @@ import {
     useRef,
     useState
 } from "react";
+import { useOnScreen } from "@mendix/widget-plugin-hooks/useOnScreen";
 
 export interface InfiniteBodyProps {
     className?: string;
     hasMoreItems: boolean;
     isInfinite: boolean;
+    isRefreshing?: boolean;
     role?: string;
     setPage?: (computePage: (prevPage: number) => number) => void;
     style?: CSSProperties;
@@ -24,10 +25,12 @@ const offsetBottom = 30;
 export function useInfiniteControl(
     props: PropsWithChildren<InfiniteBodyProps>
 ): [trackScrolling: (e: any) => void, bodySize: number, containerRef: RefObject<HTMLDivElement | null>] {
-    const { setPage, hasMoreItems, isInfinite } = props;
+    const { setPage, hasMoreItems, isInfinite, isRefreshing } = props;
     const [bodySize, setBodySize] = useState<number>(0);
     const containerRef = useRef<HTMLDivElement>(null);
     const isVisible = useOnScreen(containerRef as RefObject<HTMLElement>);
+    const savedScrollTop = useRef(0);
+    const prevIsRefreshing = useRef(false);
 
     const trackScrolling = useCallback(
         (e: any) => {
@@ -58,6 +61,21 @@ export function useInfiniteControl(
         if (bodySize <= 0) {
             calculateBodyHeight();
         }
+    });
+
+    useLayoutEffect(() => {
+        const container = containerRef.current;
+        if (!container || !isInfinite) {
+            prevIsRefreshing.current = isRefreshing ?? false;
+            return;
+        }
+        const refreshing = isRefreshing ?? false;
+        if (refreshing && !prevIsRefreshing.current) {
+            savedScrollTop.current = container.scrollTop;
+        } else if (!refreshing && prevIsRefreshing.current && savedScrollTop.current > 0) {
+            container.scrollTop = savedScrollTop.current;
+        }
+        prevIsRefreshing.current = refreshing;
     });
 
     return [trackScrolling, bodySize, containerRef];


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

When the Mendix runtime refreshes a non-persistent entity datasource, it creates new ObjectItem instances with new IDs. React keys are built from those IDs, so all children unmount and remount, causing Chrome/Edge to lose the scroll anchor and reset scrollTop to 0.

Fix: save scrollTop when isRefreshing transitions false→true, restore it when isRefreshing transitions true→false, using useLayoutEffect to fire before the browser paints. Shared InfiniteBody hook gets an optional isRefreshing prop; datagrid's own useInfiniteControl reads it directly from the query service.
