### PR TITLE
[WC-3363] Fileuploader: dismiss action for validation errors

### DIFF
--- a/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the "Invalid file format" validation error could not be dismissed and persisted after uploading a valid file.
+
 ## [2.4.2] - 2026-04-23
 
 ### Fixed

--- a/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- We fixed an issue where the "Invalid file format" validation error could not be dismissed and persisted after uploading a valid file.
+- We fixed an issue where validation errors could not be dismissed and persisted after uploading a valid file.
 
 ## [2.4.2] - 2026-04-23
 

--- a/packages/pluggableWidgets/file-uploader-web/src/components/ActionsBar.tsx
+++ b/packages/pluggableWidgets/file-uploader-web/src/components/ActionsBar.tsx
@@ -11,6 +11,10 @@ interface ButtonsBarProps {
 }
 
 export const ActionsBar = ({ actions, store }: ButtonsBarProps): ReactElement | null => {
+    if (store.fileStatus === "validationError") {
+        return <DismissActionsBar store={store} />;
+    }
+
     if (!actions) {
         return <DefaultActionsBar store={store} />;
     }
@@ -65,6 +69,25 @@ function DefaultActionsBar(props: ButtonsBarProps): ReactElement {
                 title={translations.get("removeButtonTextMessage")}
                 action={onRemove}
                 isDisabled={!props.store.canRemove}
+            />
+        </div>
+    );
+}
+
+function DismissActionsBar({ store }: ButtonsBarProps): ReactElement {
+    const translations = useTranslationsStore();
+
+    const onDismiss = useCallback(() => {
+        store.dismiss();
+    }, [store]);
+
+    return (
+        <div className={"entry-details-actions"}>
+            <ActionButton
+                icon={<span className={"remove-icon"} aria-hidden />}
+                title={translations.get("removeButtonTextMessage")}
+                action={onDismiss}
+                isDisabled={false}
             />
         </div>
     );

--- a/packages/pluggableWidgets/file-uploader-web/src/components/Dropzone.tsx
+++ b/packages/pluggableWidgets/file-uploader-web/src/components/Dropzone.tsx
@@ -24,7 +24,7 @@ export const Dropzone = observer(
         acceptFileTypes,
         disabled
     }: DropzoneProps): ReactElement => {
-        const { getRootProps, getInputProps, isDragAccept, isDragReject } = useDropzone({
+        const { getRootProps, getInputProps, isDragActive, isDragAccept, isDragReject } = useDropzone({
             onDrop,
             maxSize: maxSize || undefined,
             maxFiles: maxFilesPerUpload,
@@ -33,7 +33,7 @@ export const Dropzone = observer(
         });
 
         const translations = useTranslationsStore();
-        const [type, msg] = getMessage(translations, isDragAccept, isDragReject);
+        const [type, msg] = getMessage(translations, isDragAccept, isDragActive && isDragReject);
 
         return (
             <Fragment>

--- a/packages/pluggableWidgets/file-uploader-web/src/components/__tests__/DismissActionsBar.spec.tsx
+++ b/packages/pluggableWidgets/file-uploader-web/src/components/__tests__/DismissActionsBar.spec.tsx
@@ -1,0 +1,75 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FileUploaderContainerProps } from "../../../typings/FileUploaderProps";
+import { FileStore } from "../../stores/FileStore";
+import { TranslationsStoreProvider } from "../../utils/useTranslationsStore";
+import { ActionsBar } from "../ActionsBar";
+
+jest.mock("../../utils/mx-data", () => ({
+    fetchDocumentUrl: jest.fn(),
+    fetchImageThumbnail: jest.fn(),
+    fetchMxObject: jest.fn(),
+    removeObject: jest.fn(),
+    saveFile: jest.fn(),
+    fileHasContents: jest.fn()
+}));
+
+function makeFakeProps(): FileUploaderContainerProps {
+    const dv = (v: string): { value: string; status: string } => ({ value: v, status: "available" });
+    return {
+        name: "fileUploader1",
+        uploadMode: "files",
+        maxFileSize: 10,
+        maxFilesPerUpload: { value: { toNumber: () => 5 } },
+        readOnlyMode: false,
+        objectCreationTimeout: 30,
+        allowedFileFormats: "",
+        removeButtonTextMessage: dv("Remove"),
+        downloadButtonTextMessage: dv("Download"),
+        unavailableCreateActionMessage: dv("Unavailable"),
+        uploadFailureTooManyFilesMessage: dv("Too many"),
+        uploadFailureInvalidFileFormatMessage: dv("Invalid format"),
+        uploadFailureFileIsTooBigMessage: dv("Too big")
+    } as unknown as FileUploaderContainerProps;
+}
+
+function makeValidationErrorStore(): { store: FileStore; dismiss: jest.Mock } {
+    const dismiss = jest.fn();
+    const rootStore = { dismissFile: dismiss, _uploadMode: "files", isReadOnly: false } as any;
+    const store = FileStore.newFileWithError(new File([], "bad.txt"), "bad format", rootStore);
+    return { store, dismiss };
+}
+
+function renderWithTranslations(store: FileStore): void {
+    const props = makeFakeProps();
+    render(
+        <TranslationsStoreProvider props={props}>
+            <ActionsBar store={store} />
+        </TranslationsStoreProvider>
+    );
+}
+
+describe("DismissActionsBar", () => {
+    it("renders dismiss button for validationError file", () => {
+        const { store } = makeValidationErrorStore();
+        renderWithTranslations(store);
+        expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("calls store.dismiss() when button clicked", () => {
+        const { store } = makeValidationErrorStore();
+        const dismissSpy = jest.spyOn(store, "dismiss");
+        renderWithTranslations(store);
+        fireEvent.click(screen.getByRole("button"));
+        expect(dismissSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not render DismissActionsBar for non-validationError file", () => {
+        const rootStore = { dismissFile: jest.fn(), _uploadMode: "files", isReadOnly: false } as any;
+        const store = FileStore.newFile(new File([], "ok.txt"), rootStore);
+        (store as any).fileStatus = "done";
+        renderWithTranslations(store);
+        // DefaultActionsBar renders 2 buttons (download + remove)
+        expect(screen.queryAllByRole("button")).toHaveLength(2);
+    });
+});

--- a/packages/pluggableWidgets/file-uploader-web/src/components/__tests__/DismissActionsBar.spec.tsx
+++ b/packages/pluggableWidgets/file-uploader-web/src/components/__tests__/DismissActionsBar.spec.tsx
@@ -53,7 +53,7 @@ describe("DismissActionsBar", () => {
     it("renders dismiss button for validationError file", () => {
         const { store } = makeValidationErrorStore();
         renderWithTranslations(store);
-        expect(screen.getByRole("button")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
     });
 
     it("calls store.dismiss() when button clicked", () => {

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/FileStore.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/FileStore.ts
@@ -60,7 +60,8 @@ export class FileStore {
             imagePreviewUrl: computed,
             upload: action,
             fetchMxObject: action,
-            markMissing: action
+            markMissing: action,
+            dismiss: action
         });
     }
 
@@ -74,6 +75,10 @@ export class FileStore {
     markError(errorMessage: string): void {
         this.fileStatus = "validationError";
         this.errorDescription = errorMessage;
+    }
+
+    dismiss(): void {
+        this._rootStore.files = this._rootStore.files.filter(f => f !== this);
     }
 
     canExecute(listAction: ListActionValue): boolean {
@@ -123,6 +128,7 @@ export class FileStore {
             runInAction(() => {
                 this.fileStatus = "done";
                 this._rootStore.objectCreationHelper.reportUploadSuccess(this._objectItem!);
+                this._rootStore.dismissValidationErrors();
             });
         } catch (_e: unknown) {
             runInAction(() => {

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/FileStore.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/FileStore.ts
@@ -128,7 +128,6 @@ export class FileStore {
             runInAction(() => {
                 this.fileStatus = "done";
                 this._rootStore.objectCreationHelper.reportUploadSuccess(this._objectItem!);
-                this._rootStore.dismissValidationErrors();
             });
         } catch (_e: unknown) {
             runInAction(() => {

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/FileStore.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/FileStore.ts
@@ -78,7 +78,7 @@ export class FileStore {
     }
 
     dismiss(): void {
-        this._rootStore.files = this._rootStore.files.filter(f => f !== this);
+        this._rootStore.dismissFile(this);
     }
 
     canExecute(listAction: ListActionValue): boolean {

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/FileUploaderStore.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/FileUploaderStore.ts
@@ -74,6 +74,7 @@ export class FileUploaderStore {
         makeObservable(this, {
             updateProps: action,
             processDrop: action,
+            dismissValidationErrors: action,
             setMessage: action,
             processExistingFileItem: action,
             files: observable,
@@ -142,6 +143,10 @@ export class FileUploaderStore {
         this.errorMessage = msg;
     }
 
+    dismissValidationErrors(): void {
+        this.files = this.files.filter(file => file.fileStatus !== "validationError");
+    }
+
     processDrop(acceptedFiles: File[], fileRejections: FileRejection[]): void {
         if (!this.objectCreationHelper.canCreateFiles) {
             console.error(
@@ -158,6 +163,7 @@ export class FileUploaderStore {
             return;
         }
 
+        this.dismissValidationErrors();
         this.setMessage();
 
         for (const file of fileRejections) {

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/FileUploaderStore.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/FileUploaderStore.ts
@@ -74,7 +74,6 @@ export class FileUploaderStore {
         makeObservable(this, {
             updateProps: action,
             processDrop: action,
-            dismissValidationErrors: action,
             dismissFile: action,
             setMessage: action,
             processExistingFileItem: action,
@@ -144,7 +143,7 @@ export class FileUploaderStore {
         this.errorMessage = msg;
     }
 
-    dismissValidationErrors(): void {
+    private dismissValidationErrors(): void {
         this.files = this.files.filter(file => file.fileStatus !== "validationError");
         this.setMessage();
     }

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/FileUploaderStore.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/FileUploaderStore.ts
@@ -146,10 +146,14 @@ export class FileUploaderStore {
 
     dismissValidationErrors(): void {
         this.files = this.files.filter(file => file.fileStatus !== "validationError");
+        this.setMessage();
     }
 
     dismissFile(file: FileStore): void {
         this.files = this.files.filter(f => f !== file);
+        if (!this.files.some(f => f.fileStatus === "validationError")) {
+            this.setMessage();
+        }
     }
 
     processDrop(acceptedFiles: File[], fileRejections: FileRejection[]): void {
@@ -169,7 +173,7 @@ export class FileUploaderStore {
         }
 
         this.dismissValidationErrors();
-        this.setMessage();
+        this.setMessage(fileRejections.length ? this.translations.get("dropzoneRejectedMessage") : undefined);
 
         for (const file of fileRejections) {
             const newFileStore = FileStore.newFileWithError(

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/FileUploaderStore.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/FileUploaderStore.ts
@@ -75,6 +75,7 @@ export class FileUploaderStore {
             updateProps: action,
             processDrop: action,
             dismissValidationErrors: action,
+            dismissFile: action,
             setMessage: action,
             processExistingFileItem: action,
             files: observable,
@@ -145,6 +146,10 @@ export class FileUploaderStore {
 
     dismissValidationErrors(): void {
         this.files = this.files.filter(file => file.fileStatus !== "validationError");
+    }
+
+    dismissFile(file: FileStore): void {
+        this.files = this.files.filter(f => f !== file);
     }
 
     processDrop(acceptedFiles: File[], fileRejections: FileRejection[]): void {

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileStore.spec.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileStore.spec.ts
@@ -1,6 +1,5 @@
 import { FileStore } from "../FileStore";
 import { FileUploaderStore } from "../FileUploaderStore";
-import * as mxData from "../../utils/mx-data";
 
 jest.mock("../../utils/mx-data", () => ({
     fetchDocumentUrl: jest.fn(),
@@ -11,19 +10,12 @@ jest.mock("../../utils/mx-data", () => ({
     fileHasContents: jest.fn()
 }));
 
-function makeRootStore(): { dismissFile: jest.Mock; dismissValidationErrors: jest.Mock } {
+function makeRootStore(): { dismissFile: jest.Mock } {
     return {
         dismissFile: jest.fn(),
-        dismissValidationErrors: jest.fn(),
-        objectCreationHelper: {
-            canCreateFiles: true,
-            request: jest.fn().mockResolvedValue({ id: "obj-1" }),
-            reportUploadSuccess: jest.fn(),
-            reportUploadFailure: jest.fn()
-        },
         _uploadMode: "files",
         isReadOnly: false
-    } as unknown as FileUploaderStore & { dismissFile: jest.Mock; dismissValidationErrors: jest.Mock };
+    } as unknown as FileUploaderStore & { dismissFile: jest.Mock };
 }
 
 describe("FileStore.dismiss()", () => {
@@ -33,18 +25,5 @@ describe("FileStore.dismiss()", () => {
         store.dismiss();
         expect(rootStore.dismissFile).toHaveBeenCalledTimes(1);
         expect(rootStore.dismissFile).toHaveBeenCalledWith(store);
-    });
-});
-
-describe("FileStore.upload()", () => {
-    it("does not call dismissValidationErrors on successful upload", async () => {
-        const rootStore = makeRootStore();
-        (mxData.saveFile as jest.Mock).mockResolvedValue(undefined);
-        (mxData.fetchMxObject as jest.Mock).mockResolvedValue({ get2: jest.fn(() => "name.pdf") });
-
-        const store = FileStore.newFile(new File(["content"], "good.pdf"), rootStore as any);
-        await store.upload();
-
-        expect(rootStore.dismissValidationErrors).not.toHaveBeenCalled();
     });
 });

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileStore.spec.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileStore.spec.ts
@@ -1,0 +1,29 @@
+import { FileStore } from "../FileStore";
+import { FileUploaderStore } from "../FileUploaderStore";
+
+jest.mock("../../utils/mx-data", () => ({
+    fetchDocumentUrl: jest.fn(),
+    fetchImageThumbnail: jest.fn(),
+    fetchMxObject: jest.fn(),
+    removeObject: jest.fn(),
+    saveFile: jest.fn(),
+    fileHasContents: jest.fn()
+}));
+
+function makeRootStore(): { dismissFile: jest.Mock } {
+    return {
+        dismissFile: jest.fn(),
+        _uploadMode: "files",
+        isReadOnly: false
+    } as unknown as FileUploaderStore & { dismissFile: jest.Mock };
+}
+
+describe("FileStore.dismiss()", () => {
+    it("calls dismissFile on root store with itself", () => {
+        const rootStore = makeRootStore();
+        const store = FileStore.newFileWithError(new File([], "test.txt"), "bad format", rootStore as any);
+        store.dismiss();
+        expect(rootStore.dismissFile).toHaveBeenCalledTimes(1);
+        expect(rootStore.dismissFile).toHaveBeenCalledWith(store);
+    });
+});

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileStore.spec.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileStore.spec.ts
@@ -1,5 +1,6 @@
 import { FileStore } from "../FileStore";
 import { FileUploaderStore } from "../FileUploaderStore";
+import * as mxData from "../../utils/mx-data";
 
 jest.mock("../../utils/mx-data", () => ({
     fetchDocumentUrl: jest.fn(),
@@ -10,12 +11,19 @@ jest.mock("../../utils/mx-data", () => ({
     fileHasContents: jest.fn()
 }));
 
-function makeRootStore(): { dismissFile: jest.Mock } {
+function makeRootStore(): { dismissFile: jest.Mock; dismissValidationErrors: jest.Mock } {
     return {
         dismissFile: jest.fn(),
+        dismissValidationErrors: jest.fn(),
+        objectCreationHelper: {
+            canCreateFiles: true,
+            request: jest.fn().mockResolvedValue({ id: "obj-1" }),
+            reportUploadSuccess: jest.fn(),
+            reportUploadFailure: jest.fn()
+        },
         _uploadMode: "files",
         isReadOnly: false
-    } as unknown as FileUploaderStore & { dismissFile: jest.Mock };
+    } as unknown as FileUploaderStore & { dismissFile: jest.Mock; dismissValidationErrors: jest.Mock };
 }
 
 describe("FileStore.dismiss()", () => {
@@ -25,5 +33,18 @@ describe("FileStore.dismiss()", () => {
         store.dismiss();
         expect(rootStore.dismissFile).toHaveBeenCalledTimes(1);
         expect(rootStore.dismissFile).toHaveBeenCalledWith(store);
+    });
+});
+
+describe("FileStore.upload()", () => {
+    it("does not call dismissValidationErrors on successful upload", async () => {
+        const rootStore = makeRootStore();
+        (mxData.saveFile as jest.Mock).mockResolvedValue(undefined);
+        (mxData.fetchMxObject as jest.Mock).mockResolvedValue({ get2: jest.fn(() => "name.pdf") });
+
+        const store = FileStore.newFile(new File(["content"], "good.pdf"), rootStore as any);
+        await store.upload();
+
+        expect(rootStore.dismissValidationErrors).not.toHaveBeenCalled();
     });
 });

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileUploaderStore.spec.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileUploaderStore.spec.ts
@@ -38,49 +38,6 @@ function makeDoneFile(store: FileUploaderStore): FileStore {
     return f;
 }
 
-describe("FileUploaderStore.dismissValidationErrors()", () => {
-    it("removes only validationError files", () => {
-        const store = makeStore();
-        const validationFile = makeValidationErrorFile(store);
-        const doneFile = makeDoneFile(store);
-        store.files = [validationFile, doneFile];
-
-        store.dismissValidationErrors();
-
-        expect(store.files).toHaveLength(1);
-        expect(store.files[0]).toBe(doneFile);
-    });
-
-    it("leaves files untouched when none have validationError status", () => {
-        const store = makeStore();
-        const doneFile = makeDoneFile(store);
-        store.files = [doneFile];
-
-        store.dismissValidationErrors();
-
-        expect(store.files).toHaveLength(1);
-    });
-
-    it("empties files when all have validationError status", () => {
-        const store = makeStore();
-        store.files = [makeValidationErrorFile(store), makeValidationErrorFile(store)];
-
-        store.dismissValidationErrors();
-
-        expect(store.files).toHaveLength(0);
-    });
-
-    it("clears errorMessage", () => {
-        const store = makeStore();
-        store.errorMessage = "Some files may not be uploadable.";
-        store.files = [makeValidationErrorFile(store)];
-
-        store.dismissValidationErrors();
-
-        expect(store.errorMessage).toBeUndefined();
-    });
-});
-
 describe("FileUploaderStore.dismissFile()", () => {
     it("removes the specific file from the list", () => {
         const store = makeStore();

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileUploaderStore.spec.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileUploaderStore.spec.ts
@@ -1,0 +1,109 @@
+import { FileStore } from "../FileStore";
+import { FileUploaderStore } from "../FileUploaderStore";
+import { TranslationsStore } from "../TranslationsStore";
+
+jest.mock("../../utils/mx-data", () => ({
+    fetchDocumentUrl: jest.fn(),
+    fetchImageThumbnail: jest.fn(),
+    fetchMxObject: jest.fn(),
+    removeObject: jest.fn(),
+    saveFile: jest.fn(),
+    fileHasContents: jest.fn()
+}));
+
+function makeStore(): FileUploaderStore {
+    const translations = { get: jest.fn(() => "msg"), updateProps: jest.fn() } as unknown as TranslationsStore;
+    const store = Object.create(FileUploaderStore.prototype) as FileUploaderStore;
+    store.files = [];
+    return Object.assign(store, {
+        translations,
+        objectCreationHelper: { canCreateFiles: true, enable: jest.fn(), updateProps: jest.fn(), request: jest.fn() },
+        updateProcessor: { processUpdate: jest.fn() },
+        isReadOnly: false,
+        _uploadMode: "files" as const,
+        _maxFileSizeMiB: 10,
+        _maxFileSize: 10 * 1024 * 1024,
+        acceptedFileTypes: [],
+        existingItemsLoaded: false
+    });
+}
+
+function makeValidationErrorFile(store: FileUploaderStore): FileStore {
+    return FileStore.newFileWithError(new File([], "bad.txt"), "bad format", store);
+}
+
+function makeDoneFile(store: FileUploaderStore): FileStore {
+    const f = FileStore.newFile(new File([], "good.txt"), store);
+    (f as any).fileStatus = "done";
+    return f;
+}
+
+describe("FileUploaderStore.dismissValidationErrors()", () => {
+    it("removes only validationError files", () => {
+        const store = makeStore();
+        const validationFile = makeValidationErrorFile(store);
+        const doneFile = makeDoneFile(store);
+        store.files = [validationFile, doneFile];
+
+        store.dismissValidationErrors();
+
+        expect(store.files).toHaveLength(1);
+        expect(store.files[0]).toBe(doneFile);
+    });
+
+    it("leaves files untouched when none have validationError status", () => {
+        const store = makeStore();
+        const doneFile = makeDoneFile(store);
+        store.files = [doneFile];
+
+        store.dismissValidationErrors();
+
+        expect(store.files).toHaveLength(1);
+    });
+
+    it("empties files when all have validationError status", () => {
+        const store = makeStore();
+        store.files = [makeValidationErrorFile(store), makeValidationErrorFile(store)];
+
+        store.dismissValidationErrors();
+
+        expect(store.files).toHaveLength(0);
+    });
+});
+
+describe("FileUploaderStore.dismissFile()", () => {
+    it("removes the specific file from the list", () => {
+        const store = makeStore();
+        const fileA = makeValidationErrorFile(store);
+        const fileB = makeValidationErrorFile(store);
+        store.files = [fileA, fileB];
+
+        store.dismissFile(fileA);
+
+        expect(store.files).toHaveLength(1);
+        expect(store.files[0]).toBe(fileB);
+    });
+
+    it("does not remove other files", () => {
+        const store = makeStore();
+        const fileA = makeValidationErrorFile(store);
+        const fileB = makeDoneFile(store);
+        store.files = [fileA, fileB];
+
+        store.dismissFile(fileA);
+
+        expect(store.files[0]).toBe(fileB);
+    });
+
+    it("is a no-op when file is not in the list", () => {
+        const store = makeStore();
+        const fileA = makeValidationErrorFile(store);
+        const fileB = makeValidationErrorFile(store);
+        store.files = [fileA];
+
+        store.dismissFile(fileB);
+
+        expect(store.files).toHaveLength(1);
+        expect(store.files[0]).toBe(fileA);
+    });
+});

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileUploaderStore.spec.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileUploaderStore.spec.ts
@@ -69,6 +69,16 @@ describe("FileUploaderStore.dismissValidationErrors()", () => {
 
         expect(store.files).toHaveLength(0);
     });
+
+    it("clears errorMessage", () => {
+        const store = makeStore();
+        store.errorMessage = "Some files may not be uploadable.";
+        store.files = [makeValidationErrorFile(store)];
+
+        store.dismissValidationErrors();
+
+        expect(store.errorMessage).toBeUndefined();
+    });
 });
 
 describe("FileUploaderStore.dismissFile()", () => {
@@ -97,6 +107,7 @@ describe("FileUploaderStore.dismissFile()", () => {
 
     it("is a no-op when file is not in the list", () => {
         const store = makeStore();
+        store.errorMessage = "Some files may not be uploadable.";
         const fileA = makeValidationErrorFile(store);
         const fileB = makeValidationErrorFile(store);
         store.files = [fileA];
@@ -105,5 +116,49 @@ describe("FileUploaderStore.dismissFile()", () => {
 
         expect(store.files).toHaveLength(1);
         expect(store.files[0]).toBe(fileA);
+        expect(store.errorMessage).toBe("Some files may not be uploadable.");
+    });
+
+    it("clears errorMessage when last validationError file is dismissed", () => {
+        const store = makeStore();
+        store.errorMessage = "Some files may not be uploadable.";
+        const file = makeValidationErrorFile(store);
+        store.files = [file];
+
+        store.dismissFile(file);
+
+        expect(store.errorMessage).toBeUndefined();
+    });
+
+    it("keeps errorMessage while other validationError files remain", () => {
+        const store = makeStore();
+        store.errorMessage = "Some files may not be uploadable.";
+        const fileA = makeValidationErrorFile(store);
+        const fileB = makeValidationErrorFile(store);
+        store.files = [fileA, fileB];
+
+        store.dismissFile(fileA);
+
+        expect(store.errorMessage).toBe("Some files may not be uploadable.");
+    });
+});
+
+describe("FileUploaderStore.processDrop() errorMessage", () => {
+    it("sets errorMessage when file rejections exist", () => {
+        const store = makeStore();
+        const rejection = { file: new File([], "bad.xlsx"), errors: [{ code: "file-invalid-type", message: "bad" }] };
+
+        store.processDrop([], [rejection]);
+
+        expect(store.errorMessage).toBe("msg");
+    });
+
+    it("clears errorMessage when no rejections", () => {
+        const store = makeStore();
+        store.errorMessage = "Some files may not be uploadable.";
+
+        store.processDrop([], []);
+
+        expect(store.errorMessage).toBeUndefined();
     });
 });

--- a/packages/pluggableWidgets/file-uploader-web/src/ui/FileUploader.scss
+++ b/packages/pluggableWidgets/file-uploader-web/src/ui/FileUploader.scss
@@ -328,12 +328,12 @@ Place your custom CSS here
             }
 
             &.invalid {
-                opacity: 0.7;
+                .entry-details-preview,
+                .entry-details-main {
+                    opacity: 0.5;
+                }
                 .download-icon {
                     visibility: hidden;
-                }
-                .entry-details-actions {
-                    display: none;
                 }
             }
         }


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

- Fixed an issue where the "Invalid file format" validation error had no way to be dismissed
- Each rejected file entry now has a dismiss (✕) button that removes the entry and clears the yellow dropzone warning
- Yellow warning persists as long as any rejected files remain in the list; clears when the last one is dismissed
- Dropping a new batch clears previous rejected entries and sets the warning only if the new batch also contains rejections

### What should be covered while testing?

**Single rejected file**
- Configure File Uploader with restricted formats (e.g. PDF only)
- Drop one unsupported file — yellow warning appears, rejected entry visible
- Click dismiss (✕) on the entry — entry removed, yellow warning disappears

**Mixed batch (valid + invalid)**
- Drop a batch with one unsupported and one supported file
- Yellow warning appears; both entries visible (supported file uploading, rejected file showing error)
- Confirm yellow warning **stays** after the valid file finishes uploading
- Click dismiss on the rejected entry — entry removed, yellow warning disappears

**Multiple rejected files**
- Drop two unsupported files
- Both rejected entries visible, yellow warning present
- Dismiss one — yellow warning stays (one entry remains)
- Dismiss the second — yellow warning disappears

**New drop clears old rejections**
- Drop one unsupported file — rejected entry visible, yellow warning present
- Drop one supported file — rejected entry from the previous drop disappears immediately and yellow warning clears immediately on drop (before upload completes)