### PR TITLE
[WC-3409] Combobox: prevent 1px collapse

### DIFF
--- a/openspec/changes/fix-combobox-flex-collapse/.openspec.yaml
+++ b/openspec/changes/fix-combobox-flex-collapse/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/fix-combobox-flex-collapse/proposal.md
+++ b/openspec/changes/fix-combobox-flex-collapse/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Combobox shrinks to 1px when placed in a flex container with `align-items: center` (row). The widget becomes unusable — invisible to the user — without any CSS override from the app developer.
+
+## Root cause
+
+The actual DOM chain in the bug scenario:
+
+```
+.row-center  (user's CSS: display:flex, flex-flow:row, align-items:center)
+  └─ .form-group.no-columns  (Atlas: flex-direction:column, no explicit width)
+       └─ .widget-combobox  (flex-grow:1 — grows height in column container, not width)
+            └─ .widget-combobox-input-container.form-control  (Atlas: min-width:50px — too narrow)
+                 └─ .widget-combobox-selected-items  (min-width:0 — intentional for tag wrapping)
+                      └─ .widget-combobox-input  (max-width:0 unfocused, width:1px multiselect inactive)
+```
+
+The user created `.row-center`. Atlas injected `.form-group.no-columns` (column flex, no explicit width). Inside it, `flex-grow:1` on `.widget-combobox` distributes height, not width. Width is sized by content.
+
+Atlas has `min-width: 0` on `.widget-combobox` and `min-width: 50px` on `.form-control` (`.widget-combobox-input-container`). The `50px` floor propagates up — but it is too narrow: the down-arrow icon alone consumes ~53px, leaving zero space for text input.
+
+**Why native textbox is not affected:**
+
+Textbox renders `.form-control` directly inside `.form-group` — Atlas's `min-width: 50px` is wide enough for a plain input. Combobox `.form-control` must also contain the down-arrow icon, making `50px` insufficient.
+
+## What changes
+
+`packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss` — `.widget-combobox-input-container` rule.
+
+Add `min-width: 15ch` — overrides Atlas's `50px` floor on `.form-control` with a value wide enough to be usable. Scoped to the combobox, not a global Atlas change. `ch` scales with font-size.
+
+## Impact
+
+Must not break:
+
+- Single-select combobox layout in all container types
+- Multiselect combobox layout (active and inactive states)
+- Atlas UI demo site rendering (already unaffected per ticket)

--- a/openspec/changes/fix-combobox-flex-collapse/tests.md
+++ b/openspec/changes/fix-combobox-flex-collapse/tests.md
@@ -1,29 +1,3 @@
 ## Tests
 
-- [ ] **Combobox root element has min-width: 15ch in stylesheet**
-    - **Type:** unit
-    - **Given:** Combobox.scss source
-    - **When:** `.widget-combobox` rule is inspected
-    - **Then:** `min-width` is `15ch`
-    - **Status:** needs update — `src/__tests__/ComboboxStyles.spec.ts` currently asserts `min-content`
-
-- [ ] **Single-select combobox renders with visible width in flex container with align-items center**
-    - **Type:** e2e
-    - **Given:** Single-select Combobox on page `/p/combobox-flex-layout` (`.mx-name-comboBoxFlexSingle`)
-    - **When:** Page loads with no interaction
-    - **Then:** Combobox bounding rect width is greater than 10px
-    - **Status:** pending — needs test page in Studio Pro
-
-- [ ] **Multiselect combobox renders with visible width in flex container with align-items center**
-    - **Type:** e2e
-    - **Given:** Multiselect Combobox on page `/p/combobox-flex-layout` (`.mx-name-comboBoxFlexMulti`)
-    - **When:** Page loads with no interaction
-    - **Then:** Combobox bounding rect width is greater than 10px
-    - **Status:** pending — needs test page in Studio Pro
-
-- [x] **Multiselect inactive input still collapses to 1px (intentional behavior preserved)**
-    - **Type:** unit
-    - **Given:** Combobox.scss source
-    - **When:** multiselect inactive rule inspected
-    - **Then:** `.widget-combobox-input` has `width: 1px`
-    - **Status:** done — `src/__tests__/ComboboxStyles.spec.ts`
+No automated tests. The fix is a single CSS property change; behavior is verified manually per the PR test plan.

--- a/openspec/changes/fix-combobox-flex-collapse/tests.md
+++ b/openspec/changes/fix-combobox-flex-collapse/tests.md
@@ -1,0 +1,29 @@
+## Tests
+
+- [ ] **Combobox root element has min-width: 15ch in stylesheet**
+    - **Type:** unit
+    - **Given:** Combobox.scss source
+    - **When:** `.widget-combobox` rule is inspected
+    - **Then:** `min-width` is `15ch`
+    - **Status:** needs update — `src/__tests__/ComboboxStyles.spec.ts` currently asserts `min-content`
+
+- [ ] **Single-select combobox renders with visible width in flex container with align-items center**
+    - **Type:** e2e
+    - **Given:** Single-select Combobox on page `/p/combobox-flex-layout` (`.mx-name-comboBoxFlexSingle`)
+    - **When:** Page loads with no interaction
+    - **Then:** Combobox bounding rect width is greater than 10px
+    - **Status:** pending — needs test page in Studio Pro
+
+- [ ] **Multiselect combobox renders with visible width in flex container with align-items center**
+    - **Type:** e2e
+    - **Given:** Multiselect Combobox on page `/p/combobox-flex-layout` (`.mx-name-comboBoxFlexMulti`)
+    - **When:** Page loads with no interaction
+    - **Then:** Combobox bounding rect width is greater than 10px
+    - **Status:** pending — needs test page in Studio Pro
+
+- [x] **Multiselect inactive input still collapses to 1px (intentional behavior preserved)**
+    - **Type:** unit
+    - **Given:** Combobox.scss source
+    - **When:** multiselect inactive rule inspected
+    - **Then:** `.widget-combobox-input` has `width: 1px`
+    - **Status:** done — `src/__tests__/ComboboxStyles.spec.ts`

--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the combobox collapsed to 1px width when placed inside a flex row container with `align-items: center`.
+
 ## [2.8.1] - 2026-04-30
 
 ### Fixed

--- a/packages/pluggableWidgets/combobox-web/e2e/Combobox.spec.js
+++ b/packages/pluggableWidgets/combobox-web/e2e/Combobox.spec.js
@@ -174,6 +174,28 @@ test.describe("combobox-web", () => {
     });
 });
 
+// WC-3409: flex align-items center collapse fix
+test.describe("flex container layout (WC-3409)", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/p/combobox-flex-layout");
+        await waitForMendixApp(page);
+    });
+
+    test("single-select combobox has visible width in flex align-items:center container", async ({ page }) => {
+        const comboBox = page.locator(".mx-name-comboBoxFlexSingle");
+        await expect(comboBox).toBeVisible({ timeout: 10000 });
+        const box = await comboBox.boundingBox();
+        expect(box.width).toBeGreaterThan(10);
+    });
+
+    test("multiselect combobox has visible width in flex align-items:center container", async ({ page }) => {
+        const comboBox = page.locator(".mx-name-comboBoxFlexMulti");
+        await expect(comboBox).toBeVisible({ timeout: 10000 });
+        const box = await comboBox.boundingBox();
+        expect(box.width).toBeGreaterThan(10);
+    });
+});
+
 function getOptions(combobox) {
     return combobox.locator(`[role=listbox] [role=option]`);
 }

--- a/packages/pluggableWidgets/combobox-web/e2e/Combobox.spec.js
+++ b/packages/pluggableWidgets/combobox-web/e2e/Combobox.spec.js
@@ -174,28 +174,6 @@ test.describe("combobox-web", () => {
     });
 });
 
-// WC-3409: flex align-items center collapse fix
-test.describe("flex container layout (WC-3409)", () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto("/p/combobox-flex-layout");
-        await waitForMendixApp(page);
-    });
-
-    test("single-select combobox has visible width in flex align-items:center container", async ({ page }) => {
-        const comboBox = page.locator(".mx-name-comboBoxFlexSingle");
-        await expect(comboBox).toBeVisible({ timeout: 10000 });
-        const box = await comboBox.boundingBox();
-        expect(box.width).toBeGreaterThan(10);
-    });
-
-    test("multiselect combobox has visible width in flex align-items:center container", async ({ page }) => {
-        const comboBox = page.locator(".mx-name-comboBoxFlexMulti");
-        await expect(comboBox).toBeVisible({ timeout: 10000 });
-        const box = await comboBox.boundingBox();
-        expect(box.width).toBeGreaterThan(10);
-    });
-});
-
 function getOptions(combobox) {
     return combobox.locator(`[role=listbox] [role=option]`);
 }

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -18,7 +18,6 @@ $cb-skeleton-light: rgba(194, 194, 194, 0.2);
 $cb-skeleton-dark: #d2d2d2;
 
 .widget-combobox {
-    min-width: 0;
     flex-grow: 1;
     position: relative;
     transition: color 150ms ease 0s;
@@ -141,6 +140,7 @@ $cb-skeleton-dark: #d2d2d2;
 
     .widget-combobox-input-container {
         flex-grow: 1;
+        min-width: 15ch; // overrides Atlas .form-control 50px floor; prevents collapse in column flex containers
         transition: box-shadow 150ms ease 0s;
 
         &-disabled {

--- a/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
+++ b/packages/pluggableWidgets/combobox-web/src/ui/Combobox.scss
@@ -19,6 +19,7 @@ $cb-skeleton-dark: #d2d2d2;
 
 .widget-combobox {
     flex-grow: 1;
+    min-width: 0;
     position: relative;
     transition: color 150ms ease 0s;
     &-menu {


### PR DESCRIPTION
## Summary

- Fixes WC-3409: Combobox collapses to 1px when placed in a flex row container with \`align-items: center\`
- Root cause: Mendix injects \`.form-group.no-columns\` (column flex, no explicit width) between the user's container and \`.widget-combobox\`. \`flex-grow: 1\` distributes height in a column container, not width. Children suppress \`min-width\` to ~0 via \`min-width: 0\` on \`.widget-combobox-selected-items\` (intentional, needed for multiselect tag wrapping). Atlas's \`min-width: 50px\` on \`.form-control\` is too narrow — the down-arrow icon alone consumes ~53px.
- Fix: \`min-width: 15ch\` on \`.widget-combobox-input-container\` — overrides Atlas's \`50px\` floor with a value wide enough to be usable. Scoped to combobox only. \`ch\` scales with font-size.

## Changes

- \`src/ui/Combobox.scss\` — \`min-width: 15ch\` on \`.widget-combobox-input-container\`
- \`CHANGELOG.md\` — entry added under \`[Unreleased]\`

## Test plan

1. Create a new page in Studio Pro with a container whose CSS class applies \`display: flex; flex-flow: row; align-items: center\`.
2. Place a **Combobox** widget (single-select, connected to any enumeration attribute) inside that container.
3. Run the app locally and open the page.
4. **Before the fix**: the combobox is invisible (collapses to ~1px width). **After the fix**: the combobox renders with a visible width (≥ 15ch).
5. Repeat with a **multi-select** Combobox to confirm the same result.
6. Verify that typing in the combobox input and selecting a value still works normally.

## Override

To restore previous behavior: \`.widget-combobox-input-container { min-width: 0; }\` in app CSS.