### PR TITLE
[WC-3502]: fix gallery design mode preview blocking widget selection

### DIFF
--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - We fixed an issue where the Gallery widget could crash with an "invalid attribute id" error when a stored sort order referenced an attribute that was no longer available. The widget now falls back to the default sort order instead.
 
+- We fixed an issue in Studio Pro design mode where widgets placed inside a gallery item could not be selected or hovered. Double-clicking them opened the properties of the surrounding container instead.
+
 ## [3.11.3] - 2026-07-27
 
 ### Fixed

--- a/packages/pluggableWidgets/gallery-web/src/ui/GalleryPreview.scss
+++ b/packages/pluggableWidgets/gallery-web/src/ui/GalleryPreview.scss
@@ -16,4 +16,8 @@
         rgba(255, 255, 255, 0.75) 100%
     );
     z-index: 1;
+    // Purely decorative fade. Without this, the overlay swallows hit-testing in
+    // Studio Pro design mode, so clicks on widgets inside a gallery item resolve
+    // to the surrounding container instead.
+    pointer-events: none;
 }


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)
<!---->

---

### Description

In Studio Pro design mode, widgets placed inside a gallery item could not be hovered or selected — double-clicking an image or text opened the properties of the surrounding container instead. The decorative gradient fade drawn by
`.widget-gallery-content::before` spans the full gallery content at `z-index: 1` and, lacking `pointer-events: none`, captured all hit-testing, so Studio Pro resolved clicks to the nearest ancestor.

Marked the pseudo-element as `pointer-events: none`. It is purely decorative, so the fade still renders identically while clicks pass through to the real widgets underneath. The stylesheet is imported only by `Gallery.editorPreview.tsx`, so there is no runtime impact.

Ticket: https://mendix.atlassian.net/browse/WC-3502

### What should be covered while testing?

Studio Pro 11.12.1 (the version the issue was reported against):

1. Create a new page from the **List** page template (it contains a Gallery).
2. Stay in **Design mode** — do not switch to Structure mode.
3. Double-click the image inside a gallery item → the **Image** properties dialog should open (before the fix: Container properties opened).
4. Repeat for the text widget inside the item → **Text** properties should open.
5. Hover over the nested widgets → the highlight should land on the widget itself, not on the container.
6. Confirm the gradient fade over the lower gallery rows still renders as before.
7. Confirm Structure mode and the Page Explorer still select widgets correctly.
8. Run the app and confirm the gallery renders and behaves unchanged at runtime.

Note: design-mode preview bundles are cached — press F4 (Synchronize project directory) after deploying the widget, and reopen the app if the old behaviour persists.