### PR TITLE
chore: auto-fix eslint issues in post-edit hook

### DIFF
--- a/.claude/hooks/post-edit.sh
+++ b/.claude/hooks/post-edit.sh
@@ -44,6 +44,13 @@ else
     pnpm exec prettier --write "$FILE_PATH" 2>/dev/null
 fi
 
+# Auto-fix eslint-fixable issues (import order, prefer-const, etc.) on the edited file.
+# This corrects fixable warnings that the report-only lint pass below would otherwise
+# leave in place (import/order is a warning, so it never fails lint but does clutter diffs).
+if [[ -n "$PACKAGE_DIR" ]]; then
+    (cd "$PACKAGE_DIR" && pnpm exec eslint --fix "$FILE_PATH" 2>/dev/null)
+fi
+
 # Run lint from the package directory using the project's lint setup
 if [[ -n "$PACKAGE_DIR" ]]; then
     LINT_OUTPUT=$(cd "$PACKAGE_DIR" && pnpm run lint 2>&1)


### PR DESCRIPTION
### Pull request type

Refactoring (e.g. file rename, variable rename, etc.)

---

### Description

**What:** The Claude Code / Copilot `PostToolUse` hook (`.claude/hooks/post-edit.sh`) now runs `eslint --fix` on the edited file after `prettier --write` and before the report-only lint pass.

**Why:** The hook previously ran `prettier --write` (which does not reorder imports) then a report-only `pnpm run lint`. Fixable eslint issues at **warning** severity — notably `import/order` — were never auto-corrected and never failed lint (warnings keep the exit code at 0). They leaked into commits and had to be fixed manually with `eslint --fix`.

**Change:** Add a single-file `eslint --fix "$FILE_PATH"` step, scoped and `cd`-ed the same way as the existing prettier step. It auto-corrects every eslint-fixable rule (import order, `prefer-const`, etc.) on each edit; the final `pnpm run lint` still gates on errors.

Verified by piping a simulated `PostToolUse` payload (`{"tool_input":{"file_path":"…"}}`) for a file with out-of-order imports through the hook — imports were reordered and the hook exited 0.

### What should be covered while testing?

1. Edit a `.ts`/`.tsx` file in a widget package so it has a fixable eslint issue (e.g. imports out of order).
2. The hook should auto-reorder/fix on save without manual intervention.
3. A file with a non-fixable eslint **error** should still be reported back (hook exits 2), unchanged behavior.
