### PR TITLE
[WC-3485]: fix(app-events-web): remove unexpected spacing caused by widget styles

### DIFF
--- a/packages/pluggableWidgets/events-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/events-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue with the widget causing unexpected spacing in the page layout.
+
 ## [1.3.0] - 2026-02-25
 
 ### Fixed

--- a/packages/pluggableWidgets/events-web/src/ui/Events.scss
+++ b/packages/pluggableWidgets/events-web/src/ui/Events.scss
@@ -1,7 +1,3 @@
-$brand-primary: #264ae5;
-$gray-dark: #606671;
 .widget-events {
-    flex-grow: 1;
-    position: relative;
-    transition: color 150ms ease 0s;
+    display: none;
 }


### PR DESCRIPTION
## Summary

- The `widget-events` class had `flex-grow: 1`, `position: relative`, and `transition` styles that caused the widget div to occupy space in flex layouts at runtime
- Since App Events is a purely logical widget with no visual content, it should be hidden (`display: none`)
- Removed the leftover styles and replaced with `display: none`

## Test plan

- [x] Place an App Events widget inside a flex container in Studio Pro and verify no unexpected spacing appears
- [x] Verify the widget still fires events correctly (no visual regression expected — widget renders nothing)