### PR TITLE
fix(image-web): use icon size in structure preview

### DIFF
--- a/packages/pluggableWidgets/image-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/image-web/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - We fixed an issue with close icon of an enlarged image not being visible in apps deployed in non-local environments.
 
+- We fixed an issue with Structure preview showing icons in the wrong size.
+
 ## [1.6.0] - 2026-07-29
 
 ### Changed

--- a/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
+++ b/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
@@ -96,7 +96,9 @@ export function getProperties(
             "heightUnit",
             "height",
             "minHeightUnit",
-            "maxHeightUnit"
+            "minHeight",
+            "maxHeightUnit",
+            "maxHeight"
         ]);
     } else {
         hidePropertyIn(defaultProperties, values, "iconSize");

--- a/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
+++ b/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
@@ -188,6 +188,10 @@ export function getPreview(
         height?: number,
         previewImage?: { type: "static"; imageUrl: string }
     ] {
+        if (values.datasource === "icon" && values.imageIcon?.type === "glyph") {
+            return [values.iconSize ?? 14, values.iconSize ?? 14];
+        }
+
         const imageObject =
             values.imageObject?.type === "static"
                 ? values.imageObject // static image


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

The Image widget applies image dimension logic to icon sources in Studio Pro's Structure mode. When height is set to automatic, the default `maxHeight` of 250px is used for the placeholder, causing small icons to occupy 250px vertically.

This change preserves the existing placeholder but uses the configured `iconSize` for both its width and height when the data source is set to Icon.

Design mode and runtime rendering are unaffected.

Fixes mendix/web-widgets#2373

### What should be covered while testing?

1. Add an Image widget to a page.
2. Set its data source to **Icon**.
3. Select an icon and set **Icon size** to 15px.
4. Open the page in Structure mode.
5. Verify that the placeholder is approximately 15×15px instead of 250px high.
6. Verify that Design mode and runtime rendering remain unchanged.