### PR TITLE
popup-menu-web: add changelog for clickCloseOn option

### DIFF
--- a/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- We added a "Close on" option for the Click trigger, letting you choose whether the menu closes when you click anywhere on the page or only when you click outside the menu.
+
 ## [4.1.0] - 2026-04-13
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Adds `[Unreleased]` changelog entry for the "Close on" option introduced in #2084.

## Notes

- Merge-order: land this after (or together with) #2084 — otherwise main ships a changelog line for a feature it does not yet have.

## Test plan

- [ ] CHANGELOG-only; no code to test.