### PR TITLE
fix(maps-web): migrate test mocks to dynamic.available() API

### DIFF
--- a/packages/pluggableWidgets/maps-web/src/__tests__/Maps.spec.tsx
+++ b/packages/pluggableWidgets/maps-web/src/__tests__/Maps.spec.tsx
@@ -9,10 +9,10 @@ describe("Maps", () => {
     function staticMarker(latitude: string, longitude: string): MarkersType {
         return {
             locationType: "latlng",
-            latitude: dynamic(latitude),
-            longitude: dynamic(longitude),
-            address: dynamic(""),
-            title: dynamic("Static marker"),
+            latitude: dynamic.available(latitude),
+            longitude: dynamic.available(longitude),
+            address: dynamic.available(""),
+            title: dynamic.available("Static marker"),
             markerStyle: "default",
             customMarker: undefined,
             onClick: undefined

--- a/packages/pluggableWidgets/maps-web/src/components/__tests__/LeafletMap.spec.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/__tests__/LeafletMap.spec.tsx
@@ -13,10 +13,10 @@ function staticMarker(
 ): MarkersType {
     return {
         locationType: "latlng",
-        latitude: dynamic(latitude),
-        longitude: dynamic(longitude),
-        address: dynamic(""),
-        title: dynamic(opts?.title ?? ""),
+        latitude: dynamic.available(latitude),
+        longitude: dynamic.available(longitude),
+        address: dynamic.available(""),
+        title: dynamic.available(opts?.title ?? ""),
         markerStyle: opts?.customMarker ? "image" : "default",
         customMarker: opts?.customMarker ? ({ value: { uri: opts.customMarker } } as any) : undefined,
         onClick: opts?.onClick ? ({ canExecute: true, execute: opts.onClick } as any) : undefined


### PR DESCRIPTION
## Summary
  - maps-web test mocks still called the removed bare dynamic(value) helper, breaking CI code quality check on main
  - Migrated to dynamic.available(value) per the refactor in commit b6f8b2685

  ## Test plan
  - [x] pnpm run test in packages/pluggableWidgets/maps-web — 12 suites / 90 tests pass