### PR TITLE
[WC-3547]: Data Grid 2 Stack top bar in narrow containers

### DIFF
--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Data Grid 2
+
+#### Fixed
+
+- We fixed an issue where the top bar did not stack its content vertically in narrow containers.
+
 ## [3.11.4] DataWidgets - 2026-08-24
 
 ### [3.11.4] DropdownSort

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/_datagrid.scss
@@ -622,7 +622,7 @@ $root: ".widget-datagrid";
 }
 
 @container widget-datagrid-header (width < 500px) {
-    #{$root}-padding-top {
+    #{$root}-paging-top {
         flex-direction: column-reverse;
         :where(#{$root}-tb-start, #{$root}-tb-end) {
             width: 100%;


### PR DESCRIPTION
### Pull request type

Bug fix (non-breaking change which fixes an issue)

---

### Description

`_datagrid.scss`'s top-bar container query targets `#{$root}-padding-top`, which no element ever carries — the class is `widget-datagrid-paging-top`. The footer counterpart directly above it is spelled correctly, so this looks like a typo from when the two blocks were written.

Effect: Data Grid 2's top bar has never stacked its content vertically in containers narrower than 500px, while the footer always has. One word changed.

Worth reviewing with care despite the size: because the rule has never applied, fixing it *changes* narrow-width layout for the first time. Below 500px the top bar now switches to `column-reverse` and centres its zones, matching the footer's behaviour and the original intent.

Found while investigating WC-3505; split out so Gallery and Data Grid 2 changes stay separately reviewable. Ticket created.

### What should be covered while testing?

1. Place a Data Grid 2 with pagination `Above grid` and multi selection with `Show selection count` = Top.
2. Put it in a container narrower than 500px, or shrink the browser until the grid container crosses that width.
3. The top bar should stack vertically (pagination above the selection count, `column-reverse`) with both zones full width and centred — the same way the footer already behaves.
4. Above 500px, nothing should change from current behaviour.


[WC-3505]: https://mendix.atlassian.net/browse/WC-3505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ