### PR TITLE
[WC-3501]: fix(combobox-web): fix inverted editability logic

### DIFF
--- a/packages/pluggableWidgets/combobox-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/combobox-web/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the custom editability condition (`never` or `conditionally`) was ignored when the combobox attribute was present and editable.
+
+- We fixed an issue where the editability setting was inverted: setting editability to `false` allowed editing, and setting it to `true` prevented editing. The editability condition expression now behaves correctly: `true` means editable, `false` means read-only.
+
+### Breaking changes
+
+- The editability fix above is a potential breaking change. Apps that worked around the bug by inverting their editability expression will now have the opposite (incorrect) behavior after upgrading. Review any combobox widgets using a custom editability expression and remove the inversion workaround, otherwise fields may unexpectedly become editable or read-only.
+
 ## [2.8.2] - 2026-07-17
 
 ### Fixed

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Database/__tests__/utils.spec.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Database/__tests__/utils.spec.ts
@@ -1,0 +1,156 @@
+import Big from "big.js";
+import { EditableValue } from "mendix";
+import { dynamic, EditableValueBuilder } from "@mendix/widget-plugin-test-utils";
+import { getReadonly } from "../utils";
+
+describe("getReadonly", () => {
+    describe("when targetAttribute is readOnly", () => {
+        it("is read-only regardless of customEditability 'default'", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").isReadOnly().build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "default",
+                dynamic.available(true)
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it("is read-only regardless of customEditability 'never'", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").isReadOnly().build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "never",
+                dynamic.available(true)
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it("is read-only regardless of customEditability 'conditionally' with expression true", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").isReadOnly().build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "conditionally",
+                dynamic.available(true)
+            );
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe("when targetAttribute is editable", () => {
+        it("is editable when customEditability is 'default'", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "default",
+                dynamic.available(true)
+            );
+
+            expect(result).toBe(false);
+        });
+
+        it("is read-only when customEditability is 'never'", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "never",
+                dynamic.available(true)
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it("is read-only when customEditability is 'conditionally' and expression value is false", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "conditionally",
+                dynamic.available(false)
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it("is editable when customEditability is 'conditionally' and expression value is true", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "conditionally",
+                dynamic.available(true)
+            );
+
+            expect(result).toBe(false);
+        });
+
+        it("is read-only when customEditability is 'conditionally' and expression is loading", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "conditionally",
+                dynamic.loading()
+            );
+
+            expect(result).toBe(true);
+        });
+
+        it("is read-only when customEditability is 'conditionally' and expression is unavailable", () => {
+            const targetAttribute = new EditableValueBuilder<string>().withValue("value").build();
+
+            const result = getReadonly(
+                targetAttribute as unknown as EditableValue<string | Big>,
+                "conditionally",
+                dynamic.unavailable()
+            );
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe("when targetAttribute is undefined", () => {
+        it("is read-only when customEditability is 'never'", () => {
+            const result = getReadonly(undefined, "never", dynamic.available(true));
+
+            expect(result).toBe(true);
+        });
+
+        it("is editable when customEditability is 'default'", () => {
+            const result = getReadonly(undefined, "default", dynamic.available(false));
+
+            expect(result).toBe(false);
+        });
+
+        it("is read-only when customEditability is 'conditionally' and expression value is false", () => {
+            const result = getReadonly(undefined, "conditionally", dynamic.available(false));
+
+            expect(result).toBe(true);
+        });
+
+        it("is editable when customEditability is 'conditionally' and expression value is true", () => {
+            const result = getReadonly(undefined, "conditionally", dynamic.available(true));
+
+            expect(result).toBe(false);
+        });
+
+        it("is read-only when customEditability is 'conditionally' and expression is loading", () => {
+            const result = getReadonly(undefined, "conditionally", dynamic.loading());
+
+            expect(result).toBe(true);
+        });
+
+        it("is read-only when customEditability is 'conditionally' and expression is unavailable", () => {
+            const result = getReadonly(undefined, "conditionally", dynamic.unavailable());
+
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/packages/pluggableWidgets/combobox-web/src/helpers/Database/utils.ts
+++ b/packages/pluggableWidgets/combobox-web/src/helpers/Database/utils.ts
@@ -99,14 +99,14 @@ export function getReadonly(
     customEditability: ComboboxContainerProps["customEditability"],
     customEditabilityExpression: ComboboxContainerProps["customEditabilityExpression"]
 ): boolean {
-    if (targetAttribute) {
-        return targetAttribute.readOnly;
+    if (targetAttribute?.readOnly) {
+        return true;
     }
     if (customEditability === "never") {
         return true;
     }
-    if (customEditability === "conditionally") {
-        return customEditabilityExpression.value ?? true;
+    if (customEditability === "conditionally" && customEditabilityExpression.value !== true) {
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
## Summary

- Fixed a bug in `getReadonly()` where the `conditionally` editability mode had inverted logic: `expression.value = true` (meaning "editable") was being returned directly as the read-only flag, making the widget read-only when it should be editable, and vice versa.
- Fixed a related bug where the presence of an editable `targetAttribute` caused the function to return early with `false` (editable), bypassing the custom editability condition entirely. Now `targetAttribute` only short-circuits when it is explicitly read-only.
- Added unit tests covering all branches of `getReadonly`.

## Root cause

Two issues in `getReadonly`:
1. The original early-return on `targetAttribute` presence meant any editable attribute would always report the widget as editable, ignoring the `never` or `conditionally` settings.
2. The `conditionally` branch returned `customEditabilityExpression.value ?? true` directly, where the expression represents *editability* (true = editable), so the boolean was inverted.

