### PR TITLE
feat: add .claude/skills symlink to .agents/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
### Pull request type

No code changes (changes to documentation, CI, metadata, etc.)

---

### Description

Adds `.claude/skills` symlink pointing to `.agents/skills/` to enable Claude Code skill discovery from the centralized skills directory, establishing `.agents/skills/` as the canonical location for all skills while maintaining compatibility with Claude Code's discovery mechanism.

### What should be covered while testing?

- Verify `.claude/skills` symlink points to `../.agents/skills`
- Confirm skills in `.agents/skills/` are discoverable by Claude Code
- Test skill invocation works correctly (e.g., `/code-review`, `/debug-widget`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)