### PR TITLE
[WC-3520]: Gallery recover from stale sort-order attribute id

### DIFF
--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the Gallery widget could crash with an "invalid attribute id" error when a stored sort order referenced an attribute that was no longer available. The widget now falls back to the default sort order instead.
+
 ## [3.11.3] - 2026-07-27
 
 ### Fixed

--- a/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/.openspec.yaml
+++ b/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/design.md
+++ b/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Gallery seeds its sort state directly from `props.datasource.sortOrder` when the widget is (re)constructed:
+
+- `Gallery.container.ts` (`_04_sortBindings.init`) binds `GY.sortHostConfig` to `{ initSort: props.datasource.sortOrder }`, which flows into `SortStoreHost`.
+- `QueryParamsService.setup()` runs a MobX `reaction` with `fireImmediately: true` on `this.sort.sortOrder` and forwards whatever it contains straight to `this.query.setSortOrder(sortOrder)` (`Datasource.service.ts`), which ultimately calls the Mendix client's `ListValue.setSortOrder()`.
+- Mendix attribute ids (e.g. `attr_kaf_3`) are per-build tokens regenerated on every redeploy. A sort order persisted per-user in a personalization attribute (DB storage) therefore survives across redeploys but its attribute ids do not.
+- If the restored `sortOrder` contains an attribute id that is not present in the _current_ build's attribute set, `ListValue.setSortOrder()` throws `Sort order item: invalid attribute id '<id>'` synchronously inside the `fireImmediately` reaction — MobX catches it as an uncaught reaction exception (`onReactionError`), matching the WC-3520 stack trace exactly.
+
+Data Grid 2 does not have this bug because its `ColumnGroupStore.setColumnSettings` drops unknown `columnId`s (with a warning) and its `sortInstructions` getter re-resolves through the live columns before the sort state is ever applied. Gallery has no equivalent live re-resolution step for the props-provided `initSort` path.
+
+**Important lifecycle finding (why the fix is not in `SortOrderStore`):** In the reported repro (MIRA project, empty filter placeholder → no DropdownSort widget configured), `SortStoreHost._store` is `null`, so `SortOrderStore` is never instantiated. The stale sort order flows from `initSort` through the host straight into the `QueryParamsService` reaction, bypassing `SortOrderStore` entirely. A sanitize-on-read fix inside `SortOrderStore` (validated against its `options`) would therefore **never fire** in this configuration — the crash would survive. A diagnostic loop confirmed the stale id reaches `setSortOrder` regardless of whether a sort widget exists. The fix must sit at the choke point every sort path funnels through: the `QueryParamsService` reaction.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prevent an uncaught MobX reaction exception when a restored sort order references an attribute id the current build's runtime rejects — with or without a configured sort widget.
+- Recover to a usable state (default/unsorted order) so the Gallery renders instead of breaking.
+- Emit a diagnosable signal (`console.warn`) on fallback for support.
+- Add a regression test at the correct seam (`QueryParamsService`) proving no reaction error surfaces and the query recovers to the default sort order.
+
+**Non-Goals:**
+
+- Not changing the Mendix client runtime's `ListValue.setSortOrder()` validation behavior itself (out of repo scope) — this fix guards on the sending side only.
+- Not changing Data Grid 2's sort behavior (it is already resilient).
+- Not addressing _why_ the persisted `sortOrder` contains a stale id (attribute-id regeneration on redeploy is expected Mendix build behavior) — that is outside this widget's control.
+- Not changing the persisted personalization storage format (`toJSON`/`fromJSON` in `SortOrderStore`), which already stores indexes rather than raw attribute ids and is proven not to be the leak.
+- Not changing shared packages (`widget-plugin-sorting`, `widget-plugin-grid`).
+
+## Decisions
+
+1. **Guard at the `QueryParamsService` sort reaction, not in `SortOrderStore`.**
+   The reaction that forwards `sort.sortOrder` → `query.setSortOrder` is the single choke point every sort path passes through, whether or not a DropdownSort widget (and therefore a `SortOrderStore`) exists. The reported repro has no sort widget, so a `SortOrderStore`-level fix would not execute (see Context). Guarding at the reaction is robust to the provenance of the sort order.
+   Alternative considered and rejected: sanitize-on-read in `SortOrderStore.sortOrder`. Rejected because it does not cover the no-sort-widget path (the actual repro configuration), and it validates against the store's `options`, which are empty/absent in that configuration.
+
+2. **try/catch around `setSortOrder`, fall back to `undefined` (default order) on rejection.**
+   The runtime is the authority on which attribute ids are valid for the current build; catching its rejection is a precise signal (no need to independently re-derive the valid-id set in the widget). On rejection, applying `undefined` clears to the datasource's default order, which is guaranteed valid.
+
+3. **Emit `console.warn` on fallback, not silent drop.**
+   Unlike Data Grid 2's silent column-drop, this path is a genuine runtime rejection of persisted state. A warning makes the "why did my sort reset?" support question answerable from the browser console without being user-facing UI noise. It fires only on the (rare) rejection path, not on normal lifecycle transitions.
+
+4. **No change to `Datasource.service.ts` / shared plumbing.**
+   The `setSortOrder` pass-through there is generic and shared. The guard belongs in Gallery's own `QueryParamsService`, keeping the fix localized and avoiding behavior changes for other consumers.
+
+## Risks / Trade-offs
+
+- [Risk] Falling back to the default order means a user whose entire persisted sort is stale sees unsorted data on first load after a redeploy.
+  → Mitigation: applying the stale order would have crashed the widget entirely; recovering to default is strictly better. The next legitimate sort action re-persists valid ids. No behavior change for the common all-valid case.
+
+- [Risk] A partially-stale sort order (one valid + one stale instruction) is dropped wholesale to `undefined` rather than keeping the valid instruction.
+  → Mitigation: the runtime rejects the whole `setSortOrder` call atomically, so per-instruction salvage is not available at this seam without re-implementing the runtime's validation. Wholesale fallback is the safe, simple choice; partial salvage is a possible future enhancement if support data shows it matters.
+
+- [Risk] `console.warn` on every render if the reaction re-fires with a stale value.
+  → Mitigation: the reaction only fires on `sort.sortOrder` change; once fallback applies `undefined`, `sortOrder` settles and does not re-trigger. The warning fires once per stale restore, not per render.
+
+## Migration Plan
+
+No data migration needed (in-memory-only defensive fix, no schema/persisted-format change). Standard PR flow:
+
+1. Add regression test at `QueryParams.service.spec.ts` proving a stale attribute id no longer surfaces a reaction error and the query recovers to the default order. (Uses `onReactionError` to assert no uncaught reaction exception — a plain `not.toThrow()` gives a false green because MobX swallows reaction errors.)
+2. Implement the guarded `applySortOrder` in `QueryParamsService`.
+3. Run the full `gallery-web` test suite.
+4. Bump semver (patch) and add `CHANGELOG.md` entry for `gallery-web` (user-facing bug fix) per repo convention.
+5. Rollback: revert the single commit/PR; no persisted state or migration to unwind.
+
+## Open Questions
+
+- Should a partially-stale sort order salvage the valid instructions rather than falling back wholesale to default? Deferred pending support data — the runtime rejects atomically, so this needs per-instruction pre-validation to implement.
+- Verified against a real repro: the crash reproduces without the fix and does not with it. (The initial local MIRA project could not be made to reproduce — storage attribute set to none, no login, no data — so a proper repro project was used to confirm.)

--- a/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/proposal.md
+++ b/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Gallery widget throws an uncaught MobX reaction error — `Sort order item: invalid attribute id '<id>'` — when the sort order restored from `datasource.sortOrder` on a subsequent app run/session references an attribute id that is no longer valid. Mendix attribute ids are per-build tokens that are regenerated on redeploy, so a sort order persisted in a personalization attribute (DB, per-user) can reference an id that no longer exists in the current build. Gallery forwards this restored sort order into `ListValue.setSortOrder()` without guarding against rejection, so the invalid id reaches the Mendix client runtime, `setSortOrder` throws synchronously inside a `fireImmediately` MobX reaction, and MobX surfaces it as an uncaught reaction exception that breaks the widget. Data Grid 2 does not exhibit this bug because it re-resolves restored sort state against its live columns before applying it (WC-3520).
+
+## What Changes
+
+- `QueryParamsService` (Gallery) guards the forwarding of sort order to `ListValue.setSortOrder()`: if the runtime rejects the sort order (invalid/stale attribute id), the error is caught and the query falls back to the default (unsorted) order instead of letting the exception escape the reaction.
+- A `console.warn` is emitted on fallback so the reset is diagnosable in support scenarios, rather than failing silently or crashing.
+- Add regression coverage in `gallery-web` proving a restored sort order with a stale attribute id no longer surfaces an uncaught reaction error and recovers to the default sort order.
+
+## Capabilities
+
+### New Capabilities
+
+- `gallery-sort-order-validation`: Gallery-specific behavior that guards the application of a restored (persisted or props-provided) sort order to the datasource, recovering to the default sort order if the runtime rejects a sort instruction whose attribute id is no longer valid, mirroring the resilience Data Grid 2 already has.
+
+### Modified Capabilities
+
+_None — no existing `openspec/specs/` capability spec currently documents Gallery sort-order restoration behavior, so this is captured as a new capability rather than a delta._
+
+## Impact
+
+- `packages/pluggableWidgets/gallery-web/src/model/services/QueryParams.service.ts` — the fix site. The `sortOrder` reaction now forwards through a guarded `applySortOrder` helper (try/catch around `setSortOrder`, fall back to `undefined` on rejection).
+- `packages/pluggableWidgets/gallery-web/src/model/services/__tests__/QueryParams.service.spec.ts` — new regression test.
+- `packages/pluggableWidgets/gallery-web/CHANGELOG.md` — user-facing fix entry.
+- No XML/property schema changes. No breaking changes to widget public API. No changes to shared packages (`widget-plugin-sorting`, `widget-plugin-grid`). Fix is defensive and localized to Gallery's `QueryParamsService`.

--- a/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/specs/gallery-sort-order-validation/spec.md
+++ b/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/specs/gallery-sort-order-validation/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Applying a restored sort order never surfaces an uncaught reaction error
+
+When the Gallery widget forwards a restored (persisted or props-provided) sort order to the datasource, a rejection by the Mendix runtime — such as a sort instruction whose attribute id is no longer valid for the current app build — SHALL NOT escape as an uncaught MobX reaction exception. The widget SHALL catch the rejection and recover to the datasource's default sort order so it remains usable.
+
+This guard SHALL apply on the path every sort order takes into the datasource, regardless of whether a sort widget (DropdownSort) is configured — i.e. it SHALL NOT depend on a `SortOrderStore` being instantiated.
+
+#### Scenario: Restored sort order contains a stale attribute id
+
+- **WHEN** the widget is initialized with a `datasource.sortOrder` restored from a previous session/run that references an attribute id no longer present in the current app build
+- **THEN** the runtime rejection is caught, the query is set to the default (unsorted) order, and no uncaught reaction exception is surfaced
+
+#### Scenario: Restored sort order contains only currently valid attribute ids
+
+- **WHEN** the widget is initialized with a `datasource.sortOrder` where every attribute id is valid for the current build
+- **THEN** the full sort order is applied to the datasource unchanged, preserving order and direction
+
+#### Scenario: No sort widget configured
+
+- **WHEN** the widget has no DropdownSort configured (so no `SortOrderStore` exists) and the props-provided sort order references a stale attribute id
+- **THEN** the guard still catches the runtime rejection and recovers to the default order, because the guard sits on the shared forwarding path rather than in the sort store
+
+### Requirement: Sort-order fallback is diagnosable, not silent
+
+When the widget recovers from a rejected sort order, it SHALL emit a `console.warn` explaining that the stored sort order was ignored because it references an attribute that is no longer available. This warning SHALL fire only on the rejection/fallback path, not during normal sort application.
+
+#### Scenario: Fallback emits a warning
+
+- **WHEN** a restored sort order is rejected by the runtime and the widget falls back to the default order
+- **THEN** a `console.warn` is emitted describing the ignored sort order and including the underlying error, so the reset is diagnosable from the browser console

--- a/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/tasks.md
+++ b/packages/pluggableWidgets/gallery-web/openspec/changes/fix-stale-sort-order-attribute/tasks.md
@@ -1,0 +1,26 @@
+## 1. Implement guard in QueryParamsService
+
+- [x] 1.1 Route the `sort.sortOrder` reaction handler through a private `applySortOrder(sortOrder)` helper instead of calling `this.query.setSortOrder` directly.
+- [x] 1.2 In `applySortOrder`, wrap `this.query.setSortOrder(sortOrder)` in try/catch; on rejection, call `this.query.setSortOrder(undefined)` to fall back to the default order.
+- [x] 1.3 Emit a `console.warn` on the catch path explaining the sort order was ignored because it references an attribute that is no longer available, including the caught error.
+- [x] 1.4 Add a code comment referencing WC-3520 and the attribute-id-regeneration-on-redeploy root cause.
+
+## 2. Regression test (QueryParams.service.spec.ts)
+
+- [x] 2.1 Build a `queryStub(validIds)` whose `setSortOrder` throws `Sort order item: invalid attribute id '<id>'` for any id not in `validIds`, mirroring the Mendix runtime.
+- [x] 2.2 Register an `onReactionError` hook and assert it collected no errors — a plain `expect(...).not.toThrow()` gives a FALSE GREEN because MobX swallows reaction exceptions.
+- [x] 2.3 Test: valid sort order is applied to the query unchanged.
+- [x] 2.4 Test: a stale/invalid attribute id does not surface a reaction error.
+- [x] 2.5 Test: on an invalid id, the query recovers to the default order (`query.applied.at(-1)` is `undefined`).
+- [ ] 2.6 Run `cd packages/pluggableWidgets/gallery-web && pnpm run test -t "QueryParamsService"` and confirm all three pass; confirm the suite is RED before the Task 1 fix and GREEN after.
+
+## 3. Widget-level verification
+
+- [x] 3.1 A/B verified against a real test project: crash reproduces without the fix, does not with it. (Initial local MIRA project could not reproduce — storage attribute set to none, no login, no data — so a proper repro project was used.)
+- [x] 3.2 Confirm no XML/property schema changes are needed (none — fix is internal to `QueryParamsService`).
+
+## 4. Release hygiene
+
+- [ ] 4.1 Confirm `gallery-web` package.json version bump (patch) is present for the release.
+- [x] 4.2 Add a `CHANGELOG.md` entry for `gallery-web` describing the user-facing fix.
+- [ ] 4.3 Confirm lint/build pass for `gallery-web` (auto-lint hook runs on edit; verify no outstanding errors).

--- a/packages/pluggableWidgets/gallery-web/src/model/services/QueryParams.service.ts
+++ b/packages/pluggableWidgets/gallery-web/src/model/services/QueryParams.service.ts
@@ -27,7 +27,7 @@ export class QueryParamsService implements SetupComponent {
         add(
             reaction(
                 () => this.sort.sortOrder,
-                sortOrder => this.query.setSortOrder(sortOrder),
+                sortOrder => this.applySortOrder(sortOrder),
                 { fireImmediately: true }
             )
         );
@@ -40,5 +40,27 @@ export class QueryParamsService implements SetupComponent {
         );
 
         return disposeAll;
+    }
+
+    /**
+     * Forward the sort order to the datasource. A stored/restored sort instruction
+     * may reference an attribute id that no longer exists in the current app build
+     * (attribute ids are regenerated on redeploy). The Mendix runtime rejects such
+     * ids from setSortOrder with "invalid attribute id", which — thrown inside a
+     * mobx reaction — surfaces as an uncaught reaction error and breaks the widget
+     * (WC-3520). Guard against it: on rejection, fall back to the default (unsorted)
+     * order so the gallery stays usable.
+     */
+    private applySortOrder(sortOrder: SortInstruction[] | undefined): void {
+        try {
+            this.query.setSortOrder(sortOrder);
+        } catch (error) {
+            console.warn(
+                "Gallery: ignoring stored sort order because it references an attribute " +
+                    "that is no longer available. Resetting to default sort order.",
+                error
+            );
+            this.query.setSortOrder(undefined);
+        }
     }
 }

--- a/packages/pluggableWidgets/gallery-web/src/model/services/__tests__/QueryParams.service.spec.ts
+++ b/packages/pluggableWidgets/gallery-web/src/model/services/__tests__/QueryParams.service.spec.ts
@@ -1,0 +1,109 @@
+import { SetupComponentHost } from "@mendix/widget-plugin-mobx-kit/main";
+import { attrId } from "@mendix/widget-plugin-test-utils";
+import { ListAttributeId, SortInstruction } from "@mendix/widget-plugin-sorting/types/store";
+import { FilterCondition } from "mendix/filters";
+import { configure, observable, onReactionError } from "mobx";
+import { QueryParamsService } from "../QueryParams.service";
+
+const ATTR_A = attrId("a");
+const ATTR_B = attrId("b");
+const ATTR_STALE = attrId("kaf_3"); // gone after re-deploy
+
+configure({ enforceActions: "never" });
+
+/**
+ * Minimal SetupComponentHost that collects and runs setups synchronously,
+ * mirroring how the DI container drives services.
+ */
+function testHost(): { host: SetupComponentHost; start: () => () => void } {
+    const components: Array<{ setup(): void | (() => void) }> = [];
+    const host: SetupComponentHost = {
+        add(component) {
+            components.push(component);
+        }
+    } as SetupComponentHost;
+
+    const start = (): (() => void) => {
+        const disposers = components.map(c => c.setup()).filter(Boolean) as Array<() => void>;
+        return () => disposers.forEach(d => d());
+    };
+
+    return { host, start };
+}
+
+/**
+ * Query stub that mirrors the Mendix runtime: setSortOrder throws
+ * `assertIsValidSortOrder`-style when handed an attribute id that is not
+ * part of the current datasource's valid attribute set.
+ */
+function queryStub(validIds: ListAttributeId[]) {
+    const applied: Array<SortInstruction[] | undefined> = [];
+    return {
+        applied,
+        setSortOrder: jest.fn((order?: SortInstruction[]) => {
+            for (const [id] of order ?? []) {
+                if (!validIds.includes(id)) {
+                    throw new Error(`Sort order item: invalid attribute id '${id}'`);
+                }
+            }
+            applied.push(order);
+        }),
+        setFilter: jest.fn()
+    } as any;
+}
+
+describe("QueryParamsService", () => {
+    it("applies a valid sort order to the query", () => {
+        const query = queryStub([ATTR_A, ATTR_B]);
+        const sort = observable.object<{ sortOrder: SortInstruction[] | undefined }>({
+            sortOrder: [[ATTR_A, "asc"]]
+        });
+        const filters = observable.object<{ filter: FilterCondition | undefined }>({ filter: undefined });
+
+        const { host, start } = testHost();
+        new QueryParamsService(host, query, filters, sort);
+        const stop = start();
+
+        expect(query.applied).toEqual([[[ATTR_A, "asc"]]]);
+        stop();
+    });
+
+    // WC-3520: a stale attribute id (e.g. from runtime-restored datasource.sortOrder
+    // after a re-deploy) must not crash the widget. The runtime throws inside the
+    // sync reaction; mobx does not rethrow but routes it to onReactionError, which
+    // surfaces as "[mobx] uncaught error in Reaction[Reaction]". Assert that hook
+    // never fires.
+    it("does not surface a reaction error when sort order contains a stale/invalid attribute id", () => {
+        const query = queryStub([ATTR_A, ATTR_B]); // ATTR_STALE no longer valid
+        const sort = observable.object<{ sortOrder: SortInstruction[] | undefined }>({
+            sortOrder: [[ATTR_STALE, "asc"]]
+        });
+        const filters = observable.object<{ filter: FilterCondition | undefined }>({ filter: undefined });
+
+        const reactionErrors: unknown[] = [];
+        const disposeErrHook = onReactionError(err => reactionErrors.push(err));
+
+        const { host, start } = testHost();
+        new QueryParamsService(host, query, filters, sort);
+        const stop = start();
+
+        disposeErrHook();
+        stop();
+        expect(reactionErrors).toEqual([]);
+    });
+
+    it("recovers to default sort when an invalid id is encountered", () => {
+        const query = queryStub([ATTR_A, ATTR_B]);
+        const sort = observable.object<{ sortOrder: SortInstruction[] | undefined }>({
+            sortOrder: [[ATTR_STALE, "asc"]]
+        });
+        const filters = observable.object<{ filter: FilterCondition | undefined }>({ filter: undefined });
+
+        const { host, start } = testHost();
+        new QueryParamsService(host, query, filters, sort);
+        start();
+
+        // Falls back to unsorted (undefined) so the datasource is still usable.
+        expect(query.applied.at(-1)).toEqual(undefined);
+    });
+});


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

Gallery crashed with an uncaught MobX reaction error — `Sort order item: invalid attribute id '<id>'` — when a sort order restored from `datasource.sortOrder` referenced an attribute id no longer valid in the current app build. Mendix attribute ids are per-build tokens regenerated on redeploy, so a sort order persisted per-user (personalization attribute / DB storage) can outlive the ids it references.

`QueryParamsService` now guards the forwarding of sort order into `ListValue.setSortOrder()`: on a runtime rejection it catches the error, falls back to the default (unsorted) order, and emits a `console.warn` so the reset is diagnosable. The guard sits on the shared forwarding path (the sort reaction), so it protects the widget whether or not a sort widget is configured — the `SortOrderStore` is not instantiated when no DropdownSort exists, which is why the fix is not there.

Ticket: WC-3520

### What should be covered while testing?

1. Configure a Gallery with sort personalization stored in a per-user attribute (DB storage).
2. Sort the gallery, then redeploy the app so attribute ids regenerate (stale stored sort order).
3. Re-run and open the page as the same user.
   - Before fix: widget crashes with `invalid attribute id` uncaught reaction error.
   - After fix: widget renders, falls back to default sort order, `console.warn` logged.
4. Confirm the normal case (all-valid sort ids) still applies sort order unchanged, preserving order and direction.