### PR TITLE
chore(automation-utils): improve module changelog guard

### DIFF
--- a/automation/utils/bin/rui-check-changelogs.ts
+++ b/automation/utils/bin/rui-check-changelogs.ts
@@ -3,6 +3,7 @@
 import { Version } from "../src";
 import { parse as parseModule } from "../src/changelog-parser/parser/module/module";
 import { parse as parseWidget } from "../src/changelog-parser/parser/widget/widget";
+import type { ModuleUnreleasedVersionEntry } from "../src/changelog-parser/types";
 import { exec } from "../src/shell";
 
 interface ChangelogChange {
@@ -48,6 +49,18 @@ function compareChangelogContent(change: ChangelogChange): boolean {
         if (sectionTypes.length !== new Set(sectionTypes).size) {
             console.error(`  ❌ There are duplicated changelog types in Unreleased!`);
             return false;
+        }
+
+        if (change.type === "module") {
+            const newSubs = (newUnreleased as ModuleUnreleasedVersionEntry).subcomponents;
+            for (const sub of newSubs) {
+                console.error(
+                    `  ❌ Subcomponent entry "${sub.name.trim()}" found in [Unreleased] in the module changelog. Widget-specific changes must go in the widget's own CHANGELOG.md.`
+                );
+            }
+            if (newSubs.length > 0) {
+                return false;
+            }
         }
     } catch (error) {
         console.error(`  ❌ Failed to parse changelog: ${error instanceof Error ? error.message : String(error)}`);

--- a/automation/utils/bin/rui-update-changelog-module.ts
+++ b/automation/utils/bin/rui-update-changelog-module.ts
@@ -52,7 +52,6 @@ async function main(): Promise<void> {
                 const [unreleased] = comp.changelog.content;
                 const entry: SubComponentEntry = {
                     name: compInfo.mxpackage.name,
-                    version: compInfo.version,
                     sections: unreleased.sections
                 };
 


### PR DESCRIPTION
## Summary

- Disallow subcomponent entries (e.g. `### Gallery / #### Fixed`) in a module's `[Unreleased]` changelog section. Widget-specific changes must go in each widget's own `CHANGELOG.md`; the release bot merges them up at release time. The CI check now rejects any PR that adds such entries.
- Drop the redundant widget version from subcomponent headers written by the update-changelog-module script. Since widget versions always match the module version, `### Data Grid 2` is written instead of `### [3.11.4] Data Grid 2`.

## Test plan

- [ ] Verify CI `check-changelogs` step fails on a branch that adds a subcomponent entry to a module `[Unreleased]` section
- [ ] Verify CI `check-changelogs` step passes on a clean branch with only module-level entries
- [ ] Run `rui-update-changelog-module` locally and confirm subcomponent headers are written without a version number