### PR TITLE
chore(changelogs): document broken Dojo bundle fix for 7 widgets

### DIFF
--- a/packages/pluggableWidgets/color-picker-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/color-picker-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the widget was not loading in the Dojo client due to a broken JavaScript bundle.
+
 ## [2.1.7] - 2026-06-19
 
 ### Fixed

--- a/packages/pluggableWidgets/document-viewer-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/document-viewer-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the widget was not loading in the Dojo client due to a broken JavaScript bundle.
+
 ## [1.2.1] - 2026-06-19
 
 ### Changed

--- a/packages/pluggableWidgets/html-element-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/html-element-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the widget was not loading in the Dojo client due to a broken JavaScript bundle.
+
 ## [1.2.9] - 2026-06-23
 
 ### Security

--- a/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the widget was not loading in the Dojo client due to a broken JavaScript bundle.
+
 ## [4.3.0] - 2026-06-18
 
 ### Fixed

--- a/packages/pluggableWidgets/range-slider-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/range-slider-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the widget was not loading in the Dojo client due to a broken JavaScript bundle.
+
 ## [3.0.2] - 2026-06-15
 
 ### Fixed

--- a/packages/pluggableWidgets/signature-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/signature-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the widget was not loading in the Dojo client due to a broken JavaScript bundle.
+
 ## [2.0.0] - 2026-06-22
 
 ### Breaking changes

--- a/packages/pluggableWidgets/slider-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/slider-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the widget was not loading in the Dojo client due to a broken JavaScript bundle.
+
 ## [3.0.3] - 2026-06-15
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Adds `[Unreleased]` changelog entry to 7 widgets whose released builds emitted broken JS bundles that failed to load in the Dojo client
- Root cause: the dependency update in #2252 caused Babel helpers to be emitted as dangling top-level functions instead of inside the AMD `define([...])` wrapper; fixed in #2291
- Affected widgets: slider-web (3.0.3), range-slider-web (3.0.2), html-element-web (1.2.8 & 1.2.9), popup-menu-web (4.3.0), color-picker-web (2.1.7), document-viewer-web (1.2.1), signature-web (2.0.0)
- `data-widgets` already has the fix captured in its 3.11.2 release changelog

## Test plan

- [ ] Verify `[Unreleased]` section is present and correct in all 7 widget CHANGELOGs
- [ ] No version bumps — those happen at release time, one widget at a time