### PR TITLE
test(accordion-web): disable reduce motion

### DIFF
--- a/packages/pluggableWidgets/accordion-web/e2e/Accordion.spec.js
+++ b/packages/pluggableWidgets/accordion-web/e2e/Accordion.spec.js
@@ -39,25 +39,29 @@ test.describe("Accordion", () => {
         await expect(page.locator(`${accordionGroup} ${accordionGroupContent}`)).toBeVisible();
     });
 
-    test("shows single accordion expanded at a time", async ({ page }) => {
-        const firstAccordionGroup = ".mx-name-accordion1 > section";
-        const firstAccordionGroupContent = ".mx-name-text5";
-        const secondAccordionGroup = ".mx-name-accordion1 > section:nth-child(2)";
-        const secondAccordionGroupContent = ".mx-name-image1";
-        const thirdAccordionGroup = ".mx-name-accordion1 > section:nth-child(3)";
-        const thirdAccordionGroupContent = ".mx-name-image2";
+    test.describe("animation-dependent", () => {
+        test.use({ reducedMotion: "no-preference" });
 
-        await expect(page.locator(`${firstAccordionGroup} ${firstAccordionGroupContent}`)).not.toBeVisible();
-        await expect(page.locator(`${secondAccordionGroup} ${secondAccordionGroupContent}`)).not.toBeVisible();
-        await expect(page.locator(`${thirdAccordionGroup} ${thirdAccordionGroupContent}`)).not.toBeVisible();
-        await page.locator(firstAccordionGroup).first().click();
-        await expect(page.locator(`${firstAccordionGroup} ${firstAccordionGroupContent}`)).toBeVisible();
-        await expect(page.locator(`${secondAccordionGroup} ${secondAccordionGroupContent}`)).not.toBeVisible();
-        await expect(page.locator(`${thirdAccordionGroup} ${thirdAccordionGroupContent}`)).not.toBeVisible();
-        await page.locator(thirdAccordionGroup).first().click();
-        await expect(page.locator(`${firstAccordionGroup} ${firstAccordionGroupContent}`)).not.toBeVisible();
-        await expect(page.locator(`${secondAccordionGroup} ${secondAccordionGroupContent}`)).not.toBeVisible();
-        await expect(page.locator(`${thirdAccordionGroup} ${thirdAccordionGroupContent}`)).toBeVisible();
+        test("shows single accordion expanded at a time", async ({ page }) => {
+            const firstAccordionGroup = ".mx-name-accordion1 > section";
+            const firstAccordionGroupContent = ".mx-name-text5";
+            const secondAccordionGroup = ".mx-name-accordion1 > section:nth-child(2)";
+            const secondAccordionGroupContent = ".mx-name-image1";
+            const thirdAccordionGroup = ".mx-name-accordion1 > section:nth-child(3)";
+            const thirdAccordionGroupContent = ".mx-name-image2";
+
+            await expect(page.locator(`${firstAccordionGroup} ${firstAccordionGroupContent}`)).not.toBeVisible();
+            await expect(page.locator(`${secondAccordionGroup} ${secondAccordionGroupContent}`)).not.toBeVisible();
+            await expect(page.locator(`${thirdAccordionGroup} ${thirdAccordionGroupContent}`)).not.toBeVisible();
+            await page.locator(firstAccordionGroup).first().click();
+            await expect(page.locator(`${firstAccordionGroup} ${firstAccordionGroupContent}`)).toBeVisible();
+            await expect(page.locator(`${secondAccordionGroup} ${secondAccordionGroupContent}`)).not.toBeVisible();
+            await expect(page.locator(`${thirdAccordionGroup} ${thirdAccordionGroupContent}`)).not.toBeVisible();
+            await page.locator(thirdAccordionGroup).first().click();
+            await expect(page.locator(`${firstAccordionGroup} ${firstAccordionGroupContent}`)).not.toBeVisible();
+            await expect(page.locator(`${secondAccordionGroup} ${secondAccordionGroupContent}`)).not.toBeVisible();
+            await expect(page.locator(`${thirdAccordionGroup} ${thirdAccordionGroupContent}`)).toBeVisible();
+        });
     });
 
     test("shows multiple accordions expanded", async ({ page }) => {


### PR DESCRIPTION
<!--
IMPORTANT: Please read and follow instructions below on how to
open and submit your pull request.

REQUIRED STEPS:
1. Specify correct pull request type.
2. Write meaningful description.
3. Run `pnpm lint` and `pnpm test` in packages you changed and make sure they have no errors.
4. Add new tests (if needed) to cover new functionality.
5. Read checklist below.

CHECKLIST:
- Do you have a JIRA story for your pull request?
    - If yes, please format the PR title to match the `[XX-000]: description` pattern.
    - If no, please write your PR title using conventional commit rules.
- Does your change require mentioning in changelogs?
    - If yes, run `pnpm -w changelog` or update the `CHANGELOG.md` manually.
    - If no, ignore.
- Does your change touch XML, or is it a new feature or behavior?
    - If yes, if necessary, please create a PR with updates in the documentation (https://github.com/mendix/docs).
    - If no, ignore.
 - Is your change a bug fix or a new feature?
    - If yes, please add a description (last section in the template) of what should be tested and what steps are needed to test it.
    - If no, ignore.
-->

<!--
What type of changes does your PR introduce?
Uncomment relevant sections below by removing `<!--` at the beginning of the line.
-->

### Pull request type

<!-- No code changes (changes to documentation, CI, metadata, etc.)
<!---->

<!-- Dependency changes (any modification to dependencies in `package.json`)
<!---->

<!-- Refactoring (e.g. file rename, variable rename, etc.)
<!---->

<!-- Bug fix (non-breaking change which fixes an issue)
<!---->

<!-- New feature (non-breaking change which adds functionality)
<!---->

<!-- Breaking change (fix or feature that would cause existing functionality to change)
<!---->

Test related change (New E2E test, test automation, etc.)
<!---->

---

<!---
Describe your changes in detail.
Try to explain WHAT and WHY you change, fix or refactor.
-->

### Description

**Root cause**: Commit eb29cbf61 added contextOptions: { reducedMotion: "reduce" } to the shared Playwright config. This causes Chromium to emulate prefers-reduced-motion: reduce, which skips CSS transitions. The accordion's "single expand" mode relies
  on a CSS height transition — when the transition fires, transitionend triggers completeTransitioning(), which finally applies widget-accordion-group-collapsed (display: none). With no transition, transitionend never fires, so the previously-open
  group stays visible.                                                                                                                                                                                                                                      
   
 **Fix**: Wrapped "shows single accordion expanded at a time" in a test.describe("animation-dependent") block with test.use({ reducedMotion: "no-preference" }). This overrides the global setting for that test only, restoring normal transition behavior so transitionend fires and the collapse completes correctly. The beforeEach still handles navigation — no duplicate goto calls. 
<!--
Please uncomment and fill in the following section
to describe which part of the package needs to be tested
and how it can be tested.
-->
<!--
### What should be covered while testing?
-->
