### PR TITLE
docs(file-uploader): add missing 2.5.0 changelog entry for file removal

### DIFF
--- a/packages/modules/file-uploader/CHANGELOG.md
+++ b/packages/modules/file-uploader/CHANGELOG.md
@@ -38,7 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Files in the list are now ordered with successful uploads above rejected files.
 
-- Removing a file with the default remove button now removes the entry from the file list immediately, instead of leaving it in the list greyed out with the "File removal success" text. This matches how removal already worked when custom buttons are configured.
+- Removing a file with the default remove button now removes the entry from the file list immediately, instead of leaving it in the list greyed out. This matches how removal already worked when custom buttons are configured.
 
 ## [2.4.2] FileUploader - 2026-04-23
 

--- a/packages/modules/file-uploader/CHANGELOG.md
+++ b/packages/modules/file-uploader/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### FileUploader
+
+#### Changed
+
+- Since version 2.5.0, removing a file with the default remove button removes the entry from the file list immediately, instead of leaving it in the list greyed out. This matches how removal already worked when custom buttons are configured. This change was missing from the 2.5.0 release notes.
+
 ## [2.5.0] FileUploader - 2026-06-29
 
 ### [2.5.0] FileUploader
@@ -37,8 +43,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Files now upload in a queue rather than being marked as errors when too many are dropped at once. Queued files show a "Waiting..." state while they wait for a concurrent slot.
 
 - Files in the list are now ordered with successful uploads above rejected files.
-
-- Removing a file with the default remove button now removes the entry from the file list immediately, instead of leaving it in the list greyed out. This matches how removal already worked when custom buttons are configured.
 
 ## [2.4.2] FileUploader - 2026-04-23
 

--- a/packages/modules/file-uploader/CHANGELOG.md
+++ b/packages/modules/file-uploader/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Files in the list are now ordered with successful uploads above rejected files.
 
+- Removing a file with the default remove button now removes the entry from the file list immediately, instead of leaving it in the list greyed out with the "File removal success" text. This matches how removal already worked when custom buttons are configured.
+
 ## [2.4.2] FileUploader - 2026-04-23
 
 ### [2.4.2] FileUploader

--- a/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Files in the list are now ordered with successful uploads above rejected files.
 
+- Removing a file with the default remove button now removes the entry from the file list immediately, instead of leaving it in the list greyed out with the "File removal success" text. This matches how removal already worked when custom buttons are configured.
+
 ## [2.4.2] - 2026-04-23
 
 ### Fixed

--- a/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Since version 2.5.0, removing a file with the default remove button removes the entry from the file list immediately, instead of leaving it in the list greyed out. This matches how removal already worked when custom buttons are configured. This change was missing from the 2.5.0 release notes.
+
 ## [2.5.0] - 2026-06-29
 
 ### Fixed
@@ -35,8 +39,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Files now upload in a queue rather than being marked as errors when too many are dropped at once. Queued files show a "Waiting..." state while they wait for a concurrent slot.
 
 - Files in the list are now ordered with successful uploads above rejected files.
-
-- Removing a file with the default remove button now removes the entry from the file list immediately, instead of leaving it in the list greyed out. This matches how removal already worked when custom buttons are configured.
 
 ## [2.4.2] - 2026-04-23
 

--- a/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/file-uploader-web/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Files in the list are now ordered with successful uploads above rejected files.
 
-- Removing a file with the default remove button now removes the entry from the file list immediately, instead of leaving it in the list greyed out with the "File removal success" text. This matches how removal already worked when custom buttons are configured.
+- Removing a file with the default remove button now removes the entry from the file list immediately, instead of leaving it in the list greyed out. This matches how removal already worked when custom buttons are configured.
 
 ## [2.4.2] - 2026-04-23
 


### PR DESCRIPTION
### Pull request type

No code changes (changes to documentation, CI, metadata, etc.)

---

### Description

File Uploader 2.5.0 changed the default remove button behaviour: `FileStore.remove()` now calls
`rootStore.dismissFile(this)` instead of setting `fileStatus = "removedFile"`, so removing a file
drops the entry from the list immediately rather than leaving it greyed out in the list.

The change was intentional and recorded in the change proposal for that release
(`packages/pluggableWidgets/file-uploader-web/openspec/proposal.md`, under Impact), but was never
carried into either CHANGELOG.md. A customer upgrading from 2.4.2 to 2.5.0 hit it during testing
and raised a ticket to ask whether it was a bug.

This PR adds the missing bullet to the existing `Changed` section of the 2.5.0 release in both
changelogs:

- `packages/pluggableWidgets/file-uploader-web/CHANGELOG.md`
- `packages/modules/file-uploader/CHANGELOG.md`

Amending a shipped release section rather than logging it under Unreleased, because the change
belongs to 2.5.0 and anyone diffing release notes for that upgrade should see it there. Marketplace
release page is being updated separately to reach existing 2.5.0 adopters.

No version bump, no source changes.