### PR TITLE
[WC-3549]: fix(file-uploader-web): offline suport

### DIFF
--- a/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where thumbnails were not displayed correctly in offline mode. The widget now correctly displays thumbnails for files that have been uploaded while offline.
+
 ### Changed
 
 - Since version 2.5.0, removing a file with the default remove button removes the entry from the file list immediately, instead of leaving it in the list greyed out. This matches how removal already worked when custom buttons are configured. This change was missing from the 2.5.0 release notes.

--- a/packages/pluggableWidgets/file-uploader-web/src/components/FileEntry.tsx
+++ b/packages/pluggableWidgets/file-uploader-web/src/components/FileEntry.tsx
@@ -39,6 +39,7 @@ export const FileEntryContainer = observer(({ store, actions }: FileEntryContain
             errorMessage={store.errorDescription}
             defaultAction={defaultListAction && store.canExecute(defaultListAction) ? onDefaultAction : undefined}
             actions={<ActionsBar actions={actions} store={store} />}
+            onThumbnailError={() => store.handleThumbnailError()}
         />
     );
 });
@@ -53,6 +54,7 @@ interface FileEntryProps {
     errorMessage?: string;
 
     defaultAction?: () => void;
+    onThumbnailError?: () => void;
 
     actions?: ReactNode;
 }
@@ -98,7 +100,12 @@ function FileEntry(props: FileEntryProps): ReactElement {
                     })}
                 >
                     {props.thumbnail ? (
-                        <img className={"image-preview"} src={props.thumbnail} alt="" />
+                        <img
+                            className={"image-preview"}
+                            src={props.thumbnail}
+                            alt=""
+                            onError={props.onThumbnailError}
+                        />
                     ) : (
                         <FileIcon mimeType={props.mimeType} />
                     )}

--- a/packages/pluggableWidgets/file-uploader-web/src/components/__tests__/FileEntry.spec.tsx
+++ b/packages/pluggableWidgets/file-uploader-web/src/components/__tests__/FileEntry.spec.tsx
@@ -1,0 +1,93 @@
+import "@testing-library/jest-dom";
+import { Big } from "big.js";
+import { fireEvent, render } from "@testing-library/react";
+import { dynamic } from "@mendix/widget-plugin-test-utils";
+import { FileUploaderContainerProps } from "../../../typings/FileUploaderProps";
+import { FileStore } from "../../stores/FileStore";
+import { TranslationsStoreProvider } from "../../utils/useTranslationsStore";
+import { FileEntryContainer } from "../FileEntry";
+
+jest.mock("../../utils/mx-data", () => ({
+    fetchDocumentUrl: jest.fn(),
+    fetchImageThumbnail: jest.fn(),
+    fetchMxObject: jest.fn(),
+    removeObject: jest.fn(),
+    saveFile: jest.fn(),
+    fileHasContents: jest.fn()
+}));
+
+jest.mock("../../utils/useRootStore", () => ({
+    useRootStore: () => ({ maxTotalFiles: 5, isReadOnly: false })
+}));
+
+function makeFakeProps(): FileUploaderContainerProps {
+    return {
+        name: "fileUploader1",
+        uploadMode: "images",
+        maxFileSize: 10,
+        maxFilesPerUpload: dynamic.available(new Big(5)),
+        readOnlyMode: false,
+        objectCreationTimeout: 30,
+        allowedFileFormats: "",
+        removeButtonTextMessage: dynamic.available("Remove"),
+        downloadButtonTextMessage: dynamic.available("Download"),
+        unavailableCreateActionMessage: dynamic.available("Unavailable"),
+        uploadFailureTooManyFilesMessage: dynamic.available("Too many"),
+        uploadFailureInvalidFileFormatMessage: dynamic.available("Invalid format"),
+        uploadFailureFileIsTooBigMessage: dynamic.available("Too big")
+    } as unknown as FileUploaderContainerProps;
+}
+
+function makeImageStore(thumbnailUrl: string): FileStore {
+    const rootStore = {
+        dismissFile: jest.fn(),
+        _uploadMode: "images",
+        uploadMode: "images",
+        isReadOnly: false,
+        isFileUploadLimitReached: false
+    } as any;
+    const store = FileStore.newFile(new File([], "img.jpg"), rootStore);
+    (store as any)._thumbnailUrl = thumbnailUrl;
+    (store as any)._documentUrl = "http://host/doc.jpg";
+    return store;
+}
+
+function renderWithTranslations(store: FileStore): ReturnType<typeof render> {
+    const props = makeFakeProps();
+    return render(
+        <TranslationsStoreProvider props={props}>
+            <FileEntryContainer store={store} />
+        </TranslationsStoreProvider>
+    );
+}
+
+describe("FileEntryContainer thumbnail onError", () => {
+    it("calls store.handleThumbnailError() when the img fires an error event", () => {
+        const store = makeImageStore("http://cdn/thumb.jpg");
+        const spy = jest.spyOn(store, "handleThumbnailError");
+
+        const { container } = renderWithTranslations(store);
+
+        // img has alt="" so RTL assigns role "presentation" — query directly
+        const img = container.querySelector("img.image-preview")!;
+        expect(img).not.toBeNull();
+        fireEvent.error(img);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not render an img when no thumbnail is set", () => {
+        const rootStore = {
+            dismissFile: jest.fn(),
+            _uploadMode: "images",
+            uploadMode: "images",
+            isReadOnly: false,
+            isFileUploadLimitReached: false
+        } as any;
+        const store = FileStore.newFile(new File([], "doc.pdf"), rootStore);
+
+        const { container } = renderWithTranslations(store);
+
+        expect(container.querySelector("img.image-preview")).toBeNull();
+    });
+});

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/FileStore.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/FileStore.ts
@@ -38,6 +38,8 @@ export class FileStore {
     private _objectItem?: ObjectItem = undefined;
     private _mxObject?: MxObject = undefined;
     private _thumbnailUrl?: string = undefined;
+    private _documentUrl?: string = undefined;
+    private _thumbnailFailed: boolean = false;
     private _rootStore: FileUploaderStore;
 
     key: number;
@@ -51,11 +53,13 @@ export class FileStore {
         this._rootStore = rootStore;
         this.fileStatus = type;
 
-        makeObservable<this, "_mxObject" | "_thumbnailUrl">(this, {
+        makeObservable<this, "_mxObject" | "_thumbnailUrl" | "_documentUrl" | "_thumbnailFailed">(this, {
             fileStatus: observable,
             _mxObject: observable,
             errorDescription: observable,
             _thumbnailUrl: observable,
+            _documentUrl: observable,
+            _thumbnailFailed: observable,
             canRemove: computed,
             canRetry: computed,
             imagePreviewUrl: computed,
@@ -64,7 +68,8 @@ export class FileStore {
             markMissing: action,
             setQueued: action,
             retry: action,
-            dismiss: action
+            dismiss: action,
+            handleThumbnailError: action
         });
     }
 
@@ -212,16 +217,25 @@ export class FileStore {
         }
     }
 
+    handleThumbnailError(): void {
+        this._thumbnailFailed = true;
+    }
+
     async updateThumbnailUrl(): Promise<void> {
         if (this._rootStore.uploadMode !== "images") {
             return;
         }
 
         this._thumbnailUrl = undefined;
+        this._thumbnailFailed = false;
         if (this._mxObject) {
-            const url = await fetchImageThumbnail(this._mxObject);
+            const [thumbnailUrl, documentUrl] = await Promise.all([
+                fetchImageThumbnail(this._mxObject),
+                fetchDocumentUrl(this._mxObject)
+            ]);
             runInAction(() => {
-                this._thumbnailUrl = url;
+                this._thumbnailUrl = thumbnailUrl;
+                this._documentUrl = documentUrl;
             });
         }
     }
@@ -237,6 +251,9 @@ export class FileStore {
             return;
         }
 
+        if (this._thumbnailFailed) {
+            return this._documentUrl;
+        }
         if (this._thumbnailUrl) {
             return this._thumbnailUrl;
         }

--- a/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileStore.spec.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/stores/__tests__/FileStore.spec.ts
@@ -10,10 +10,11 @@ jest.mock("../../utils/mx-data", () => ({
     fileHasContents: jest.fn()
 }));
 
-function makeRootStore(): { dismissFile: jest.Mock } {
+function makeRootStore(uploadMode: "files" | "images" = "files"): FileUploaderStore & { dismissFile: jest.Mock } {
     return {
         dismissFile: jest.fn(),
-        _uploadMode: "files",
+        _uploadMode: uploadMode,
+        uploadMode,
         isReadOnly: false
     } as unknown as FileUploaderStore & { dismissFile: jest.Mock };
 }
@@ -25,5 +26,42 @@ describe("FileStore.dismiss()", () => {
         store.dismiss();
         expect(rootStore.dismissFile).toHaveBeenCalledTimes(1);
         expect(rootStore.dismissFile).toHaveBeenCalledWith(store);
+    });
+});
+
+describe("FileStore.imagePreviewUrl thumbnail fallback", () => {
+    function makeImageStore(): FileStore {
+        const rootStore = makeRootStore("images");
+        const store = FileStore.newFile(new File([], "img.jpg"), rootStore as any);
+        (store as any)._thumbnailUrl = "http://cdn/thumb.jpg";
+        (store as any)._documentUrl = "http://host/doc.jpg";
+        return store;
+    }
+
+    it("returns thumbnailUrl when no error has occurred", () => {
+        const store = makeImageStore();
+        expect(store.imagePreviewUrl).toBe("http://cdn/thumb.jpg");
+    });
+
+    it("returns documentUrl after handleThumbnailError()", () => {
+        const store = makeImageStore();
+        store.handleThumbnailError();
+        expect(store.imagePreviewUrl).toBe("http://host/doc.jpg");
+    });
+
+    it("returns documentUrl on repeated handleThumbnailError() calls (no loop)", () => {
+        const store = makeImageStore();
+        store.handleThumbnailError();
+        store.handleThumbnailError();
+        expect(store.imagePreviewUrl).toBe("http://host/doc.jpg");
+    });
+
+    it("returns undefined in files uploadMode even after handleThumbnailError()", () => {
+        const rootStore = makeRootStore("files");
+        const store = FileStore.newFile(new File([], "doc.pdf"), rootStore as any);
+        (store as any)._thumbnailUrl = "http://cdn/thumb.jpg";
+        (store as any)._documentUrl = "http://host/doc.pdf";
+        store.handleThumbnailError();
+        expect(store.imagePreviewUrl).toBeUndefined();
     });
 });

--- a/packages/pluggableWidgets/file-uploader-web/src/utils/__tests__/mx-data.spec.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/utils/__tests__/mx-data.spec.ts
@@ -1,0 +1,88 @@
+import { fetchDocumentUrl, fetchImageThumbnail, saveFile } from "../mx-data";
+
+function makeMxObject(name = "file.jpg") {
+    return {
+        getGuid: () => "guid-123",
+        get: (_attr: string) => "2024-01-01T00:00:00.000Z",
+        get2: (attr: string) => (attr === "Name" ? name : undefined)
+    };
+}
+
+beforeEach(() => {
+    (window as any).mx = undefined;
+});
+
+describe("saveFile", () => {
+    it("passes file.name as the second argument to saveDocument", () => {
+        const saveDocument = jest.fn((_id, _name, _meta, _file, resolve) => resolve());
+        (window as any).mx = { data: { saveDocument } };
+
+        const item = { id: "obj-1" } as any;
+        const file = new File(["data"], "photo.jpg", { type: "image/jpeg" });
+
+        return saveFile(item, file).then(() => {
+            expect(saveDocument).toHaveBeenCalledWith(
+                "obj-1",
+                "photo.jpg",
+                {},
+                file,
+                expect.any(Function),
+                expect.any(Function)
+            );
+        });
+    });
+
+    it("forwards the file blob itself as the fourth argument", () => {
+        const saveDocument = jest.fn((_id, _name, _meta, _file, resolve) => resolve());
+        (window as any).mx = { data: { saveDocument } };
+
+        const item = { id: "obj-2" } as any;
+        const file = new File(["content"], "report.pdf");
+
+        return saveFile(item, file).then(() => {
+            expect(saveDocument.mock.calls[0][3]).toBe(file);
+        });
+    });
+});
+
+describe("fetchDocumentUrl", () => {
+    it("passes mxObject.get2('Name') as the fourth argument to getDocumentUrl", async () => {
+        const getDocumentUrl = jest.fn().mockResolvedValue("http://host/doc");
+        (window as any).mx = { data: { getDocumentUrl } };
+
+        await fetchDocumentUrl(makeMxObject("report.pdf") as any);
+
+        expect(getDocumentUrl).toHaveBeenCalledWith("guid-123", expect.anything(), false, "report.pdf");
+    });
+
+    it("requests a non-thumbnail URL (thumb=false)", async () => {
+        const getDocumentUrl = jest.fn().mockResolvedValue("http://host/doc");
+        (window as any).mx = { data: { getDocumentUrl } };
+
+        await fetchDocumentUrl(makeMxObject() as any);
+
+        expect(getDocumentUrl.mock.calls[0][2]).toBe(false);
+    });
+});
+
+describe("fetchImageThumbnail", () => {
+    it("passes mxObject.get2('Name') as the fourth argument to getDocumentUrl", async () => {
+        const getDocumentUrl = jest.fn().mockResolvedValue("http://host/thumb-url");
+        const getImageUrl = jest.fn((_url, resolve) => resolve("http://host/thumb.jpg"));
+        (window as any).mx = { data: { getDocumentUrl, getImageUrl } };
+
+        await fetchImageThumbnail(makeMxObject("banner.png") as any);
+
+        expect(getDocumentUrl).toHaveBeenCalledWith("guid-123", expect.anything(), true, "banner.png");
+    });
+
+    it("requests a thumbnail URL (thumb=true)", async () => {
+        const getDocumentUrl = jest.fn().mockResolvedValue("http://host/thumb-url");
+        const getImageUrl = jest.fn((_url, resolve) => resolve("http://host/thumb.jpg"));
+        (window as any).mx = { data: { getDocumentUrl, getImageUrl } };
+
+        await fetchImageThumbnail(makeMxObject() as any);
+
+        expect(getDocumentUrl.mock.calls[0][2]).toBe(true);
+    });
+});

--- a/packages/pluggableWidgets/file-uploader-web/src/utils/mx-data.ts
+++ b/packages/pluggableWidgets/file-uploader-web/src/utils/mx-data.ts
@@ -8,9 +8,9 @@ export type MxObject = {
     get2(name: string): string | Big | boolean;
 };
 
-export function saveFile(item: ObjectItem, fileToUpload: Blob): Promise<void> {
+export function saveFile(item: ObjectItem, fileToUpload: File): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-        (window as any).mx.data.saveDocument(item.id, null, {}, fileToUpload, resolve, reject);
+        (window as any).mx.data.saveDocument(item.id, fileToUpload.name, {}, fileToUpload, resolve, reject);
     });
 }
 
@@ -40,11 +40,21 @@ export function fetchMxObject(objectItem: ObjectItem): Promise<MxObject> {
 }
 
 export async function fetchDocumentUrl(mxObject: MxObject): Promise<string> {
-    return (window as any).mx.data.getDocumentUrl(mxObject.getGuid(), mxObject.get("changedDate"), false);
+    return (window as any).mx.data.getDocumentUrl(
+        mxObject.getGuid(),
+        mxObject.get("changedDate"),
+        false,
+        mxObject.get2("Name")
+    );
 }
 
 export async function fetchImageThumbnail(mxObject: MxObject): Promise<string> {
-    const docUrl = await (window as any).mx.data.getDocumentUrl(mxObject.getGuid(), mxObject.get("changedDate"), true);
+    const docUrl = await (window as any).mx.data.getDocumentUrl(
+        mxObject.getGuid(),
+        mxObject.get("changedDate"),
+        true,
+        mxObject.get2("Name")
+    );
     return new Promise<string>((resolve, reject) => {
         (window as any).mx.data.getImageUrl(docUrl, resolve, reject);
     });


### PR DESCRIPTION
Potential solution for [Support ticket #283525](https://support.mendix.com/hc/en-us/requests/283525)

We have encountered an issue with the Mendix FileUploader widget from the marketplace when using PWA offline synchronization profiles. Although the widget is marked as offline-compatible in the source code (https://github.com/mendix/web-widgets/blob/main/packages/pluggableWidgets/file-uploader-web/src/FileUploader.xml#L2C106-L2C129), image previews fail to display during multi-file uploads in PWA offline mode. It does not set the file name correctly, and image can not be displayed in the app.

Note that single file uploads work correctly with the default File Uploader included in Studio Pro.

<img width="405" height="795" alt="TestPWA_UploadOfflineImages" src="https://github.com/user-attachments/assets/6158fcd2-3213-442f-b0fb-c23d8478a83a" />