### PR TITLE
chore(data-widgets): move unreleased changelog entries to widget changelogs

### DIFF
--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -6,22 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Data Grid 2
-
-#### Fixed
-
-- We fixed an issue where the top bar did not stack its content vertically in narrow containers.
-
-### Gallery
-
-#### Changed
-
-- The "Pagination" design property now offers Left, Center and Right as alignment buttons. Existing selections are preserved.
-
-#### Fixed
-
-- We fixed the pagination alignment design property, which had no effect on the position of the pagination controls.
-
 ## [3.11.4] DataWidgets - 2026-08-24
 
 ### [3.11.4] DropdownSort

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue where the top bar did not stack its content vertically in narrow containers.
+
 ### Added
 
 - We added two optional export event actions — **On before export** and **On after export** — so developers can log export operations via a microflow or nanoflow. `On before export` fires just before the export starts and provides the grid name, visible column titles, chunk size, file name, sheet name, and start time. `On after export` fires after the export finishes (whether completed or canceled) and also provides the total number of exported rows, a status string (`"success"` or `"aborted"`), and an end time.


### PR DESCRIPTION
### Pull request type

<!-- No code changes (changes to documentation, CI, metadata, etc.) -->

### Description

The `data-widgets` module's `CHANGELOG.md` had unreleased entries that belong to individual widget changelogs instead (they're rolled up into the module changelog automatically at release time, not written there by hand). Moved the "Data Grid 2" top-bar fix entry to `datagrid-web/CHANGELOG.md`. The "Gallery" entries in the module file were stale duplicates already present, verbatim or superseded, in `gallery-web/CHANGELOG.md` — removed, no move needed.