### PR TITLE
[WC-3322]: Fix range-slider decimal places formatting

### DIFF
--- a/packages/pluggableWidgets/range-slider-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/range-slider-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Mark labels and numeric tooltips now respect the configured `decimalPlaces` and the user's session locale (decimal separator and thousands grouping). Previously, marks and tooltips rendered raw numbers via `.toString()`, ignoring locale and decimal precision settings.
+
 ## [3.0.1] - 2026-02-10
 
 ### Added

--- a/packages/pluggableWidgets/range-slider-web/src/RangeSlider.editorPreview.tsx
+++ b/packages/pluggableWidgets/range-slider-web/src/RangeSlider.editorPreview.tsx
@@ -11,11 +11,13 @@ export function getPreviewCss(): string {
 
 export function preview(props: RangeSliderPreviewProps): ReactNode {
     const { min, max, step, value } = getPreviewValues(props);
+    const decimalPlaces = props.decimalPlaces ?? 0;
     const marks = createMarks({
         min,
         max,
         numberOfMarks: props.noOfMarkers ?? 1,
-        decimalPlaces: props.decimalPlaces ?? 0
+        decimalPlaces,
+        format: (v: number) => v.toFixed(decimalPlaces)
     });
 
     const style = getStyleProp({

--- a/packages/pluggableWidgets/range-slider-web/src/components/Container.tsx
+++ b/packages/pluggableWidgets/range-slider-web/src/components/Container.tsx
@@ -1,5 +1,7 @@
+import { NumberFormatter } from "mendix";
 import { ReactElement, useMemo, useRef } from "react";
 import { RangeSliderContainerProps } from "../../typings/RangeSliderProps";
+import { createValueFormatter } from "../utils/helpers";
 import { useNumber } from "../utils/useNumber";
 import { RangeSlider as RangeComponent } from "./RangeSlider";
 import { useOnChangeDebounced } from "../utils/useOnChangeDebounced";
@@ -41,9 +43,22 @@ function InnerContainer(props: InnerContainerProps): ReactElement {
 
     const { onChange } = useOnChangeDebounced({ lowerBoundAttribute, upperBoundAttribute, onChange: props.onChange });
 
+    const formatLower = useMemo(
+        () => createValueFormatter(lowerBoundAttribute.formatter as NumberFormatter, props.decimalPlaces),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [lowerBoundAttribute.formatter, props.decimalPlaces]
+    );
+
+    const formatUpper = useMemo(
+        () => createValueFormatter(upperBoundAttribute.formatter as NumberFormatter, props.decimalPlaces),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [upperBoundAttribute.formatter, props.decimalPlaces]
+    );
+
     const marks = useMarks({
         noOfMarkers: props.noOfMarkers,
         decimalPlaces: props.decimalPlaces,
+        format: formatLower,
         min,
         max
     });
@@ -73,7 +88,10 @@ function InnerContainer(props: InnerContainerProps): ReactElement {
             max={props.max}
             handleRender={(node, handleProps) => {
                 const isCustomText = tooltipTypeCheck[handleProps.index] === "customText";
-                const displayValue = isCustomText ? (tooltipValue[handleProps.index]?.value ?? "") : handleProps.value;
+                const fmt = handleProps.index === 0 ? formatLower : formatUpper;
+                const displayValue = isCustomText
+                    ? (tooltipValue[handleProps.index]?.value ?? "")
+                    : fmt(handleProps.value);
                 return (
                     <HandleTooltip
                         value={displayValue}

--- a/packages/pluggableWidgets/range-slider-web/src/utils/__tests__/helpers.spec.ts
+++ b/packages/pluggableWidgets/range-slider-web/src/utils/__tests__/helpers.spec.ts
@@ -1,0 +1,57 @@
+import { Big } from "big.js";
+import { NumberFormatter } from "mendix";
+import { createValueFormatter } from "../helpers";
+
+function fakeNumberFormatter(
+    config: { groupDigits: boolean; decimalPrecision?: number },
+    locale: { decimal: string; group: string } = { decimal: ".", group: "," }
+): NumberFormatter {
+    return {
+        type: "number",
+        config,
+        withConfig: (next: { groupDigits: boolean; decimalPrecision?: number }) =>
+            fakeNumberFormatter({ ...config, ...next }, locale),
+        format: (value?: Big) => {
+            if (value == null) {
+                return "";
+            }
+            const fixed = value.toNumber().toFixed(config.decimalPrecision ?? 0);
+            const [intPart, fracPart] = fixed.split(".");
+            const grouped = config.groupDigits ? intPart.replace(/\B(?=(\d{3})+(?!\d))/g, locale.group) : intPart;
+            return fracPart != null ? `${grouped}${locale.decimal}${fracPart}` : grouped;
+        },
+        parse: () => ({ valid: false })
+    } as unknown as NumberFormatter;
+}
+
+describe("createValueFormatter", () => {
+    it("redefines the formatter's decimal precision (forces trailing zeros)", () => {
+        const format = createValueFormatter(fakeNumberFormatter({ groupDigits: false }), 2);
+        expect(format(10)).toBe("10.00");
+        expect(format(9.2)).toBe("9.20");
+    });
+
+    it("formats without decimals when decimalPlaces is 0", () => {
+        const format = createValueFormatter(fakeNumberFormatter({ groupDigits: false }), 0);
+        expect(format(10)).toBe("10");
+        expect(format(9.7)).toBe("10");
+    });
+
+    it("respects the locale decimal separator from the formatter", () => {
+        const format = createValueFormatter(
+            fakeNumberFormatter({ groupDigits: false }, { decimal: ",", group: "." }),
+            2
+        );
+        expect(format(9.2)).toBe("9,20");
+    });
+
+    it("keeps the attribute's thousands grouping when groupDigits is enabled", () => {
+        const format = createValueFormatter(fakeNumberFormatter({ groupDigits: true }), 0);
+        expect(format(1000000)).toBe("1,000,000");
+    });
+
+    it("omits thousands grouping when groupDigits is disabled", () => {
+        const format = createValueFormatter(fakeNumberFormatter({ groupDigits: false }), 0);
+        expect(format(1000000)).toBe("1000000");
+    });
+});

--- a/packages/pluggableWidgets/range-slider-web/src/utils/__tests__/marks.spec.ts
+++ b/packages/pluggableWidgets/range-slider-web/src/utils/__tests__/marks.spec.ts
@@ -1,0 +1,80 @@
+import { createMarks } from "../marks";
+
+// Simple deterministic formatter standing in for createValueFormatter's output.
+const formatWith =
+    (decimalPlaces: number, decimalSeparator = ".") =>
+    (value: number): string => {
+        const fixed = value.toFixed(decimalPlaces);
+        return decimalSeparator === "." ? fixed : fixed.replace(".", decimalSeparator);
+    };
+
+describe("createMarks", () => {
+    it("forces trailing zeros when decimalPlaces > 0 and value is whole number", () => {
+        const marks = createMarks({ numberOfMarks: 2, decimalPlaces: 2, format: formatWith(2), min: 0, max: 10 });
+        expect(marks).toBeDefined();
+        expect(marks![0]).toBe("0.00");
+        expect(marks![5]).toBe("5.00");
+        expect(marks![10]).toBe("10.00");
+    });
+
+    it("forces trailing zeros when decimalPlaces > 0 and value has fewer decimals", () => {
+        const marks = createMarks({ numberOfMarks: 2, decimalPlaces: 2, format: formatWith(2), min: 0, max: 9.2 });
+        expect(marks).toBeDefined();
+        expect(marks![4.6]).toBe("4.60");
+        expect(marks![9.2]).toBe("9.20");
+    });
+
+    it("does not add decimal places when decimalPlaces is 0", () => {
+        const marks = createMarks({ numberOfMarks: 4, decimalPlaces: 0, format: formatWith(0), min: 0, max: 100 });
+        expect(marks).toBeDefined();
+        expect(marks![0]).toBe("0");
+        expect(marks![25]).toBe("25");
+        expect(marks![100]).toBe("100");
+    });
+
+    it("uses locale decimal separator", () => {
+        const marks = createMarks({ numberOfMarks: 2, decimalPlaces: 2, format: formatWith(2, ","), min: 0, max: 10 });
+        expect(marks![0]).toBe("0,00");
+        expect(marks![5]).toBe("5,00");
+        expect(marks![10]).toBe("10,00");
+    });
+
+    it("uses correct numeric keys for fractional values with comma locale", () => {
+        const marks = createMarks({
+            numberOfMarks: 2,
+            decimalPlaces: 2,
+            format: formatWith(2, ","),
+            min: 0,
+            max: 9.2
+        });
+        expect(marks![4.6]).toBe("4,60");
+        expect(marks![9.2]).toBe("9,20");
+    });
+
+    it("rounds mark keys to the configured decimal places so dots align with their labels", () => {
+        // 9 intervals over 0..20 yields repeating decimals (e.g. 6.6667). The key must be the
+        // rounded value (6.7) so rc-slider positions the dot where the label reads.
+        const marks = createMarks({ numberOfMarks: 9, decimalPlaces: 1, format: formatWith(1), min: 0, max: 20 });
+        expect(Object.keys(marks!)).toContain("6.7");
+        expect(Object.keys(marks!)).not.toContain("6.666666666666667");
+        expect(marks![6.7]).toBe("6.7");
+    });
+
+    it("returns undefined when numberOfMarks is 0", () => {
+        expect(
+            createMarks({ numberOfMarks: 0, decimalPlaces: 2, format: formatWith(2), min: 0, max: 100 })
+        ).toBeUndefined();
+    });
+
+    it("returns undefined when min equals max", () => {
+        expect(
+            createMarks({ numberOfMarks: 4, decimalPlaces: 2, format: formatWith(2), min: 5, max: 5 })
+        ).toBeUndefined();
+    });
+
+    it("returns undefined when min > max", () => {
+        expect(
+            createMarks({ numberOfMarks: 2, decimalPlaces: 1, format: formatWith(1), min: 10, max: 5 })
+        ).toBeUndefined();
+    });
+});

--- a/packages/pluggableWidgets/range-slider-web/src/utils/helpers.ts
+++ b/packages/pluggableWidgets/range-slider-web/src/utils/helpers.ts
@@ -1,0 +1,17 @@
+import { Big } from "big.js";
+import { NumberFormatter } from "mendix";
+
+export type ValueFormatter = (value: number) => string;
+
+/**
+ * Builds a value formatter from the attribute's own Mendix NumberFormatter, overriding only the
+ * decimal precision. Reusing the runtime formatter means the decimal separator and thousands
+ * grouping follow the user's session locale and the attribute's `groupDigits` setting automatically.
+ */
+export function createValueFormatter(formatter: NumberFormatter, decimalPlaces: number): ValueFormatter {
+    const configured = formatter.withConfig({
+        groupDigits: formatter.config.groupDigits,
+        decimalPrecision: decimalPlaces
+    });
+    return (value: number) => configured.format(new Big(value));
+}

--- a/packages/pluggableWidgets/range-slider-web/src/utils/marks.ts
+++ b/packages/pluggableWidgets/range-slider-web/src/utils/marks.ts
@@ -1,11 +1,13 @@
 import { MarkObj } from "@rc-component/slider/lib/Marks";
 import { ReactNode } from "react";
+import { ValueFormatter } from "./helpers";
 
 export type Marks = Record<string | number, ReactNode | MarkObj>;
 
 export interface CreateMarksParams {
     numberOfMarks: number;
     decimalPlaces: number;
+    format: ValueFormatter;
     min: number;
     max: number;
 }
@@ -20,12 +22,15 @@ export function createMarks(params: CreateMarksParams): Marks | undefined {
     }
 
     const marks: Marks = {};
-    const { numberOfMarks, decimalPlaces, min, max } = params;
+    const { numberOfMarks, decimalPlaces, format, min, max } = params;
     const interval = (max - min) / numberOfMarks;
 
     for (let i = 0; i <= numberOfMarks; i++) {
-        const value = parseFloat((min + i * interval).toFixed(decimalPlaces));
-        marks[value] = value.toString();
+        const rawValue = min + i * interval;
+        // Round the key to the configured precision so rc-slider positions the dot where its
+        // label reads. toFixed always uses "." here, so parseFloat is locale-safe.
+        const key = parseFloat(rawValue.toFixed(decimalPlaces));
+        marks[key] = format(rawValue);
     }
 
     return marks;

--- a/packages/pluggableWidgets/range-slider-web/src/utils/useMarks.ts
+++ b/packages/pluggableWidgets/range-slider-web/src/utils/useMarks.ts
@@ -1,24 +1,27 @@
 import { useMemo } from "react";
+import { ValueFormatter } from "./helpers";
 import { createMarks } from "./marks";
 
 type UseMarksParams = {
     noOfMarkers: number;
     decimalPlaces: number;
+    format: ValueFormatter;
     min?: number;
     max?: number;
 };
 
 export function useMarks(props: UseMarksParams): ReturnType<typeof createMarks> {
-    const { noOfMarkers, decimalPlaces, min = 0, max = 100 } = props;
+    const { noOfMarkers, decimalPlaces, format, min = 0, max = 100 } = props;
 
     return useMemo(
         () =>
             createMarks({
                 numberOfMarks: noOfMarkers,
                 decimalPlaces,
+                format,
                 min,
                 max
             }),
-        [min, max, noOfMarkers, decimalPlaces]
+        [min, max, noOfMarkers, decimalPlaces, format]
     );
 }


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

  - Bring `range-slider-web` to parity with `slider-web`'s locale-aware number formatting
  - Mark labels and numeric tooltips now use the attribute's `NumberFormatter` instead of raw `.toString()`, respecting `decimalPlaces`, decimal separator, and thousands grouping per session locale
  - Each tooltip handle uses its own formatter (`lowerBoundAttribute` for index 0, `upperBoundAttribute` for index 1)