### PR TITLE
[WC-3462] Fix Gallery widget JS actions (Reset Filters, Clear Selection)

### DIFF
--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where "Reset All Filters" and "Clear Selection" JavaScript actions did not work with the Gallery widget. Event listeners were not registered despite the required infrastructure being in place.
+
 ## [3.11.0] - 2026-05-27
 
 ### Added

--- a/packages/pluggableWidgets/gallery-web/src/components/GalleryWidget.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/components/GalleryWidget.tsx
@@ -9,8 +9,10 @@ import { GalleryRoot as Root } from "./GalleryRoot";
 import { GalleryTopBar as TopBar } from "./GalleryTopBar";
 import { GalleryTopBarControls as TopBarControls } from "./GalleryTopBarControls";
 import { RefreshStatus } from "./RefreshStatus";
+import { useGalleryJSActions } from "../helpers/useGalleryJSActions";
 
 export function GalleryWidget(): ReactElement {
+    useGalleryJSActions();
     return (
         <Root>
             <TopBar>

--- a/packages/pluggableWidgets/gallery-web/src/helpers/useGalleryJSActions.ts
+++ b/packages/pluggableWidgets/gallery-web/src/helpers/useGalleryJSActions.ts
@@ -1,0 +1,13 @@
+import { useOnClearSelectionEvent, useOnResetFiltersEvent } from "@mendix/widget-plugin-external-events/hooks";
+import { useGalleryConfig, useSelectActions } from "../model/hooks/injection-hooks";
+
+export function useGalleryJSActions(): void {
+    const config = useGalleryConfig();
+    const selectActions = useSelectActions();
+
+    useOnResetFiltersEvent(config.name, config.filtersChannelName);
+    useOnClearSelectionEvent({
+        widgetName: config.name,
+        listener: () => selectActions.clearSelection()
+    });
+}


### PR DESCRIPTION
## Summary

Gallery widget doesn't respond to "Reset All Filters" and "Clear Selection" JS actions. Event listeners were never registered despite having all the required infrastructure.

This fix creates `useGalleryJSActions()` helper and integrates it into the widget, mirroring datagrid's working implementation.

## Testing Required

- [ ] "Reset All Filters" JS action clears gallery filters
- [ ] "Clear Selection" JS action clears gallery selection