### PR TITLE
[WC-3314] Combobox: mitigate issue with empty string to executeAction()

### DIFF
--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - We fixed an issue where the combobox collapsed to 1px width when placed inside a flex row container with `align-items: center`.
 
+- We fixed an issue where the widget crashed when using the "On filter input change" action with the new string behavior enabled.
+
 ## [2.8.1] - 2026-04-30
 
 ### Fixed

--- a/packages/pluggableWidgets/combobox-web/src/hooks/useGetSelector.ts
+++ b/packages/pluggableWidgets/combobox-web/src/hooks/useGetSelector.ts
@@ -13,7 +13,7 @@ function onInputValueChange(
     }
     if (onChangeFilterInputEvent.canExecute && !onChangeFilterInputEvent.isExecuting) {
         onChangeFilterInputEvent.execute({
-            filterInput: filterValue
+            filterInput: filterValue || undefined
         });
     }
 }


### PR DESCRIPTION
- Normalize empty string `filterValue` to `undefined` before passing to `onChangeFilterInputEvent.execute()` to prevent widget crash
- Add changelog entry for the fix


There is a test project in related WTF story. Check that after the change there is not crash when input is cleared.
