### PR TITLE
[WC-3540]: chore(html-element-web): bump dompurify to 3.4.13

### DIFF
--- a/packages/pluggableWidgets/html-element-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/html-element-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Security
+
+- Updated dompurify library to version 3.4.13 to incorporate latest security fixes.
+
 ## [1.2.11] - 2026-07-24
 
 ### Security

--- a/packages/pluggableWidgets/html-element-web/package.json
+++ b/packages/pluggableWidgets/html-element-web/package.json
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@mendix/widget-plugin-component-kit": "workspace:*",
-        "dompurify": "^3.4.12"
+        "dompurify": "^3.4.13"
     },
     "devDependencies": {
         "@mendix/automation-utils": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1667,8 +1667,8 @@ importers:
         specifier: workspace:*
         version: link:../../shared/widget-plugin-component-kit
       dompurify:
-        specifier: ^3.4.12
-        version: 3.4.12
+        specifier: ^3.4.13
+        version: 3.4.13
     devDependencies:
       '@mendix/automation-utils':
         specifier: workspace:*
@@ -6499,8 +6499,8 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -14484,7 +14484,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Summary

- Bumped `dompurify` from `3.4.12` to `3.4.13` in `html-element-web`
- Updated `pnpm-lock.yaml` (only dompurify changed)
- Added changelog entry under `[Unreleased]`

## Test plan

- [ ] Verify widget builds successfully
- [ ] Confirm no regressions in HTML sanitization behavior