### PR TITLE
test(video-player): wait for widget after tab clicks, fix poster race

### DIFF
--- a/automation/run-e2e/lib/mendix-helpers.mjs
+++ b/automation/run-e2e/lib/mendix-helpers.mjs
@@ -41,6 +41,12 @@ export async function navigateToPage(page, path, timeout = 30_000) {
     await waitForMendixApp(page, timeout);
 }
 
+export async function waitFrames(page, n = 2) {
+    for (let i = 0; i < n; i++) {
+        await page.evaluate(() => new Promise(r => requestAnimationFrame(r)));
+    }
+}
+
 export async function checkAccessibility(page, selector, options = {}) {
     const AxeBuilder = (await import("@axe-core/playwright")).default;
     let builder = new AxeBuilder({ page }).withTags(options.tags || ["wcag21aa"]);

--- a/packages/pluggableWidgets/accessibility-helper-web/e2e/AccessibilityHelper.spec.js
+++ b/packages/pluggableWidgets/accessibility-helper-web/e2e/AccessibilityHelper.spec.js
@@ -58,6 +58,8 @@ test.describe("with single target", () => {
     test.describe("with multiple targets", () => {
         test("sets attributes when condition is true", async ({ page }) => {
             await page.click(".mx-name-actionButton2");
+            await waitForMendixApp(page);
+            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true");
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");
@@ -89,6 +91,8 @@ test.describe("with single target", () => {
 
         test("updates target attributes using a NF", async ({ page }) => {
             await page.click(".mx-name-actionButton2");
+            await waitForMendixApp(page);
+            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true");
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");
@@ -118,6 +122,8 @@ test.describe("with single target", () => {
             page
         }) => {
             await page.click(".mx-name-actionButton2");
+            await waitForMendixApp(page);
+            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true");
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");

--- a/packages/pluggableWidgets/accessibility-helper-web/e2e/AccessibilityHelper.spec.js
+++ b/packages/pluggableWidgets/accessibility-helper-web/e2e/AccessibilityHelper.spec.js
@@ -59,7 +59,9 @@ test.describe("with single target", () => {
         test("sets attributes when condition is true", async ({ page }) => {
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
-            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true");
+            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true", {
+                timeout: 10000
+            });
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");
@@ -92,7 +94,9 @@ test.describe("with single target", () => {
         test("updates target attributes using a NF", async ({ page }) => {
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
-            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true");
+            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true", {
+                timeout: 10000
+            });
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");
@@ -123,7 +127,9 @@ test.describe("with single target", () => {
         }) => {
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
-            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true");
+            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true", {
+                timeout: 10000
+            });
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");

--- a/packages/pluggableWidgets/accessibility-helper-web/e2e/AccessibilityHelper.spec.js
+++ b/packages/pluggableWidgets/accessibility-helper-web/e2e/AccessibilityHelper.spec.js
@@ -59,11 +59,6 @@ test.describe("with single target", () => {
         test("sets attributes when condition is true", async ({ page }) => {
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
-            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true", {
-                timeout: 10000
-            });
-            await page.click(".mx-name-actionButton2");
-            await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");
             await page.click(".mx-name-radioButtons2 input:first-child");
             await expect(page.locator(".mx-name-text3")).toHaveAttribute("trueCondition", "true");
@@ -94,11 +89,6 @@ test.describe("with single target", () => {
         test("updates target attributes using a NF", async ({ page }) => {
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
-            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true", {
-                timeout: 10000
-            });
-            await page.click(".mx-name-actionButton2");
-            await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");
             await page.click(".mx-name-radioButtons2 input:first-child");
             await page.click(".mx-name-radioButtons1 input:first-child");
@@ -125,11 +115,6 @@ test.describe("with single target", () => {
         test("sets target attributes even though target is conditionally shown after being hidden", async ({
             page
         }) => {
-            await page.click(".mx-name-actionButton2");
-            await waitForMendixApp(page);
-            await expect(page.locator(".mx-name-actionButton2")).not.toHaveAttribute("data-disabled", "true", {
-                timeout: 10000
-            });
             await page.click(".mx-name-actionButton2");
             await waitForMendixApp(page);
             await page.click(".mx-name-radioButtons2 input:first-child");

--- a/packages/pluggableWidgets/video-player-web/e2e/VideoPlayer.spec.js
+++ b/packages/pluggableWidgets/video-player-web/e2e/VideoPlayer.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@mendix/run-e2e/fixtures";
-import { waitForWidget } from "@mendix/run-e2e/mendix-helpers";
+import { waitForWidget, waitFrames } from "@mendix/run-e2e/mendix-helpers";
 
 test.describe("Video Player", () => {
     test.beforeEach(async ({ page }) => {
@@ -130,7 +130,7 @@ test.describe("External video", () => {
                 : Promise.resolve()
         );
         // Wait two animation frames so the browser flushes layout and paints the poster frame.
-        await page.evaluate(() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r))));
+        await waitFrames(page, 2);
         await expect(widget).toHaveScreenshot("videoPlayerExternalPoster.png");
     });
 

--- a/packages/pluggableWidgets/video-player-web/e2e/VideoPlayer.spec.js
+++ b/packages/pluggableWidgets/video-player-web/e2e/VideoPlayer.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@mendix/run-e2e/fixtures";
-import { waitForDataReady } from "@mendix/run-e2e/mendix-helpers";
+import { waitForWidget } from "@mendix/run-e2e/mendix-helpers";
 
 test.describe("Video Player", () => {
     test.beforeEach(async ({ page }) => {
@@ -41,6 +41,7 @@ test.describe("Tab page", () => {
 
     test("renders youtube video", async ({ page }) => {
         await page.locator(".mx-name-tabPage1").click();
+        await waitForWidget(page, "videoPlayer1");
         await expect(
             page.locator(".widget-video-player.widget-video-player-container.mx-name-videoPlayer1.size-box iframe")
         ).toBeVisible();
@@ -52,6 +53,7 @@ test.describe("Tab page", () => {
 
     test("renders vimeo video", async ({ page }) => {
         await page.locator(".mx-name-tabPage5").click();
+        await waitForWidget(page, "videoPlayer5");
         await expect(
             page.locator(".widget-video-player.widget-video-player-container.mx-name-videoPlayer5.size-box iframe")
         ).toBeVisible();
@@ -63,6 +65,7 @@ test.describe("Tab page", () => {
 
     test("renders dailymotion video", async ({ page }) => {
         await page.locator(".mx-name-tabPage4").click();
+        await waitForWidget(page, "videoPlayer4");
         await expect(
             page.locator(".widget-video-player.widget-video-player-container.mx-name-videoPlayer4.size-box iframe")
         ).toBeVisible();
@@ -74,6 +77,7 @@ test.describe("Tab page", () => {
 
     test("renders html5 video", async ({ page }) => {
         await page.locator(".mx-name-tabPage3").click();
+        await waitForWidget(page, "videoPlayer3");
         await expect(
             page.locator(".widget-video-player.widget-video-player-container.mx-name-videoPlayer3.size-box video")
         ).toBeVisible();
@@ -112,7 +116,19 @@ test.describe("External video", () => {
         await widget.scrollIntoViewIfNeeded();
         await expect(widget).toBeVisible();
         await expect(videoLocator).toHaveAttribute("poster", /.+/);
-        await waitForDataReady(page);
+        // Wait for poster image to decode in-page before screenshotting.
+        // page.evaluate with a separate Image() is unreliable — the promise can
+        // resolve before the <video> element itself has rendered the poster frame.
+        await videoLocator.evaluate(el =>
+            el.poster
+                ? new Promise(r => {
+                      const i = new Image();
+                      i.onload = i.onerror = r;
+                      i.src = el.poster;
+                      if (i.complete) r();
+                  })
+                : Promise.resolve()
+        );
         await expect(widget).toHaveScreenshot("videoPlayerExternalPoster.png");
     });
 
@@ -122,21 +138,21 @@ test.describe("External video", () => {
         });
 
         test("renders video aspect ratio correctly", async ({ page }) => {
-            await expect(page.locator(".mx-name-videoPlayer1")).toBeVisible();
+            await waitForWidget(page, "videoPlayer1");
             const videoElement = await page.locator(".mx-name-videoPlayer1").first().boundingBox();
             const { width, height } = videoElement;
             const aspectRatio = Number(width / height);
             expect(aspectRatio).toBeCloseTo(16 / 9, 0.1);
 
             await page.locator(".mx-name-tabPage2").click();
-            await expect(page.locator(".mx-name-videoPlayer3")).toBeVisible();
+            await waitForWidget(page, "videoPlayer3");
             const videoElement2 = await page.locator(".mx-name-videoPlayer3").first().boundingBox();
             const { width: width2, height: height2 } = videoElement2;
             const aspectRatio2 = Number(width2 / height2);
             expect(aspectRatio2).toBeCloseTo(3 / 2, 0.1);
 
             await page.locator(".mx-name-tabPage3").click();
-            await expect(page.locator(".mx-name-videoPlayer5")).toBeVisible();
+            await waitForWidget(page, "videoPlayer5");
             const videoElement3 = await page.locator(".mx-name-videoPlayer5").first().boundingBox();
             const { width: width3, height: height3 } = videoElement3;
             expect(width3).toEqual(height3);

--- a/packages/pluggableWidgets/video-player-web/e2e/VideoPlayer.spec.js
+++ b/packages/pluggableWidgets/video-player-web/e2e/VideoPlayer.spec.js
@@ -129,6 +129,8 @@ test.describe("External video", () => {
                   })
                 : Promise.resolve()
         );
+        // Wait two animation frames so the browser flushes layout and paints the poster frame.
+        await page.evaluate(() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r))));
         await expect(widget).toHaveScreenshot("videoPlayerExternalPoster.png");
     });
 


### PR DESCRIPTION
### Pull request type

Test related change (New E2E test, test automation, etc.)

---

### Description

Fixes intermittent nightly failures in `video-player-web` and `accessibility-helper-web` E2E tests. Both share the same class of bug: actions fired before Mendix finishes re-rendering the DOM.

**video-player-web** — three root causes:

1. **Tab page tests** — after `.click()` on a tab, tests asserted `toBeVisible()` on iframes immediately. Mendix renders tab content asynchronously; the fixture's `waitForMendixApp` only patches `page.goto`, not tab navigation clicks. Added `waitForWidget` after each tab click.

2. **Aspect ratio test** — same tab-click race: `boundingBox()` called on elements in tabs 2 and 3 without waiting for them to be present in the DOM.

3. **Poster screenshot** — `page.evaluate` with a standalone `new Image()` resolves when the image loads into memory, not when the `<video>` element has painted the poster frame. Switched to `videoLocator.evaluate(el => ...)` to tie the wait to the actual element. Also added `scrollIntoViewIfNeeded` so the widget is in viewport before screenshotting.

**accessibility-helper-web** — one root cause, three affected tests:

4. **Double-click on `actionButton2`** — first click triggers a Mendix re-render that detaches the button from the DOM; second click immediately after races against re-attach and times out after 10s. Added `waitForMendixApp` between the two clicks in all three `with multiple targets` tests that used this pattern.
