### PR TITLE
fix(checkbox-radio-selection-web): set correct marketplace appNumber

### DIFF
--- a/packages/pluggableWidgets/checkbox-radio-selection-web/package.json
+++ b/packages/pluggableWidgets/checkbox-radio-selection-web/package.json
@@ -21,7 +21,7 @@
     "packagePath": "com.mendix.widget.web",
     "marketplace": {
         "minimumMXVersion": "10.7.0",
-        "appNumber": -1,
+        "appNumber": 245825,
         "appName": "Checkbox Radio Selection",
         "reactReady": true
     },


### PR DESCRIPTION
## Summary
- Sets `marketplace.appNumber` to `245825` in `package.json`
- Was `-1` (placeholder), causing the Marketplace publish workflow to skip the release
- Fixes failed publish for `checkbox-radio-selection-web-v1.1.2`