### PR TITLE
[WC-3428] DG2: remove margin from progress bar and pagination bar

### DIFF
--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -6,12 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### [Unreleased] Datagrid
-
-#### Fixed
-
-- We fixed an issue where a Progress Bar widget placed as Custom Content inside a Data Grid would not display correctly due to a CSS class name conflict.
-
 ## [3.11.0] DataWidgets - 2026-05-27
 
 ### [3.11.0] Datagrid

--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### [Unreleased] Datagrid
+
+#### Fixed
+
+- We fixed an issue where a Progress Bar widget placed as Custom Content inside a Data Grid would not display correctly due to a CSS class name conflict.
+
 ## [3.11.0] DataWidgets - 2026-05-27
 
 ### [3.11.0] Datagrid

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -482,7 +482,7 @@ $root: ".widget-datagrid";
     }
 }
 
-.widget-datagrid .progress-bar {
+.widget-datagrid .pagination-bar {
     margin: var(--spacing-medium, 16px);
 }
 

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -482,10 +482,6 @@ $root: ".widget-datagrid";
     }
 }
 
-.widget-datagrid .pagination-bar {
-    margin: var(--spacing-medium, 16px);
-}
-
 .widget-datagrid .widget-datagrid-load-more {
     display: block !important;
     margin: var(--spacing-small, 8px) 0;

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- We fixed an issue where a Progress Bar widget placed as Custom Content inside a Data Grid would not display correctly due to a CSS class name conflict.
+- We removed the 16px margin from both the Progress Bar and Pagination Bar inside Data Grid, fixing a visual regression caused by an unintended CSS class name match.
 
 ## [3.11.0] - 2026-05-27
 

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where a Progress Bar widget placed as Custom Content inside a Data Grid would not display correctly due to a CSS class name conflict.
+
 ## [3.11.0] - 2026-05-27
 
 ### Added


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

We removed the 16px margin from both the Progress Bar and Pagination Bar inside Data Grid. The margin was originally on the progress bar, then moved to the pagination bar in a prior fix — but neither element should have this margin. Removing it fully fixes the visual regression caused by the unintended CSS class name match.