### PR TITLE
chore: resolve post-edit hook path via CLAUDE_PROJECT_DIR

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,7 +48,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": ".claude/hooks/post-edit.sh"
+                        "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit.sh\""
                     }
                 ]
             }


### PR DESCRIPTION
The `PostToolUse` hook command was a repo-root-relative path, so it only resolved when the shell's working directory happened to be the repo root.

Widget work follows `docs/widget-scripts.md` and runs from inside the package directory, where that path does not exist. The hook fails non-blocking, so the auto-format silently stops running and the loss is easy to miss.

`$CLAUDE_PROJECT_DIR` is set to the project root, so the path resolves regardless of working directory. Behaviour at the repo root is unchanged.