### PR TITLE
[WC-3517]: Set default max height to 250px for Image widget

### DIFF
--- a/packages/pluggableWidgets/image-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/image-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- We changed the default maximum height to 250 pixels for new Image widgets. Existing widgets are not affected.
+
 ### Fixed
 
 - We fixed an issue where previews in Design and Structure modes did not respect the configured minimum and maximum image height.

--- a/packages/pluggableWidgets/image-web/e2e/onClick.spec.js
+++ b/packages/pluggableWidgets/image-web/e2e/onClick.spec.js
@@ -5,36 +5,42 @@ test.describe("Image viewer", () => {
     const dynamicImage =
         "https://www.learningcontainer.com/wp-content/uploads/2020/08/Sample-png-Image-for-Testing.png";
 
+    const imageButton = (page, widgetClass) => page.locator(`${widgetClass} [role='button']`);
+
     test("triggers a Microflow on click", async ({ page }) => {
         await page.goto("/p/onClickMicroflow");
         await waitForMendixApp(page);
-        await page.click(".mx-name-image1");
-        const modalDialog = await page.locator(".modal-dialog");
+        await imageButton(page, ".mx-name-image1").click();
+        const modalDialog = page.locator(".modal-dialog");
+        await expect(modalDialog).toBeVisible();
         await expect(modalDialog).toContainText("You clicked this image");
     });
 
     test("triggers a Nanoflow on click", async ({ page }) => {
         await page.goto("/p/onClickNanoflow");
         await waitForMendixApp(page);
-        await page.click(".mx-name-image1");
-        const modalDialog = await page.locator(".modal-dialog");
+        await imageButton(page, ".mx-name-image1").click();
+        const modalDialog = page.locator(".modal-dialog");
+        await expect(modalDialog).toBeVisible();
         await expect(modalDialog).toContainText(dynamicImage);
     });
 
     test("opens a Page on click", async ({ page }) => {
         await page.goto("/p/onClickShowPage");
         await waitForMendixApp(page);
-        await page.click(".mx-name-image1");
-        const modalDialog = await page.locator(".modal-dialog");
-        const caption = await modalDialog.locator("#mxui_widget_Window_0_caption");
+        await imageButton(page, ".mx-name-image1").click();
+        const modalDialog = page.locator(".modal-dialog");
+        await expect(modalDialog).toBeVisible();
+        const caption = modalDialog.locator("#mxui_widget_Window_0_caption");
         await expect(caption).toContainText("GazaLand");
     });
 
     test("shows full screen image on click", async ({ page }) => {
         await page.goto("/p/onClickOpenFullScreen");
         await waitForMendixApp(page);
-        await page.click(".mx-name-imageRender1");
-        const lightboxImage = await page.locator(".mx-image-viewer-lightbox img");
+        await imageButton(page, ".mx-name-imageRender1").click();
+        const lightboxImage = page.locator(".mx-image-viewer-lightbox img");
+        await expect(lightboxImage).toBeVisible();
         await expect(lightboxImage).toHaveAttribute("src", /ImageViewer\$Images\$landscape_2\.png/);
     });
 });

--- a/packages/pluggableWidgets/image-web/src/Image.xml
+++ b/packages/pluggableWidgets/image-web/src/Image.xml
@@ -110,7 +110,7 @@
                     <caption>Minimum height</caption>
                     <description />
                 </property>
-                <property key="maxHeightUnit" type="enumeration" defaultValue="none">
+                <property key="maxHeightUnit" type="enumeration" defaultValue="pixels">
                     <caption>Maximum Height unit</caption>
                     <description />
                     <enumerationValues>
@@ -120,7 +120,7 @@
                         <enumerationValue key="viewport">Viewport</enumerationValue>
                     </enumerationValues>
                 </property>
-                <property key="maxHeight" type="integer" required="true" defaultValue="0">
+                <property key="maxHeight" type="integer" required="true" defaultValue="250">
                     <caption>Maximum height</caption>
                     <description />
                 </property>


### PR DESCRIPTION
### Pull request type

<!-- Bug fix (non-breaking change which fixes an issue) -->
Bug fix (non-breaking change which fixes an issue)

---

### Description

Currently the Image widget defaults to no maximum height (`None`). This change sets the default `maxHeightUnit` to `pixels` and `maxHeight` to `250` in the widget XML, so newly placed Image widgets come with a 250px maximum height out of the box.

Existing widgets are not affected — Mendix only applies XML default values when a widget is first added to a page, so previously placed widgets retain their current settings.

**JIRA:** [WC-3517](https://mendix.atlassian.net/browse/WC-3517)

### What should be covered while testing?

- Drag a new Image widget onto a page in Studio Pro and verify the **Maximum Height unit** is set to `Pixels` and **Maximum height** is `250` by default.
- Open an existing Image widget (placed before this change) and verify its max height settings are unchanged.

[WC-3517]: https://mendix.atlassian.net/browse/WC-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ